### PR TITLE
fix(tags): keep edit modal open on save and show tag colour in list

### DIFF
--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2025.4.0",
       "license": "MIT",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.1.156",
-        "@andrewmclachlan/moo-ds": "^5.1.156",
-        "@andrewmclachlan/moo-icons": "^5.1.156",
+        "@andrewmclachlan/moo-app": "^5.1.160",
+        "@andrewmclachlan/moo-ds": "^5.1.160",
+        "@andrewmclachlan/moo-icons": "^5.1.160",
         "@azure/msal-react": "^5.4.1",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.1.156",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.1.156/22751fd4c9a2f7b3aab8559bb21eb2391208afc5",
-      "integrity": "sha512-sZYZ6P0G6pvaM36q0CdISxPBw0pJvEAIqCG0EdnbC7jmWnnRJsfmACm+GvHL3/m+bJJeXc9t58CRkEg8gMw6kA==",
+      "version": "5.1.160",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.1.160/9784e4615acbeddd12a906a7b559e7ed13981bd4",
+      "integrity": "sha512-kVf4S2MooaJGLyCTPDoXBTnVd1FF/thjq3vPC63BXQht1mHRPPasF7UwQUi4coz01+e7ajj0043eVnrDo7jmbw==",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.10.1",
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.1.156",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.1.156/a9d41adcadeb2e6d7b86043e96a0681abe4a2cd6",
-      "integrity": "sha512-bxlnpYWFO/GRkvfE56aDskkeDzDweQsNMU+CF0R6k3se/u5WvN9+tdcQ1y5uLIt7UFGexR7jEucwhMiFYEmgDg==",
+      "version": "5.1.160",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.1.160/f0496c856c3db7893826e1802a2bd59f222a6b79",
+      "integrity": "sha512-Sjp8omFbZda8Qjxk7w9d3CSR5azQ+AUHBqr5ZyKU+MN/klaoqxKjCYxAv0LBsO3azcwUndkM4Bt+3v+e1o4xLA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.1.156",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.1.156/c6d2fe51441194b5c9e41ec6da08b89309308c83",
-      "integrity": "sha512-2DCB28z1KsUPakWqdx0w8eHcwEWOkLm5MD2YXASo88a6l0ZSH/fZWlyCVEPvm3pb/z9weu7xY97pe9P/EYFJMA==",
+      "version": "5.1.160",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.1.160/6abf3a112a6feb71fb3882437fb2c9ea14ed8a27",
+      "integrity": "sha512-iVx5XY5oCp2MDRRxeWvV+YtC1dxy2QultnWjp9fgyccnDhcRD3MiOEp/9olwZz28eiIffyuIwS2b1EHSabY4EA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.6",

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -14,9 +14,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.1.156",
-    "@andrewmclachlan/moo-ds": "^5.1.156",
-    "@andrewmclachlan/moo-icons": "^5.1.156",
+    "@andrewmclachlan/moo-app": "^5.1.160",
+    "@andrewmclachlan/moo-ds": "^5.1.160",
+    "@andrewmclachlan/moo-icons": "^5.1.160",
     "@azure/msal-react": "^5.4.1",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/src/MooBank.Web.App/src/App.css
+++ b/src/MooBank.Web.App/src/App.css
@@ -12,6 +12,7 @@
 @import "css/forecast" layer(moobank);
 @import "css/visualiser" layer(moobank);
 @import "css/bills" layer(moobank);
+@import "css/tags" layer(moobank);
 @import "css/treeflex";
 
 @layer moobank {
@@ -219,3 +220,23 @@ section.upload {
         border-bottom-right-radius: 2px;
     }
 }
+
+input[type="color"].form-control {
+     width: 3rem;                                                                                                                                                                                                                                                         
+     height: calc(1.5em + 0.75rem + calc(var(--border-width, 1px) * 2));
+     padding: 0.375rem;
+ 
+     &:not(:disabled):not([readonly]) {
+         cursor: pointer;
+     }
+ 
+     &::-moz-color-swatch {
+         border: 0 !important;
+         border-radius: var(--border-radius, 0.375rem);
+     }
+ 
+     &::-webkit-color-swatch {
+         border: 0 !important;
+         border-radius: var(--border-radius, 0.375rem);
+     }
+ }

--- a/src/MooBank.Web.App/src/css/tags.css
+++ b/src/MooBank.Web.App/src/css/tags.css
@@ -1,0 +1,14 @@
+.tag-name-cell {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tag-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 1px solid var(--border-colour);
+    flex: 0 0 auto;
+}

--- a/src/MooBank.Web.App/src/routes/tags/-components/TagDetails.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/-components/TagDetails.tsx
@@ -32,7 +32,7 @@ export const TransactionTagDetails: React.FC<TransactionTagDetailsProps> = (prop
                     <label htmlFor="name">Name</label>
                     <Input id="name" placeholder="Name" type="text" value={name} onChange={(e) => setName(e.currentTarget.value)} onBlur={(e) => updateName(e.currentTarget.value)} onKeyUp={(e) => onKeyLeave(e, updateName)} />
                     <label htmlFor="colour">Colour</label>
-                    <Input id="colour" type="color" value={(tag.colour as string) ?? ""} onChange={(e) => save({ ...tag, colour: e.target.value })} />
+                    <Input id="colour" type="color" className="form-control-color" value={(tag.colour as string) ?? ""} onChange={(e) => save({ ...tag, colour: e.target.value })} />
                     <label htmlFor="exclude">Exclude from Reporting</label>
                     <Input.Switch id="exclude" checked={tag.settings?.excludeFromReporting} onChange={(e) => updateExcludeFromReporting(e.currentTarget.checked)} />
                     <label htmlFor="smooth">Allow Smoothing<Tooltip id="smoothing">Provides an option to average non-monthly transactions in trend reports</Tooltip></label>

--- a/src/MooBank.Web.App/src/routes/tags/-components/TagRow.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/-components/TagRow.tsx
@@ -1,17 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 
 import type { Tag } from "api/types.gen";
-import { ClickableIcon, EditColumn, Icon, useUpdatingState } from "@andrewmclachlan/moo-ds";
+import { EditColumn, Icon, useUpdatingState } from "@andrewmclachlan/moo-ds";
 import { useDeleteTag } from "../-hooks/useDeleteTag";
 import { useUpdateTag } from "../-hooks/useUpdateTag";
 import { TransactionTagTransactionTagPanel } from "./TagTagPanel";
-import { TransactionTagDetails } from "./TagDetails";
 import { DeleteIcon } from "@andrewmclachlan/moo-ds";
 
 
 export const TransactionTagRow: React.FC<TransactionTagRowProps> = (props) => {
-
-    const [showDetails, setShowDetails] = useState(false);
 
     const { tag, ...tagRow } = useTagRowEvents(props);
 
@@ -20,17 +17,19 @@ export const TransactionTagRow: React.FC<TransactionTagRowProps> = (props) => {
     );
 
     return (
-        <>
-            <TransactionTagDetails tag={tag} show={showDetails} onHide={() => setShowDetails(false)} />
-            <tr>
-                <EditColumn value={tag.name} onChange={t => tagRow.updateTag(t.value)} />
-                <TransactionTagTransactionTagPanel as="td" tag={tag} />
-                <td className="row-action">
-                    <span onClick={() => setShowDetails(true)}><Icon className="clickable" icon="pen-to-square" title="Edit Details" /></span>
-                    <span onClick={tagRow.deleteTag}><DeleteIcon /></span>
-                </td>
-            </tr>
-        </>
+        <tr>
+            <EditColumn value={tag.name} onChange={t => tagRow.updateTag(t.value)}>
+                <span className="tag-name-cell">
+                    <span className="tag-swatch" style={{ background: (tag.colour as string) || "var(--primary)" }} aria-hidden="true" />
+                    {tag.name}
+                </span>
+            </EditColumn>
+            <TransactionTagTransactionTagPanel as="td" tag={tag} />
+            <td className="row-action">
+                <span onClick={() => props.onEdit?.(tag)}><Icon className="clickable" icon="pen-to-square" title="Edit Details" /></span>
+                <span onClick={tagRow.deleteTag}><DeleteIcon /></span>
+            </td>
+        </tr>
     );
 }
 
@@ -62,4 +61,5 @@ function useTagRowEvents(props: TransactionTagRowProps) {
 
 export interface TransactionTagRowProps {
     tag?: Tag;
+    onEdit?: (tag: Tag) => void;
 }

--- a/src/MooBank.Web.App/src/routes/tags/index.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import React, { useEffect, useState } from "react";
 
 import { TransactionTagRow } from "./-components/TagRow";
+import { TransactionTagDetails } from "./-components/TagDetails";
 
 import { changeSortDirection, getNumberOfPages, PageSize, Pagination, PaginationControls, PaginationTh, SaveIcon, SearchBox, Section, SectionTable, SortableTh, useLocalStorage } from "@andrewmclachlan/moo-ds";
 import type { SortDirection } from "@andrewmclachlan/moo-ds";
@@ -34,15 +35,19 @@ function TransactionTags() {
 
     const [sortDirection, setSortDirection] = useState<SortDirection>("Ascending");
     const [search, setSearch] = useState("");
+    const [editingTagId, setEditingTagId] = useState<number | null>(null);
 
     const numberOfPages = getNumberOfPages(filteredTags.length, pageSize);
     const totalTags = filteredTags.length;
     const pageChange = (_current: number, newPage: number) => setPageNumber(newPage);
 
+    const editingTag = editingTagId !== null ? allTags?.find(t => t.id === editingTagId) : undefined;
+
     useEffect(() => {
-
         setPageNumber(1);
+    }, [search]);
 
+    useEffect(() => {
         const searchTerm = search.toLocaleLowerCase();
         if (searchTerm === "") {
             setFilteredTags(allTags ?? []);
@@ -122,7 +127,7 @@ function TransactionTags() {
                         <TagPanel as="td" selectedItems={newTag.tags} items={tagsList} onAdd={addTag} onCreate={createTag} onRemove={removeTag} allowCreate={false} alwaysShowEditPanel={true} onKeyUp={keyUp} />
                         <td className="row-action column-5"><span onClick={createTag}><SaveIcon /></span></td>
                     </tr>
-                    {pagedTags.map((t, i) => <TransactionTagRow key={`${i}${(t?.id ?? "")}`} tag={t} />)}
+                    {pagedTags.map((t, i) => <TransactionTagRow key={t?.id ?? `empty-${i}`} tag={t} onEdit={(tag) => setEditingTagId(tag.id)} />)}
                 </tbody>
                 {!isLoading &&
                     <tfoot>
@@ -138,6 +143,13 @@ function TransactionTags() {
                     </tfoot>
                 }
             </SectionTable>
+            {editingTag && (
+                <TransactionTagDetails
+                    tag={editingTag}
+                    show={editingTagId !== null}
+                    onHide={() => setEditingTagId(null)}
+                />
+            )}
         </TagsPage>
     );
 }


### PR DESCRIPTION
## Summary
- **Modal closes on settings edit (bug fix).** `TagDetails` was rendered inside `TagRow`, and the tags page reset pagination to page 1 on every data refresh — so editing a switch/colour invalidated the query, the page jumped back, and the row holding the modal unmounted. Modal is now lifted to the page level and tracks the editing tag by id, so it stays open across refetches and always sees the latest data.
- **Stop resetting pagination on data refresh.** The `setPageNumber(1)` call now only fires on `search` changes, not on `JSON.stringify(allTags)`.
- **Stable row keys.** Switched from index-prefixed (`\${i}\${id}`) to `tag.id` only, so deletions/reorders no longer churn every subsequent row.
- **Tag colour visible in the list.** Small 12 px coloured dot before each tag name. Falls back to `var(--primary)` when the tag has no colour set; explicit colours (including black) are preserved.
- **Dep bump.** moo-app / moo-ds / moo-icons 5.1.156 → 5.1.160.

## Test plan
- [ ] Open the tags page, click the edit icon on a tag on **page 2+**, toggle "Exclude from Reporting" — modal stays open.
- [ ] Toggle the same on **page 1** — modal stays open, no page jump.
- [ ] Change the colour swatch in the modal — list dot updates immediately, modal stays open.
- [ ] Edit a tag's name inline (`EditColumn`) — still works; colour dot still rendered when not editing.
- [ ] Search filters the list and resets to page 1; subsequent data refreshes keep the current page.
- [ ] Tags with no colour set show the primary-colour dot; tags with `#000000` keep a black dot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)