### PR TITLE
fix(mcp): set resource to MCP URL, not App ID URI

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -127,9 +127,16 @@ void AddServices(WebApplicationBuilder builder)
             // resource_metadata pointer the MCP spec requires.
             options.ForwardAuthenticate = JwtBearerDefaults.AuthenticationScheme;
             options.ForwardForbid = JwtBearerDefaults.AuthenticationScheme;
+            // The MCP spec / Claude Desktop's Custom Connector require the `resource`
+            // field in the Protected Resource Metadata document to match the MCP
+            // server URL exactly as the user enters it in the client, INCLUDING the
+            // path component. Using the App ID URI ("api://...") here makes Claude
+            // reject the metadata document and fall back to treating MooBank as the
+            // authorization server. Token audience validation is unaffected because
+            // it's driven by JwtBearer config, not this value.
             options.ResourceMetadata = new()
             {
-                Resource = "api://moobank.mclachlan.family",
+                Resource = "https://moobank.mclachlan.family/mcp",
                 AuthorizationServers = { oAuthOptions.Authority },
                 ScopesSupported = ["api://moobank.mclachlan.family/api.read"],
             };


### PR DESCRIPTION
## Summary

Per [Anthropic's Custom Connector authentication docs](https://claude.com/docs/connectors/building/authentication):

> The protected resource metadata document's \`resource\` field must match your MCP server URL exactly as the user enters it in Claude, including any path component.

Using the App ID URI (\`api://moobank.mclachlan.family\`) caused Claude Desktop's Custom Connector to reject the Protected Resource Metadata document and fall back to treating MooBank itself as the authorization server — Claude was constructing authorize URLs at \`https://moobank.mclachlan.family/authorize\` instead of Entra's endpoint.

Token audience validation is unaffected: \`aud\` claim is still \`api://moobank.mclachlan.family\`, driven by JwtBearer config.

## Test plan

- [ ] Deploy
- [ ] \`curl https://moobank.mclachlan.family/.well-known/oauth-protected-resource/mcp\` returns JSON with \`"resource": "https://moobank.mclachlan.family/mcp"\`
- [ ] Claude Desktop Custom Connector → Connect now pops the browser at \`login.microsoftonline.com\`, not the MooBank host

🤖 Generated with [Claude Code](https://claude.com/claude-code)