### PR TITLE
fix(budget): broken budget report nav link

### DIFF
--- a/src/MooBank.Web.App/src/routes/budget/-components/BudgetPage.tsx
+++ b/src/MooBank.Web.App/src/routes/budget/-components/BudgetPage.tsx
@@ -7,7 +7,7 @@ import { TwoCoins } from "@andrewmclachlan/moo-icons";
 
 export const BudgetPage: React.FC<PropsWithChildren<BudgetPageProps>> = ({ children, breadcrumbs = [] }) => (
 
-    <Page title="Budget" breadcrumbs={[{ text: "Budget", route: `/budget` }, ...breadcrumbs]} navItems={[{ text: "Report", route: `budget/report`, image: <TwoCoins /> }]}>
+    <Page title="Budget" breadcrumbs={[{ text: "Budget", route: `/budget` }, ...breadcrumbs]} navItems={[{ text: "Report", route: `/budget/report`, image: <TwoCoins /> }]}>
         {children}
     </Page>
 );


### PR DESCRIPTION
## Summary
- The budget report nav link used a relative path `budget/report` which resolved incorrectly from nested budget routes (e.g. `/budget/2026/5` would navigate to `/budget/2026/5/budget/report`)
- Changed to absolute path `/budget/report`

## Test plan
- [ ] Navigate to `/budget` and click the Report nav item — should go to `/budget/report`
- [ ] Navigate to a specific budget month (e.g. `/budget/2026/5`) and click Report — should still go to `/budget/report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)