### PR TITLE
refactor(mcp): use OAuth.AdditionalAudiences config from Asm 3.8.125

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,47 +13,47 @@
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions" Version="5.2.1" />
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.7.6" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.84.0" />
     <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="3.8.104" />
-    <PackageVersion Include="Asm.AspNetCore" Version="3.8.104" />
-    <PackageVersion Include="Asm.AspNetCore.Api" Version="3.8.104" />
-    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="3.8.104" />
-    <PackageVersion Include="Asm.Domain" Version="3.8.104" />
-    <PackageVersion Include="Asm.Domain.Infrastructure" Version="3.8.104" />
-    <PackageVersion Include="Asm.ModelContextProtocol" Version="3.8.104" />
+    <PackageVersion Include="Asm" Version="3.8.125" />
+    <PackageVersion Include="Asm.AspNetCore" Version="3.8.125" />
+    <PackageVersion Include="Asm.AspNetCore.Api" Version="3.8.125" />
+    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="3.8.125" />
+    <PackageVersion Include="Asm.Domain" Version="3.8.125" />
+    <PackageVersion Include="Asm.Domain.Infrastructure" Version="3.8.125" />
+    <PackageVersion Include="Asm.ModelContextProtocol" Version="3.8.125" />
     <PackageVersion Include="Asm.Reqnroll" Version="3.6.756" />
-    <PackageVersion Include="Asm.Testing.Domain" Version="3.8.104" />
+    <PackageVersion Include="Asm.Testing.Domain" Version="3.8.125" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -150,15 +150,6 @@ void AddServices(WebApplicationBuilder builder)
             };
         });
 
-    // SPA tokens carry the SPA app's client_id as aud (configured by Asm.OAuth
-    // via the ValidAudience set from OAuth config). MCP tokens carry the
-    // Anthropic-clients app's client_id. Add the latter to the accepted set.
-    services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
-    {
-        options.TokenValidationParameters.ValidAudiences =
-            (options.TokenValidationParameters.ValidAudiences ?? []).Append("be1a8a0d-d7ce-4252-8ca6-b797d697a80d").ToList();
-    });
-
     services.AddAuthorization(options =>
     {
         options.AddPolicies();


### PR DESCRIPTION
## Summary

Asm 3.8.125 ships \`OAuthOptions.AdditionalAudiences\` and \`AdditionalIssuers\`. They're assigned directly into \`TokenValidationParameters\` at config time, so the \`PostConfigure<JwtBearerOptions>\` hack in \`Program.cs\` (appending the Anthropic-clients client_id) can go.

Also bumps Microsoft.* packages from 10.0.7 to 10.0.8 — required by the new Asm dependency graph.

## App Service config — must land before deploy

Add an \`AdditionalAudiences\` entry to the \`OAuth\` config section on the App Service:

\`\`\`jsonc
"OAuth": {
  ...
  "AdditionalAudiences": ["be1a8a0d-d7ce-4252-8ca6-b797d697a80d"]
}
\`\`\`

Or via App Service Configuration → Application settings:

\`\`\`
OAuth__AdditionalAudiences__0 = be1a8a0d-d7ce-4252-8ca6-b797d697a80d
\`\`\`

Without that entry, Claude Desktop's MCP tokens won't validate after this PR merges.

## Test plan

- [ ] Add \`AdditionalAudiences\` to App Service config
- [ ] Merge + deploy
- [ ] SPA login still works
- [ ] Claude Desktop MCP still works (tools list, can ask "what's my balance" etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)