### PR TITLE
fix(mcp): emit resource_metadata in 401 challenge

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -125,7 +125,8 @@ void AddServices(WebApplicationBuilder builder)
             // Validate tokens via the existing JwtBearer pipeline; the MCP scheme
             // keeps ownership of the 401 challenge so it can emit the
             // resource_metadata pointer the MCP spec requires.
-            options.ForwardDefaultSelector = _ => JwtBearerDefaults.AuthenticationScheme;
+            options.ForwardAuthenticate = JwtBearerDefaults.AuthenticationScheme;
+            options.ForwardForbid = JwtBearerDefaults.AuthenticationScheme;
             options.ResourceMetadata = new()
             {
                 Resource = "api://moobank.mclachlan.family",

--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -9,9 +9,11 @@ using Asm.MooBank.Institution.Ing;
 using Asm.MooBank.Institution.Macquarie;
 using Asm.MooBank.Security;
 using Asm.OAuth;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
+using ModelContextProtocol.AspNetCore.Authentication;
 
 var result = WebApplicationStart.Run(args, "Asm.MooBank.Web.Api", AddServices, AddApp, AddHealthChecks);
 
@@ -120,6 +122,10 @@ void AddServices(WebApplicationBuilder builder)
     services.AddAuthentication(builder.Configuration)
         .AddMcp(options =>
         {
+            // Validate tokens via the existing JwtBearer pipeline; the MCP scheme
+            // keeps ownership of the 401 challenge so it can emit the
+            // resource_metadata pointer the MCP spec requires.
+            options.ForwardDefaultSelector = _ => JwtBearerDefaults.AuthenticationScheme;
             options.ResourceMetadata = new()
             {
                 Resource = "api://moobank.mclachlan.family",
@@ -233,7 +239,10 @@ void AddApp(WebApplication app)
 
     app.UseAuthorization();
 
-    app.MapMcp("mcp").RequireAuthorization();
+    app.MapMcp("mcp").RequireAuthorization(new AuthorizationPolicyBuilder()
+        .AddAuthenticationSchemes(McpAuthenticationDefaults.AuthenticationScheme)
+        .RequireAuthenticatedUser()
+        .Build());
 
     IEndpointRouteBuilder builder = app.MapGroup("/api");
 


### PR DESCRIPTION
## Summary

- Bare `WWW-Authenticate: Bearer` was being emitted on the MCP 401 because the default JwtBearer scheme owned the challenge.
- MCP clients (Claude Desktop's Custom Connector) couldn't discover Entra ID as the authorization server and fell back to treating MooBank itself as the AS — Claude was opening \`https://moobank.mclachlan.family/authorize\` instead of Entra's authorize endpoint.
- Pin \`/mcp\` to the MCP authentication scheme so it owns the 401 challenge, and forward only \`Authenticate\` and \`Forbid\` to JwtBearer so token validation is unchanged.

## Test plan

- [x] \`curl -i https://localhost:7005/mcp\` returns \`WWW-Authenticate: Bearer resource_metadata="https://localhost:7005/.well-known/oauth-protected-resource/mcp"\`
- [x] \`curl https://localhost:7005/.well-known/oauth-protected-resource/mcp\` returns the metadata document with \`authorization_servers\` pointing at Entra
- [ ] Claude Desktop Custom Connector connects against deployed MooBank and pops the browser at \`login.microsoftonline.com\`, not the MooBank host

🤖 Generated with [Claude Code](https://claude.com/claude-code)