### PR TITLE
fix(mcp): force https scheme on generated URLs in production

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -209,6 +209,20 @@ void AddServices(WebApplicationBuilder builder)
 
 void AddApp(WebApplication app)
 {
+    // MooBank is always served over HTTPS in production but the App Service /
+    // Cloudflare hop terminates TLS, so the app sees the inbound scheme as http.
+    // Force it back to https so URL generation (e.g. the resource_metadata URL in
+    // the MCP WWW-Authenticate header) emits the correct scheme. Skipped in dev
+    // where the SPA proxy may use http://localhost.
+    if (!app.Environment.IsDevelopment())
+    {
+        app.Use((ctx, next) =>
+        {
+            ctx.Request.Scheme = "https";
+            return next();
+        });
+    }
+
     if (app.Environment.IsDevelopment())
     {
         app.MapOpenApi();


### PR DESCRIPTION
## Summary

- Cloudflare + App Service terminate TLS upstream, so the app sees inbound requests as \`http\`.
- URL generation (notably the \`resource_metadata\` URL in the MCP \`WWW-Authenticate\` header) was emitting \`http://...\`, which MCP clients refuse to follow.
- Force the request scheme to \`https\` in non-dev environments. Hardcoded — no external input trusted. Dev untouched.

## Test plan

- [ ] Deploy
- [ ] \`curl -i https://moobank.mclachlan.family/mcp\` returns \`WWW-Authenticate: Bearer resource_metadata="https://moobank.mclachlan.family/.well-known/oauth-protected-resource/mcp"\` (note **https**, not http)
- [ ] Claude Desktop Custom Connector follows the link and pops the browser at \`login.microsoftonline.com\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)