### PR TITLE
fix(mcp): accept trailing-slash audience + log validation failures

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -153,8 +153,10 @@ void AddServices(WebApplicationBuilder builder)
     // The SPA's MSAL config requests tokens for api://moobank.mclachlan.family
     // (the original resource app's App ID URI). The MCP connector's tokens come
     // from a separate Entra app with App ID URI https://moobank.mclachlan.family/mcp.
-    // Accept both audiences on the JwtBearer pipeline so a single MooBank instance
-    // serves both surfaces without splitting the API.
+    // Accept both audiences (with and without trailing slash, since Anthropic's
+    // OAuth client has a known habit of normalising URIs with a trailing slash)
+    // on the JwtBearer pipeline so a single MooBank instance serves both surfaces
+    // without splitting the API.
     services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
     {
         var existing = options.TokenValidationParameters.ValidAudiences?.ToList() ?? [];
@@ -164,7 +166,24 @@ void AddServices(WebApplicationBuilder builder)
         }
         existing.Add("api://moobank.mclachlan.family");
         existing.Add("https://moobank.mclachlan.family/mcp");
+        existing.Add("https://moobank.mclachlan.family/mcp/");
         options.TokenValidationParameters.ValidAudiences = existing.Distinct().ToList();
+
+        // Diagnostic: log the exact reason when token validation fails. Remove once
+        // MCP authn is confirmed working end-to-end.
+        var existingFail = options.Events?.OnAuthenticationFailed;
+        options.Events ??= new();
+        options.Events.OnAuthenticationFailed = async ctx =>
+        {
+            var logger = ctx.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+                .CreateLogger("MooBank.JwtBearer");
+            logger.LogWarning(ctx.Exception,
+                "JwtBearer auth failed on {Path}. Accepted audiences: [{Audiences}]. Exception type: {Type}",
+                ctx.HttpContext.Request.Path,
+                string.Join(", ", ctx.Options.TokenValidationParameters.ValidAudiences ?? []),
+                ctx.Exception?.GetType().FullName);
+            if (existingFail != null) await existingFail(ctx);
+        };
     });
 
     services.AddAuthorization(options =>


### PR DESCRIPTION
## Summary

Claude Desktop's Custom Connector now passes Entra's authorize+token exchange (resource/scope/secret all aligned), but MooBank is rejecting the access token Claude presents — \`McpAuthorizationError\` with "the integration rejected the credentials".

Two defensive changes in one PR:

1. **Accept the trailing-slash audience form.** Anthropic's OAuth client is known to normalise URIs with a trailing slash (see [claude-code#52871](https://github.com/anthropics/claude-code/issues/52871)). If the token Entra issued has \`aud: https://moobank.mclachlan.family/mcp/\`, our \`ValidAudiences\` list (without slash) misses it. Adding both variants.

2. **Diagnostic logging on validation failure.** \`OnAuthenticationFailed\` now logs the exception type, the request path, and the accepted audience list. If the trailing-slash fix isn't the issue, the log entry will tell us exactly what \`aud\` the token carries vs. what MooBank is willing to accept — no more guessing.

Temporary — remove the diagnostic once MCP authn is confirmed working.

## Test plan

- [ ] Deploy
- [ ] Retry Claude Desktop Custom Connector
- [ ] If still failing: grep App Service log stream for \`MooBank.JwtBearer\` and read the failure reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)