### PR TITLE
fix(mcp): advertise scope under MCP URL App ID URI

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -134,11 +134,19 @@ void AddServices(WebApplicationBuilder builder)
             // reject the metadata document and fall back to treating MooBank as the
             // authorization server. Token audience validation is unaffected because
             // it's driven by JwtBearer config, not this value.
+            //
+            // Entra v2's /authorize endpoint also requires the `scope` parameter and
+            // the `resource` parameter to point at the same App ID URI, or it
+            // rejects with AADSTS9010010 ("resource parameter doesn't match requested
+            // scopes"). The scope advertised here must therefore live under the same
+            // App ID URI as the Resource value above — i.e. an Entra app whose App
+            // ID URI is https://moobank.mclachlan.family/mcp, with `api.read`
+            // exposed under it.
             options.ResourceMetadata = new()
             {
                 Resource = "https://moobank.mclachlan.family/mcp",
                 AuthorizationServers = { oAuthOptions.Authority },
-                ScopesSupported = ["api://moobank.mclachlan.family/api.read"],
+                ScopesSupported = ["https://moobank.mclachlan.family/mcp/api.read"],
             };
         });
 


### PR DESCRIPTION
## Summary

Entra v2's \`/authorize\` endpoint requires \`scope\` and \`resource\` parameters to share an App ID URI. Mismatched values are rejected with **AADSTS9010010** ("resource parameter doesn't match requested scopes").

PR #791 set the metadata's \`resource\` to \`https://moobank.mclachlan.family/mcp\` (required by Claude Desktop). The scope was still \`api://moobank.mclachlan.family/api.read\`, so Claude's OAuth request to Entra had mismatched URIs and was rejected.

This PR advertises the scope under the same URI as the resource: \`https://moobank.mclachlan.family/mcp/api.read\`.

## Required Entra portal work (depends on this PR)

This PR is **not effective on its own** — the scope it advertises has to actually exist in Entra.

1. On the MooBank resource app (the one with App ID URI \`api://moobank.mclachlan.family\`): either
   - **Change the App ID URI** to \`https://moobank.mclachlan.family/mcp\` (breaks SPA tokens until SPA scope config is updated), OR
   - **Create a separate Entra app** for the MCP resource with App ID URI \`https://moobank.mclachlan.family/mcp\`.
2. Expose a delegated scope \`api.read\` under \`https://moobank.mclachlan.family/mcp\`.
3. On the "MooBank MCP — Anthropic clients" app: API permissions → add \`https://moobank.mclachlan.family/mcp/api.read\` and grant.
4. Pre-authorize the client app for the new scope.
5. JwtBearer config (Asm.OAuth) must accept the new audience \`https://moobank.mclachlan.family/mcp\` alongside the existing one.

Without step 5 the access token will validate-fail even if Entra issues it.

## Test plan

- [ ] Steps 1–5 above completed
- [ ] Deploy
- [ ] \`curl https://moobank.mclachlan.family/.well-known/oauth-protected-resource/mcp\` shows the new scope
- [ ] Claude Desktop Custom Connector → Connect: no AADSTS9010010, token flows through, tools listed

## References

- [claude-code#52871](https://github.com/anthropics/claude-code/issues/52871) — related trailing-slash bug
- [IBM mcp-context-forge#2881](https://github.com/IBM/mcp-context-forge/issues/2881) — same Entra v2 scope+resource conflict
- AADSTS9010010 docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)