### PR TITLE
fix(mcp): accept both SPA and MCP audiences in JwtBearer

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -150,6 +150,23 @@ void AddServices(WebApplicationBuilder builder)
             };
         });
 
+    // The SPA's MSAL config requests tokens for api://moobank.mclachlan.family
+    // (the original resource app's App ID URI). The MCP connector's tokens come
+    // from a separate Entra app with App ID URI https://moobank.mclachlan.family/mcp.
+    // Accept both audiences on the JwtBearer pipeline so a single MooBank instance
+    // serves both surfaces without splitting the API.
+    services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+    {
+        var existing = options.TokenValidationParameters.ValidAudiences?.ToList() ?? [];
+        if (options.TokenValidationParameters.ValidAudience is { Length: > 0 } single)
+        {
+            existing.Add(single);
+        }
+        existing.Add("api://moobank.mclachlan.family");
+        existing.Add("https://moobank.mclachlan.family/mcp");
+        options.TokenValidationParameters.ValidAudiences = existing.Distinct().ToList();
+    });
+
     services.AddAuthorization(options =>
     {
         options.AddPolicies();


### PR DESCRIPTION
## Summary

With Option B (separate Entra resource app for MCP), the MooBank backend now needs to validate two distinct audiences on incoming tokens:

| Surface | App ID URI / aud claim |
|---|---|
| SPA (existing) | \`api://moobank.mclachlan.family\` |
| MCP connector (new) | \`https://moobank.mclachlan.family/mcp\` |

\`PostConfigure<JwtBearerOptions>\` appends both URIs to \`ValidAudiences\`, preserving anything Asm.OAuth already wired up (the existing \`ValidAudience\` is folded in too, so this is additive — no regression for the SPA).

Together with PR #791 (resource = MCP URL) and PR #792 (scope under matching App ID URI), this completes the three-part Entra v2 + MCP fix.

## Test plan

- [ ] Entra: separate "MooBank API — MCP" app created with App ID URI \`https://moobank.mclachlan.family/mcp\` and \`api.read\` scope exposed (done)
- [ ] Anthropic clients app pre-authorized for the new scope (done)
- [ ] Deploy
- [ ] Claude Desktop Custom Connector → Connect: no AADSTS9010010, tools list populates
- [ ] SPA login still works (existing \`api://...\` audience still accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)