### PR TITLE
fix(mcp): accept anthropic-clients client_id as a valid audience

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -150,13 +150,11 @@ void AddServices(WebApplicationBuilder builder)
             };
         });
 
-    // The SPA's MSAL config requests tokens for api://moobank.mclachlan.family
-    // (the original resource app's App ID URI). The MCP connector's tokens come
-    // from a separate Entra app with App ID URI https://moobank.mclachlan.family/mcp.
-    // Accept both audiences (with and without trailing slash, since Anthropic's
-    // OAuth client has a known habit of normalising URIs with a trailing slash)
-    // on the JwtBearer pipeline so a single MooBank instance serves both surfaces
-    // without splitting the API.
+    // Accept tokens minted for any of MooBank's surfaces:
+    // - api://moobank.mclachlan.family — original resource app, used by the SPA.
+    // - https://moobank.mclachlan.family/mcp — MCP resource app's App ID URI.
+    // - be1a8a0d-... — the Anthropic-clients app's client_id, which is the aud
+    //   on tokens minted via the MCP OAuth flow.
     services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
     {
         var existing = options.TokenValidationParameters.ValidAudiences?.ToList() ?? [];
@@ -166,24 +164,8 @@ void AddServices(WebApplicationBuilder builder)
         }
         existing.Add("api://moobank.mclachlan.family");
         existing.Add("https://moobank.mclachlan.family/mcp");
-        existing.Add("https://moobank.mclachlan.family/mcp/");
+        existing.Add("be1a8a0d-d7ce-4252-8ca6-b797d697a80d");
         options.TokenValidationParameters.ValidAudiences = existing.Distinct().ToList();
-
-        // Diagnostic: log the exact reason when token validation fails. Remove once
-        // MCP authn is confirmed working end-to-end.
-        var existingFail = options.Events?.OnAuthenticationFailed;
-        options.Events ??= new();
-        options.Events.OnAuthenticationFailed = async ctx =>
-        {
-            var logger = ctx.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
-                .CreateLogger("MooBank.JwtBearer");
-            logger.LogWarning(ctx.Exception,
-                "JwtBearer auth failed on {Path}. Accepted audiences: [{Audiences}]. Exception type: {Type}",
-                ctx.HttpContext.Request.Path,
-                string.Join(", ", ctx.Options.TokenValidationParameters.ValidAudiences ?? []),
-                ctx.Exception?.GetType().FullName);
-            if (existingFail != null) await existingFail(ctx);
-        };
     });
 
     services.AddAuthorization(options =>


### PR DESCRIPTION
## Summary

Tokens minted via the MCP OAuth flow carry the Anthropic-clients app's \`client_id\` (\`be1a8a0d-...\`) as the \`aud\` claim, not the resource App ID URI. Add it to \`ValidAudiences\` so JwtBearer accepts them.

Drops the temporary diagnostic logging and trailing-slash variant added in #796 — no longer needed.

## Test plan

- [ ] Deploy
- [ ] Retry Claude Desktop Custom Connector — tools list populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)