### PR TITLE
feat(dashboard): add forecast widget and shared widget error state

### DIFF
--- a/src/MooBank.Web.App/src/App.css
+++ b/src/MooBank.Web.App/src/App.css
@@ -10,6 +10,7 @@
 @import "css/transactions" layer(moobank);
 @import "css/transactions/transactionsHeader" layer(moobank);
 @import "css/forecast" layer(moobank);
+@import "css/dashboard" layer(moobank);
 @import "css/visualiser" layer(moobank);
 @import "css/bills" layer(moobank);
 @import "css/tags" layer(moobank);

--- a/src/MooBank.Web.App/src/components/WidgetError.tsx
+++ b/src/MooBank.Web.App/src/components/WidgetError.tsx
@@ -1,0 +1,12 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export interface WidgetErrorProps {
+    message?: string;
+}
+
+export const WidgetError: React.FC<WidgetErrorProps> = ({ message = "Unable to load this widget" }) => (
+    <div className="widget-error">
+        <FontAwesomeIcon icon="triangle-exclamation" className="widget-error-icon" />
+        <div className="widget-error-message">{message}</div>
+    </div>
+);

--- a/src/MooBank.Web.App/src/components/index.ts
+++ b/src/MooBank.Web.App/src/components/index.ts
@@ -14,3 +14,4 @@ export * from "./TransactionSearch";
 export * from "./TransactionListProvider";
 export * from "./TagPanel";
 export * from "./TagSelector";
+export * from "./WidgetError";

--- a/src/MooBank.Web.App/src/css/dashboard.css
+++ b/src/MooBank.Web.App/src/css/dashboard.css
@@ -1,0 +1,23 @@
+.widget-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    height: 100%;
+    min-height: 120px;
+    padding: 1rem;
+    text-align: center;
+    color: var(--secondary-colour);
+}
+
+.widget-error-icon {
+    font-size: 2rem;
+    opacity: 0.55;
+}
+
+.widget-error-message {
+    font-size: 0.95rem;
+    max-width: 22ch;
+    line-height: 1.3;
+}

--- a/src/MooBank.Web.App/src/css/forecast.css
+++ b/src/MooBank.Web.App/src/css/forecast.css
@@ -75,3 +75,8 @@
         font-size: 0.875rem;
     }
 }
+
+.forecast-widget-chart {
+    height: 100%;
+    min-height: 300px;
+}

--- a/src/MooBank.Web.App/src/main.tsx
+++ b/src/MooBank.Web.App/src/main.tsx
@@ -2,13 +2,13 @@
 import { createRoot } from "react-dom/client";
 
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faArrowsRotate, faCheck, faCheckCircle, faTrashAlt, faChevronDown, faChevronUp, faArrowLeft, faChevronRight, faCircleChevronLeft, faDoorClosed, faLongArrowUp, faLongArrowDown, faUpload, faXmark, faFilterCircleXmark, faInfoCircle, faPenToSquare, faPlus, faUser } from "@fortawesome/free-solid-svg-icons";
+import { faArrowsRotate, faCheck, faCheckCircle, faTrashAlt, faChevronDown, faChevronUp, faArrowLeft, faChevronRight, faCircleChevronLeft, faDoorClosed, faLongArrowUp, faLongArrowDown, faUpload, faXmark, faFilterCircleXmark, faInfoCircle, faPenToSquare, faPlus, faTriangleExclamation, faUser } from "@fortawesome/free-solid-svg-icons";
 
 import * as serviceWorker from "./serviceWorkerRegistration";
 import { StrictMode } from "react";
 import { App } from "App";
 
-library.add(faArrowsRotate, faCheck, faCheckCircle, faTrashAlt, faChevronDown, faChevronUp, faArrowLeft, faDoorClosed, faLongArrowUp, faLongArrowDown, faChevronRight, faCircleChevronLeft, faUpload, faXmark, faFilterCircleXmark, faInfoCircle, faPenToSquare, faPlus, faUser);
+library.add(faArrowsRotate, faCheck, faCheckCircle, faTrashAlt, faChevronDown, faChevronUp, faArrowLeft, faDoorClosed, faLongArrowUp, faLongArrowDown, faChevronRight, faCircleChevronLeft, faUpload, faXmark, faFilterCircleXmark, faInfoCircle, faPenToSquare, faPlus, faTriangleExclamation, faUser);
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
@@ -2,16 +2,17 @@ import { Widget } from "@andrewmclachlan/moo-ds";
 import { lastMonth, lastMonthName } from "utils/dateFns";
 import { Breakdown } from "../accounts/$id/reports/-components/Breakdown";
 import { useAccounts } from "hooks/useAccounts";
+import { WidgetError } from "components/WidgetError";
 
 export const BreakdownWidget: React.FC = () => {
 
-    const {data: accounts, isLoading } = useAccounts();
+    const {data: accounts, isLoading, isError } = useAccounts();
 
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     return (
         <Widget header={(account && `Breakdown - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading}>
-            {account && <Breakdown accountId={account?.id} period={lastMonth} reportType={"Debit"} />}
+            {isError ? <WidgetError /> : account && <Breakdown accountId={account?.id} period={lastMonth} reportType={"Debit"} />}
         </Widget>
     );
 };

--- a/src/MooBank.Web.App/src/routes/-dashboard/Budget.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Budget.tsx
@@ -8,7 +8,7 @@ import { useChartColours } from "utils/chartColours";
 import { lastMonth, lastMonthName } from "utils/dateFns";
 import { Bar } from "react-chartjs-2";
 import { useBudgetReportForMonth } from "./-hooks/useBudgetReportForMonth";
-import { Amount } from "components";
+import { Amount, WidgetError } from "components";
 
 export const BudgetWidget: React.FC = () => {
 
@@ -16,7 +16,7 @@ export const BudgetWidget: React.FC = () => {
 
     const period = lastMonth;
 
-    const { data: report, isLoading } = useBudgetReportForMonth(lastMonth.startDate.getFullYear(), lastMonth.startDate.getMonth());
+    const { data: report, isLoading, isError } = useBudgetReportForMonth(lastMonth.startDate.getFullYear(), lastMonth.startDate.getMonth());
 
     const dataset: ChartData<"bar", number[], string> = {
         labels: [formatPeriod(period?.startDate, period?.endDate)],
@@ -37,7 +37,8 @@ export const BudgetWidget: React.FC = () => {
 
     return (
         <Widget header={`Budget - ${lastMonthName}`} size="single" className="report budget" loading={isLoading}>
-            {report &&
+            {isError && <WidgetError />}
+            {!isError && report &&
                 <>
                     {difference >= 0 ?
                         <h4><Amount amount={difference} prefix="$" suffix=" saved" decimalPlaces={0} positiveColour negativeColour /></h4> :

--- a/src/MooBank.Web.App/src/routes/-dashboard/Dashboard.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Dashboard.tsx
@@ -7,6 +7,7 @@ import { SummaryWidget } from "./Summary";
 import { BudgetWidget } from "./Budget";
 import { TopTagsWidget } from "./TopTags";
 import { BreakdownWidget } from "./Breakdown";
+import { ForecastWidget } from "./Forecast";
 
 const props: DashboardProps = {
     title: "Home",
@@ -20,6 +21,7 @@ export function Dashboard() {
             <SummaryWidget />
             <BreakdownWidget />
             <TopTagsWidget />
+            <ForecastWidget />
         </DashboardPage>
     );
 }

--- a/src/MooBank.Web.App/src/routes/-dashboard/Forecast.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Forecast.tsx
@@ -1,0 +1,114 @@
+import { useEffect } from "react";
+import { addMonths, format, parseISO, startOfMonth } from "date-fns";
+import { Widget } from "@andrewmclachlan/moo-ds";
+import type { ChartOptions } from "chart.js";
+import { Line } from "react-chartjs-2";
+
+import { useChartColours } from "utils/chartColours";
+import { WidgetError } from "components/WidgetError";
+import { useForecastPlans } from "../forecast/-hooks/useForecastPlans";
+import { useForecastPlan } from "../forecast/-hooks/useForecastPlan";
+import { useRunForecast } from "../forecast/-hooks/useRunForecast";
+
+const MONTHS_BEHIND = 6;
+const MONTHS_AHEAD = 6;
+
+export const ForecastWidget: React.FC = () => {
+
+    const { data: plans, isLoading: plansLoading, isError: plansError } = useForecastPlans();
+    const plan = plans?.[0];
+    const planId = plan?.id ?? "";
+
+    const { data: planDetail, isError: planError } = useForecastPlan(planId);
+    const { run, result, isPending, isError: runError } = useRunForecast();
+    const colours = useChartColours();
+
+    useEffect(() => {
+        if (planId && planDetail) {
+            run(planId);
+        }
+    }, [planId, planDetail?.updatedUtc]);
+
+    // No forecast plan exists at all - don't render the widget
+    if (!plansLoading && !plansError && plans && plans.length === 0) {
+        return null;
+    }
+
+    const header = plan ? `Forecast - ${plan.name}` : "Forecast";
+    const hasError = plansError || planError || runError;
+
+    if (hasError) {
+        return (
+            <Widget header={header} size="double" headerSize={2} className="report forecast-widget">
+                <WidgetError />
+            </Widget>
+        );
+    }
+
+    const today = startOfMonth(new Date());
+    const windowStart = addMonths(today, -MONTHS_BEHIND);
+    const windowEnd = addMonths(today, MONTHS_AHEAD);
+
+    const months = (result?.months ?? []).filter(m => {
+        const monthDate = parseISO(m.monthStart);
+        return monthDate >= windowStart && monthDate <= windowEnd;
+    });
+
+    const labels = months.map(m => format(parseISO(m.monthStart), "MMM yy"));
+
+    const data = {
+        labels,
+        datasets: [
+            {
+                label: "Projected Balance",
+                data: months.map(m => m.openingBalance),
+                borderColor: "rgb(53, 162, 235)",
+                backgroundColor: "rgba(53, 162, 235, 0.5)",
+                tension: 0.1,
+            },
+            {
+                label: "Actual Balance",
+                data: months.map(m => m.actualBalance ?? null),
+                borderColor: colours.income,
+                backgroundColor: colours.incomeTrend,
+                tension: 0.1,
+                spanGaps: false,
+            },
+        ],
+    };
+
+    const options: ChartOptions<"line"> = {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            legend: { position: "top" },
+            tooltip: {
+                callbacks: {
+                    label: (context) => {
+                        const value = context.parsed.y;
+                        return `${context.dataset.label}: $${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+                    },
+                },
+            },
+        },
+        scales: {
+            y: {
+                grid: { color: colours.grid },
+                ticks: {
+                    callback: (value) => `$${Number(value).toLocaleString()}`,
+                },
+            },
+            x: {
+                grid: { color: colours.grid },
+            },
+        },
+    };
+
+    return (
+        <Widget header={header} size="double" headerSize={2} className="report forecast-widget" loading={plansLoading || isPending}>
+            <div className="forecast-widget-chart">
+                <Line data={data} options={options} />
+            </div>
+        </Widget>
+    );
+};

--- a/src/MooBank.Web.App/src/routes/-dashboard/InOut.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/InOut.tsx
@@ -3,16 +3,17 @@ import { InOut } from "../accounts/$id/reports/-components/InOut";
 import { useAccounts } from "hooks/useAccounts";
 import { useInOutReport } from "hooks/useInOutReport";
 import { Widget } from "@andrewmclachlan/moo-ds";
+import { WidgetError } from "components/WidgetError";
 
 export const InOutWidget: React.FC = () => {
 
-    const { data: accounts, isLoading } = useAccounts();
+    const { data: accounts, isLoading, isError } = useAccounts();
 
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     return (
         <Widget header={(account && `${account.name} - ${lastMonthName}`) ?? lastMonthName} size="single" headerSize={2} className="report inout" loading={isLoading}>
-            {account && <InOut accountId={account?.id} period={lastMonth} useInOutReport={useInOutReport} />}
+            {isError ? <WidgetError /> : account && <InOut accountId={account?.id} period={lastMonth} useInOutReport={useInOutReport} />}
         </Widget>
     );
 };

--- a/src/MooBank.Web.App/src/routes/-dashboard/Summary.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Summary.tsx
@@ -2,10 +2,11 @@ import { useFormattedAccounts } from "hooks/useFormattedAccounts";
 import { Section, Widget } from "@andrewmclachlan/moo-ds";
 import { KeyValue } from "components/KeyValue";
 import { Amount } from "components/Amount";
+import { WidgetError } from "components/WidgetError";
 
 export const SummaryWidget: React.FC = () => {
 
-    const { data: accounts, isLoading } = useFormattedAccounts();
+    const { data: accounts, isLoading, isError } = useFormattedAccounts();
 
     const totals = accounts?.groups.flatMap(g => g.instruments);
     const grandTotal = totals?.reduce((acc, i) => acc + i.currentBalanceLocalCurrency, 0);
@@ -13,16 +14,20 @@ export const SummaryWidget: React.FC = () => {
 
     return (
         <Widget header="Summary" className="summary" loading={isLoading} size="single">
-            <KeyValue className="net-worth">
-                <div>Net Worth</div>
-                <Amount amount={grandTotal} positiveColour negativeColour plus minus />
-            </KeyValue>
-            <Section.Subheading>Groups</Section.Subheading>
-            {groupTotals?.map((ag, index) =>
-                <KeyValue key={index}>
-                    <div>{ag.name}</div>
-                    <div><Amount amount={ag.total} positiveColour negativeColour plus minus /></div>
-                </KeyValue>
+            {isError ? <WidgetError /> : (
+                <>
+                    <KeyValue className="net-worth">
+                        <div>Net Worth</div>
+                        <Amount amount={grandTotal} positiveColour negativeColour plus minus />
+                    </KeyValue>
+                    <Section.Subheading>Groups</Section.Subheading>
+                    {groupTotals?.map((ag, index) =>
+                        <KeyValue key={index}>
+                            <div>{ag.name}</div>
+                            <div><Amount amount={ag.total} positiveColour negativeColour plus minus /></div>
+                        </KeyValue>
+                    )}
+                </>
             )}
         </Widget>
     );

--- a/src/MooBank.Web.App/src/routes/-dashboard/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/TopTags.tsx
@@ -2,16 +2,17 @@ import { Widget } from "@andrewmclachlan/moo-ds";
 import { lastMonth, lastMonthName } from "utils/dateFns";
 import { TopTags } from "../accounts/$id/reports/-components/TopTags";
 import { useAccounts } from "hooks/useAccounts";
+import { WidgetError } from "components/WidgetError";
 
 export const TopTagsWidget: React.FC = () => {
 
-    const {data: accounts, isLoading } = useAccounts();
+    const {data: accounts, isLoading, isError } = useAccounts();
 
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     return (
         <Widget header={(account && `Top Tags - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading}>
-            {account && <TopTags accountId={account?.id} period={lastMonth} reportType={"Debit"} top={10} />}
+            {isError ? <WidgetError /> : account && <TopTags accountId={account?.id} period={lastMonth} reportType={"Debit"} top={10} />}
         </Widget>
     );
 };

--- a/src/MooBank.Web.App/src/routes/forecast/-hooks/useRunForecast.ts
+++ b/src/MooBank.Web.App/src/routes/forecast/-hooks/useRunForecast.ts
@@ -6,7 +6,7 @@ import { forecastKey } from "./keys";
 export const useRunForecast = () => {
     const queryClient = useQueryClient();
 
-    const { mutate, mutateAsync, data, isPending } = useMutation({
+    const { mutate, mutateAsync, data, isPending, isError } = useMutation({
         ...runForecastMutation(),
         onSuccess: (_data, variables) => {
             queryClient.setQueryData(
@@ -28,5 +28,5 @@ export const useRunForecast = () => {
         return mutateAsync({ path: { planId } });
     };
 
-    return { run, runAsync, result: data as ForecastResult | undefined, isPending };
+    return { run, runAsync, result: data as ForecastResult | undefined, isPending, isError };
 };


### PR DESCRIPTION
## Summary
- New **Forecast** dashboard widget (double-size) that shows the first forecast plan's projected vs actual balance over a `±6 month` window, so the chart stays legible at widget size instead of trying to render the entire plan horizon.
- New reusable **`WidgetError`** component — a centered warning triangle + "Unable to load this widget" message. Wired into every dashboard widget (`InOut`, `Budget`, `Summary`, `Breakdown`, `TopTags`, `Forecast`) so an API failure no longer makes the widget vanish.
- Side change: `useRunForecast` now exposes `isError` (previously only `isPending`), needed by the new widget.

## Test plan
- [ ] Dashboard loads with a forecast plan → Forecast widget renders the trimmed ±6 month chart.
- [ ] Dashboard loads with **no** forecast plan → Forecast widget is omitted (other widgets still render).
- [ ] Force an API error (e.g. block `/api/accounts`) → affected widgets show the "Unable to load this widget" message instead of being blank.
- [ ] Force a forecast run error → Forecast widget shows the error state.
- [ ] Dark theme still looks right (`WidgetError` uses `var(--secondary-colour)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)