### PR TITLE
feat(reports): widget and chart clickthroughs (#815)

### DIFF
--- a/src/MooBank.Web.App/src/components/PeriodSelector.tsx
+++ b/src/MooBank.Web.App/src/components/PeriodSelector.tsx
@@ -54,7 +54,22 @@ export type PeriodType = "thisMonth" | "lastMonth" | "previousMonth" | "last3Mon
 
 export const usePeriodSelector = ({instant, cacheKey, ...props}: PeriodSelectorProps) => {
     const [customPeriod, setCustomPeriod] = useCustomPeriod();
-    const [selectedPeriod, setSelectedPeriod] = useLocalStorage(cacheKey, "1");
+    const [storedPeriod, setStoredPeriod] = useLocalStorage(cacheKey, "1");
+
+    // ?period=X in the URL overrides the stored value as the initial state.
+    // Set once on mount; user interaction with the dropdown still writes to localStorage as normal.
+    const [selectedPeriod, setSelectedPeriodState] = useState<string>(() => {
+        const urlPeriodId = new URLSearchParams(window.location.search).get("period");
+        if (urlPeriodId && periodOptions.some(o => o.value === urlPeriodId)) {
+            return urlPeriodId;
+        }
+        return storedPeriod;
+    });
+    const setSelectedPeriod = (value: string) => {
+        setSelectedPeriodState(value);
+        setStoredPeriod(value);
+    };
+
     const [period, setPeriod] = useState<Period>(periodOptions.find(o => o.value === selectedPeriod) ?? (selectedPeriod === "-1" ? customPeriod : lastMonth));
     const [customStart, setCustomStart] = useState<Date>(customPeriod.startDate);
     const [customEnd, setCustomEnd] = useState<Date>(customPeriod.endDate);

--- a/src/MooBank.Web.App/src/hooks/period.ts
+++ b/src/MooBank.Web.App/src/hooks/period.ts
@@ -14,7 +14,13 @@ export const useCustomPeriod = (): [period: Period, setPeriod: (value: Period) =
 }
 
 export const getPeriod = (): Period => {
-    
+
+    const urlPeriodId = new URLSearchParams(window.location.search).get("period");
+    if (urlPeriodId) {
+        const match = periodOptions.find(o => o.value === urlPeriodId);
+        if (match) return match;
+    }
+
     const periodId = JSON.parse(localStorage.getItem("period-id")) ?? "1";
 
     if (periodId !== "-1") {

--- a/src/MooBank.Web.App/src/routeTree.gen.ts
+++ b/src/MooBank.Web.App/src/routeTree.gen.ts
@@ -64,6 +64,7 @@ import { Route as AccountsIdReportsInOutRouteImport } from "./routes/accounts/$i
 import { Route as AccountsIdReportsByTagRouteImport } from "./routes/accounts/$id/reports/by-tag"
 import { Route as AccountsIdReportsAllTagAverageRouteImport } from "./routes/accounts/$id/reports/all-tag-average"
 import { Route as AccountsIdVirtualVirtualIdRouteRouteImport } from "./routes/accounts/$id/virtual.$virtualId/route"
+import { Route as AccountsIdReportsBreakdownRouteRouteImport } from "./routes/accounts/$id/reports/breakdown/route"
 import { Route as AccountsIdVirtualVirtualIdIndexRouteImport } from "./routes/accounts/$id/virtual.$virtualId/index"
 import { Route as AccountsIdReportsTagTrendIndexRouteImport } from "./routes/accounts/$id/reports/tag-trend/index"
 import { Route as AccountsIdReportsBreakdownIndexRouteImport } from "./routes/accounts/$id/reports/breakdown/index"
@@ -356,6 +357,12 @@ const AccountsIdVirtualVirtualIdRouteRoute =
     path: "/virtual/$virtualId",
     getParentRoute: () => AccountsIdRouteRoute,
   } as any)
+const AccountsIdReportsBreakdownRouteRoute =
+  AccountsIdReportsBreakdownRouteRouteImport.update({
+    id: "/breakdown",
+    path: "/breakdown",
+    getParentRoute: () => AccountsIdReportsRouteRoute,
+  } as any)
 const AccountsIdVirtualVirtualIdIndexRoute =
   AccountsIdVirtualVirtualIdIndexRouteImport.update({
     id: "/",
@@ -370,9 +377,9 @@ const AccountsIdReportsTagTrendIndexRoute =
   } as any)
 const AccountsIdReportsBreakdownIndexRoute =
   AccountsIdReportsBreakdownIndexRouteImport.update({
-    id: "/breakdown/",
-    path: "/breakdown/",
-    getParentRoute: () => AccountsIdReportsRouteRoute,
+    id: "/",
+    path: "/",
+    getParentRoute: () => AccountsIdReportsBreakdownRouteRoute,
   } as any)
 const AccountsIdVirtualVirtualIdTransactionsRoute =
   AccountsIdVirtualVirtualIdTransactionsRouteImport.update({
@@ -394,9 +401,9 @@ const AccountsIdReportsTagTrendTagIdRoute =
   } as any)
 const AccountsIdReportsBreakdownTagIdRoute =
   AccountsIdReportsBreakdownTagIdRouteImport.update({
-    id: "/breakdown/$tagId",
-    path: "/breakdown/$tagId",
-    getParentRoute: () => AccountsIdReportsRouteRoute,
+    id: "/$tagId",
+    path: "/$tagId",
+    getParentRoute: () => AccountsIdReportsBreakdownRouteRoute,
   } as any)
 const AccountsIdManageVirtualCreateRoute =
   AccountsIdManageVirtualCreateRouteImport.update({
@@ -459,6 +466,7 @@ export interface FileRoutesByFullPath {
   "/settings/families/": typeof SettingsFamiliesIndexRoute
   "/settings/institutions/": typeof SettingsInstitutionsIndexRoute
   "/shares/$id/": typeof SharesIdIndexRoute
+  "/accounts/$id/reports/breakdown": typeof AccountsIdReportsBreakdownRouteRouteWithChildren
   "/accounts/$id/virtual/$virtualId": typeof AccountsIdVirtualVirtualIdRouteRouteWithChildren
   "/accounts/$id/reports/all-tag-average": typeof AccountsIdReportsAllTagAverageRoute
   "/accounts/$id/reports/by-tag": typeof AccountsIdReportsByTagRoute
@@ -587,6 +595,7 @@ export interface FileRoutesById {
   "/settings/families/": typeof SettingsFamiliesIndexRoute
   "/settings/institutions/": typeof SettingsInstitutionsIndexRoute
   "/shares/$id/": typeof SharesIdIndexRoute
+  "/accounts/$id/reports/breakdown": typeof AccountsIdReportsBreakdownRouteRouteWithChildren
   "/accounts/$id/virtual/$virtualId": typeof AccountsIdVirtualVirtualIdRouteRouteWithChildren
   "/accounts/$id/reports/all-tag-average": typeof AccountsIdReportsAllTagAverageRoute
   "/accounts/$id/reports/by-tag": typeof AccountsIdReportsByTagRoute
@@ -656,6 +665,7 @@ export interface FileRouteTypes {
     | "/settings/families/"
     | "/settings/institutions/"
     | "/shares/$id/"
+    | "/accounts/$id/reports/breakdown"
     | "/accounts/$id/virtual/$virtualId"
     | "/accounts/$id/reports/all-tag-average"
     | "/accounts/$id/reports/by-tag"
@@ -783,6 +793,7 @@ export interface FileRouteTypes {
     | "/settings/families/"
     | "/settings/institutions/"
     | "/shares/$id/"
+    | "/accounts/$id/reports/breakdown"
     | "/accounts/$id/virtual/$virtualId"
     | "/accounts/$id/reports/all-tag-average"
     | "/accounts/$id/reports/by-tag"
@@ -1227,6 +1238,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof AccountsIdVirtualVirtualIdRouteRouteImport
       parentRoute: typeof AccountsIdRouteRoute
     }
+    "/accounts/$id/reports/breakdown": {
+      id: "/accounts/$id/reports/breakdown"
+      path: "/breakdown"
+      fullPath: "/accounts/$id/reports/breakdown"
+      preLoaderRoute: typeof AccountsIdReportsBreakdownRouteRouteImport
+      parentRoute: typeof AccountsIdReportsRouteRoute
+    }
     "/accounts/$id/virtual/$virtualId/": {
       id: "/accounts/$id/virtual/$virtualId/"
       path: "/"
@@ -1243,10 +1261,10 @@ declare module "@tanstack/react-router" {
     }
     "/accounts/$id/reports/breakdown/": {
       id: "/accounts/$id/reports/breakdown/"
-      path: "/breakdown"
+      path: "/"
       fullPath: "/accounts/$id/reports/breakdown/"
       preLoaderRoute: typeof AccountsIdReportsBreakdownIndexRouteImport
-      parentRoute: typeof AccountsIdReportsRouteRoute
+      parentRoute: typeof AccountsIdReportsBreakdownRouteRoute
     }
     "/accounts/$id/virtual/$virtualId/transactions": {
       id: "/accounts/$id/virtual/$virtualId/transactions"
@@ -1271,10 +1289,10 @@ declare module "@tanstack/react-router" {
     }
     "/accounts/$id/reports/breakdown/$tagId": {
       id: "/accounts/$id/reports/breakdown/$tagId"
-      path: "/breakdown/$tagId"
+      path: "/$tagId"
       fullPath: "/accounts/$id/reports/breakdown/$tagId"
       preLoaderRoute: typeof AccountsIdReportsBreakdownTagIdRouteImport
-      parentRoute: typeof AccountsIdReportsRouteRoute
+      parentRoute: typeof AccountsIdReportsBreakdownRouteRoute
     }
     "/accounts/$id/manage/virtual/create": {
       id: "/accounts/$id/manage/virtual/create"
@@ -1324,29 +1342,44 @@ const SettingsRouteRouteWithChildren = SettingsRouteRoute._addFileChildren(
   SettingsRouteRouteChildren,
 )
 
+interface AccountsIdReportsBreakdownRouteRouteChildren {
+  AccountsIdReportsBreakdownTagIdRoute: typeof AccountsIdReportsBreakdownTagIdRoute
+  AccountsIdReportsBreakdownIndexRoute: typeof AccountsIdReportsBreakdownIndexRoute
+}
+
+const AccountsIdReportsBreakdownRouteRouteChildren: AccountsIdReportsBreakdownRouteRouteChildren =
+  {
+    AccountsIdReportsBreakdownTagIdRoute: AccountsIdReportsBreakdownTagIdRoute,
+    AccountsIdReportsBreakdownIndexRoute: AccountsIdReportsBreakdownIndexRoute,
+  }
+
+const AccountsIdReportsBreakdownRouteRouteWithChildren =
+  AccountsIdReportsBreakdownRouteRoute._addFileChildren(
+    AccountsIdReportsBreakdownRouteRouteChildren,
+  )
+
 interface AccountsIdReportsRouteRouteChildren {
+  AccountsIdReportsBreakdownRouteRoute: typeof AccountsIdReportsBreakdownRouteRouteWithChildren
   AccountsIdReportsAllTagAverageRoute: typeof AccountsIdReportsAllTagAverageRoute
   AccountsIdReportsByTagRoute: typeof AccountsIdReportsByTagRoute
   AccountsIdReportsInOutRoute: typeof AccountsIdReportsInOutRoute
   AccountsIdReportsMonthlyBalancesRoute: typeof AccountsIdReportsMonthlyBalancesRoute
   AccountsIdReportsIndexRoute: typeof AccountsIdReportsIndexRoute
-  AccountsIdReportsBreakdownTagIdRoute: typeof AccountsIdReportsBreakdownTagIdRoute
   AccountsIdReportsTagTrendTagIdRoute: typeof AccountsIdReportsTagTrendTagIdRoute
-  AccountsIdReportsBreakdownIndexRoute: typeof AccountsIdReportsBreakdownIndexRoute
   AccountsIdReportsTagTrendIndexRoute: typeof AccountsIdReportsTagTrendIndexRoute
 }
 
 const AccountsIdReportsRouteRouteChildren: AccountsIdReportsRouteRouteChildren =
   {
+    AccountsIdReportsBreakdownRouteRoute:
+      AccountsIdReportsBreakdownRouteRouteWithChildren,
     AccountsIdReportsAllTagAverageRoute: AccountsIdReportsAllTagAverageRoute,
     AccountsIdReportsByTagRoute: AccountsIdReportsByTagRoute,
     AccountsIdReportsInOutRoute: AccountsIdReportsInOutRoute,
     AccountsIdReportsMonthlyBalancesRoute:
       AccountsIdReportsMonthlyBalancesRoute,
     AccountsIdReportsIndexRoute: AccountsIdReportsIndexRoute,
-    AccountsIdReportsBreakdownTagIdRoute: AccountsIdReportsBreakdownTagIdRoute,
     AccountsIdReportsTagTrendTagIdRoute: AccountsIdReportsTagTrendTagIdRoute,
-    AccountsIdReportsBreakdownIndexRoute: AccountsIdReportsBreakdownIndexRoute,
     AccountsIdReportsTagTrendIndexRoute: AccountsIdReportsTagTrendIndexRoute,
   }
 

--- a/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
@@ -11,7 +11,7 @@ export const BreakdownWidget: React.FC = () => {
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     return (
-        <Widget header={(account && `Breakdown - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading}>
+        <Widget header={(account && `Breakdown - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading} to={account ? `/accounts/${account.id}/reports/breakdown?period=1` : undefined}>
             {isError ? <WidgetError /> : account && <Breakdown accountId={account?.id} period={lastMonth} reportType={"Debit"} />}
         </Widget>
     );

--- a/src/MooBank.Web.App/src/routes/-dashboard/Budget.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Budget.tsx
@@ -36,7 +36,7 @@ export const BudgetWidget: React.FC = () => {
     const difference = Math.round((((report?.budgetedAmount ?? 0) - Math.abs(report?.actual ?? 0)) / 10.0)) * 10;
 
     return (
-        <Widget header={`Budget - ${lastMonthName}`} size="single" className="report budget" loading={isLoading}>
+        <Widget header={`Budget - ${lastMonthName}`} size="single" className="report budget" loading={isLoading} to={`/budget/report/${lastMonth.startDate.getFullYear()}/${lastMonth.startDate.getMonth()}`}>
             {isError && <WidgetError />}
             {!isError && report &&
                 <>

--- a/src/MooBank.Web.App/src/routes/-dashboard/Forecast.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Forecast.tsx
@@ -39,7 +39,7 @@ export const ForecastWidget: React.FC = () => {
 
     if (hasError) {
         return (
-            <Widget header={header} size="double" headerSize={2} className="report forecast-widget">
+            <Widget header={header} size="double" headerSize={2} className="report forecast-widget" to="/forecast">
                 <WidgetError />
             </Widget>
         );
@@ -105,7 +105,7 @@ export const ForecastWidget: React.FC = () => {
     };
 
     return (
-        <Widget header={header} size="double" headerSize={2} className="report forecast-widget" loading={plansLoading || isPending}>
+        <Widget header={header} size="double" headerSize={2} className="report forecast-widget" loading={plansLoading || isPending} to="/forecast">
             <div className="forecast-widget-chart">
                 <Line data={data} options={options} />
             </div>

--- a/src/MooBank.Web.App/src/routes/-dashboard/InOut.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/InOut.tsx
@@ -12,7 +12,7 @@ export const InOutWidget: React.FC = () => {
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     return (
-        <Widget header={(account && `${account.name} - ${lastMonthName}`) ?? lastMonthName} size="single" headerSize={2} className="report inout" loading={isLoading}>
+        <Widget header={(account && `${account.name} - ${lastMonthName}`) ?? lastMonthName} size="single" headerSize={2} className="report inout" loading={isLoading} to={account ? `/accounts/${account.id}/reports/in-out?period=1` : undefined}>
             {isError ? <WidgetError /> : account && <InOut accountId={account?.id} period={lastMonth} useInOutReport={useInOutReport} />}
         </Widget>
     );

--- a/src/MooBank.Web.App/src/routes/-dashboard/Summary.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Summary.tsx
@@ -13,7 +13,7 @@ export const SummaryWidget: React.FC = () => {
     const groupTotals = accounts?.groups.filter(ag => ag.total);
 
     return (
-        <Widget header="Summary" className="summary" loading={isLoading} size="single">
+        <Widget header="Summary" className="summary" loading={isLoading} size="single" to="/accounts">
             {isError ? <WidgetError /> : (
                 <>
                     <KeyValue className="net-worth">

--- a/src/MooBank.Web.App/src/routes/-dashboard/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/TopTags.tsx
@@ -11,7 +11,7 @@ export const TopTagsWidget: React.FC = () => {
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     return (
-        <Widget header={(account && `Top Tags - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading}>
+        <Widget header={(account && `Top Tags - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading} to={account ? `/accounts/${account.id}/reports/all-tag-average?period=1` : undefined}>
             {isError ? <WidgetError /> : account && <TopTags accountId={account?.id} period={lastMonth} reportType={"Debit"} top={10} />}
         </Widget>
     );

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/Breakdown.tsx
@@ -1,16 +1,14 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 
 import { useBreakdownReport } from "../../../-hooks/useBreakdownReport";
-import { useTag } from "../../../-hooks/useTag";
 
-import type { ChartData, LegendItem } from "chart.js";
-import { Doughnut, getElementAtEvent } from "react-chartjs-2";
+import type { ChartData } from "chart.js";
+import { Doughnut } from "react-chartjs-2";
 
 import type { Period } from "models/dateFns";
-import { useNavigate, useParams } from "@tanstack/react-router";
 import { chartColours } from "utils/chartColours";
 import type { transactionTypeFilter } from "store/state";
-import type { Tag, TagValue } from "api/types.gen";
+import type { TagValue } from "api/types.gen";
 
 
 export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, reportType, selectedTagChanged }) => {
@@ -58,13 +56,13 @@ export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, 
                 mode: "point",
                 intersect: true,
             },
-        }}
-            onClick={(e) => {
-                const elements = getElementAtEvent(chartRef.current!, e);
+            onClick: (_event, elements) => {
                 if (elements.length !== 1) return;
                 const tag = report.data!.tags[elements[0].index];
                 selectedTagChanged?.(tag);
-            }} />
+            },
+        }}
+        />
     );
 }
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/BreakdownPage.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/BreakdownPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useTag } from "../../../-hooks/useTag";
 import { ReportsPage } from "./ReportsPage";
@@ -19,47 +19,42 @@ import { getPeriod } from "hooks";
 
 export const BreakdownPage = () => {
 
-    const { id: accountId, tagId } = useParams({ strict: false });
+    const { id: accountId, tagId: tagIdParam } = useParams({ strict: false });
+    const tagId = tagIdParam ? parseInt(tagIdParam) : undefined;
 
     const navigate = useNavigate();
 
     const [reportType, setReportType] = useState<transactionTypeFilter>("Debit");
     const [period, setPeriod] = useState<Period>(getPeriod());
-    const [selectedTagId, setSelectedTagId] = useState<number | undefined>(undefined);
     const [previousTagIds, setPreviousTagIds] = useState<number[]>([]);
-    const tag = useTag(selectedTagId ?? 0);
+    const tag = useTag(tagId);
 
-    useEffect(() => {
-        if (selectedTagId !== undefined) {
-            setPreviousTagIds([...previousTagIds, selectedTagId]);
-        }
-        setSelectedTagId(tagId ? parseInt(tagId) : undefined);
-    }, [tagId]);
-
-    const selectedTagChanged = (tag: TagValue) => {
-        if (selectedTagId !== undefined) {
-            setPreviousTagIds([...previousTagIds, selectedTagId]);
-        }
-        setSelectedTagId(tag.tagId ?? undefined);
-
-
-        if (!tag.hasChildren || tag.tagId === selectedTagId) {
-
-            const url = !tag.tagId ? `/accounts/${accountId}?untagged=true` : `/accounts/${accountId}?tag=${tag.tagId}&type=${reportType}`;
-
+    const selectedTagChanged = (clickedTag: TagValue) => {
+        if (!clickedTag.hasChildren || clickedTag.tagId === tagId) {
+            const url = !clickedTag.tagId
+                ? `/accounts/${accountId}?untagged=true`
+                : `/accounts/${accountId}?tag=${clickedTag.tagId}&type=${reportType}`;
             navigate({ to: url });
             return;
         }
 
-        const newUrl = `/accounts/${accountId}/reports/breakdown/${tagId}`;
-        window.history.replaceState({ path: newUrl }, "", newUrl);
-    }
+        if (tagId !== undefined) {
+            setPreviousTagIds([...previousTagIds, tagId]);
+        }
+        navigate({
+            to: `/accounts/${accountId}/reports/breakdown/${clickedTag.tagId}`,
+            replace: true,
+        });
+    };
 
     const goBack = () => {
-        console.debug("Previous Tag IDs: ", previousTagIds);
-        setSelectedTagId(previousTagIds.pop());
-        setPreviousTagIds([...previousTagIds]);
-    }
+        const previous = previousTagIds[previousTagIds.length - 1];
+        setPreviousTagIds(previousTagIds.slice(0, -1));
+        const url = previous !== undefined
+            ? `/accounts/${accountId}/reports/breakdown/${previous}`
+            : `/accounts/${accountId}/reports/breakdown`;
+        navigate({ to: url, replace: true });
+    };
 
 
     return (
@@ -71,7 +66,7 @@ export const BreakdownPage = () => {
             <Section className="report doughnut">
                 {tag.data?.name && <h3><FontAwesomeIcon className="clickable" icon="circle-chevron-left" size="xs" onClick={goBack} /> {tag.data.name}</h3>}
                 {!tag.data && <h3>Top-Level Tags</h3>}
-                <Breakdown accountId={accountId} tagId={selectedTagId} period={period} reportType={reportType} selectedTagChanged={selectedTagChanged} />
+                <Breakdown accountId={accountId} tagId={tagId} period={period} reportType={reportType} selectedTagChanged={selectedTagChanged} />
             </Section>
         </ReportsPage>
     );

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
@@ -1,9 +1,9 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { useAllTagAverageReport } from "../../../-hooks/useAllTagAverageReport";
 
 import type { ChartData } from "chart.js";
-import { Bar, getElementAtEvent } from "react-chartjs-2";
+import { Bar } from "react-chartjs-2";
 
 import type { Period } from "models/dateFns";
 import { useNavigate } from "@tanstack/react-router";
@@ -16,8 +16,6 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
     const [showGross] = useState<boolean>(false); //TODO: may make this an option
 
     const report = useAllTagAverageReport(accountId, period?.startDate, period?.endDate, reportType, top);
-
-    const chartRef = useRef(null);
 
     const dataset: ChartData<"bar", number[], string> = {
         labels: report.data?.tags.map(t => t.tagName) ?? [],
@@ -37,7 +35,7 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
     }
 
     return (
-        <Bar id="alltagaverage" ref={chartRef} data={dataset} options={{
+        <Bar id="alltagaverage" data={dataset} options={{
             plugins: {
                 legend: {
                     display: false,
@@ -58,13 +56,13 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
                 }
             },
             maintainAspectRatio: false,
-        }}
-            onClick={(e) => {
-                const elements = getElementAtEvent(chartRef.current!, e);
+            onClick: (_event, elements) => {
                 if (elements.length !== 1) return;
-                if (!report.data!.tags[elements[0].index].hasChildren) return;
-                navigate({ to: `/accounts/${accountId}/reports/breakdown/${report.data!.tags[elements[0].index].tagId}` });
-            }}
+                const tag = report.data!.tags[elements[0].index];
+                const url = !tag.tagId ? `/accounts/${accountId}?untagged=true` : `/accounts/${accountId}?tag=${tag.tagId}&type=${reportType}`;
+                navigate({ to: url });
+            },
+        }}
         />
     );
 }

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/breakdown/$tagId.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/breakdown/$tagId.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { BreakdownPage } from "../-components/BreakdownPage";
 
 export const Route = createFileRoute("/accounts/$id/reports/breakdown/$tagId")({
-    component: BreakdownPage,
+    component: () => null,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/breakdown/index.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/breakdown/index.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { BreakdownPage } from "../-components/BreakdownPage";
 
 export const Route = createFileRoute("/accounts/$id/reports/breakdown/")({
-    component: BreakdownPage,
+    component: () => null,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/breakdown/route.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/breakdown/route.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { BreakdownPage } from "../-components/BreakdownPage";
+
+export const Route = createFileRoute("/accounts/$id/reports/breakdown")({
+    component: () => (
+        <>
+            <BreakdownPage />
+            <Outlet />
+        </>
+    ),
+});

--- a/src/MooBank.Web.App/src/routes/accounts/-hooks/useBreakdownReport.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-hooks/useBreakdownReport.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { tagBreakdownReportForTagOptions, tagBreakdownReportOptions } from "api/@tanstack/react-query.gen";
 import { formatISODate } from "utils/dateFns";
 import type { transactionTypeFilter } from "store/state";
@@ -11,5 +11,6 @@ export const useBreakdownReport = (accountId: string, start: Date, end: Date, re
     return useQuery({
         ...(options as ReturnType<typeof tagBreakdownReportOptions>),
         enabled: !!start && !!end,
+        placeholderData: keepPreviousData,
     });
 };

--- a/src/MooBank.Web.App/src/routes/accounts/-hooks/useTag.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-hooks/useTag.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { getTagOptions } from "api/@tanstack/react-query.gen";
 
-export const useTag = (id: number) => useQuery({
+export const useTag = (id?: number) => useQuery({
     ...getTagOptions({ path: { id } }),
     enabled: !!id,
 });

--- a/src/MooBank.Web.App/src/routes/budget/-components/BudgetReportYear.tsx
+++ b/src/MooBank.Web.App/src/routes/budget/-components/BudgetReportYear.tsx
@@ -1,7 +1,7 @@
-import React, { useRef } from "react";
+import React from "react";
 
 import type { ChartData } from "chart.js";
-import { Bar, getElementAtEvent } from "react-chartjs-2";
+import { Bar } from "react-chartjs-2";
 
 import { Section } from "@andrewmclachlan/moo-ds";
 import { useChartColours } from "utils/chartColours";
@@ -11,7 +11,6 @@ import { useBudgetReport } from "../-hooks/useBudgetReport";
 export const BudgetReportYear: React.FC<BudgetReportYearProps> = ({ year, onDrilldown }) => {
 
     const colours = useChartColours();
-    const chartRef = useRef(null);
 
     const report = useBudgetReport(year);
 
@@ -32,7 +31,7 @@ export const BudgetReportYear: React.FC<BudgetReportYearProps> = ({ year, onDril
     return (
         <Section className="report" style={{ width: "2000px ! important" }}>
             <h3>Budget Report</h3>
-            <Bar id="budget-report" ref={chartRef} data={dataset} options={{
+            <Bar id="budget-report" data={dataset} options={{
                 plugins: {
                     tooltip: {
                         mode: "point",
@@ -47,13 +46,12 @@ export const BudgetReportYear: React.FC<BudgetReportYearProps> = ({ year, onDril
                     x: {
                         stacked: false
                     }
-                }
-            }}
-                onClick={(e) => {
-                    const elements = getElementAtEvent(chartRef.current!, e);
+                },
+                onClick: (_event, elements) => {
                     if (elements.length !== 1) return;
                     onDrilldown(report.data!.items[elements[0].index].month);
-                }}
+                },
+            }}
             />
         </Section>
     );

--- a/src/MooBank.Web.App/src/utils/chartSetup.ts
+++ b/src/MooBank.Web.App/src/utils/chartSetup.ts
@@ -1,4 +1,5 @@
 import { Chart, registerables } from "chart.js";
+import type { Plugin } from "chart.js";
 import annotationPlugin from "chartjs-plugin-annotation";
 import chartTrendline from "chartjs-plugin-trendline";
 
@@ -17,4 +18,26 @@ const safeAnnotationPlugin: typeof annotationPlugin = {
     },
 };
 
-Chart.register(...registerables, safeAnnotationPlugin, chartTrendline);
+// Show a pointer cursor when the mouse is over a data element on a chart
+// that has declared a Chart.js `options.onClick` handler. Charts whose click
+// behaviour is wired via the React `onClick` prop won't surface here — they
+// need to use Chart.js's own `onClick` option to opt in.
+const pointerCursorPlugin: Plugin = {
+    id: "pointerCursor",
+    afterEvent(chart, args) {
+        const event = args.event;
+        if (event.type !== "mousemove") return;
+        const canvas = chart.canvas;
+        if (!canvas || typeof chart.options.onClick !== "function") return;
+        const nativeEvent = (event.native ?? event) as Event;
+        const elements = chart.getElementsAtEventForMode(
+            nativeEvent,
+            "nearest",
+            { intersect: true },
+            false,
+        );
+        canvas.style.cursor = elements.length > 0 ? "pointer" : "default";
+    },
+};
+
+Chart.register(...registerables, safeAnnotationPlugin, chartTrendline, pointerCursorPlugin);


### PR DESCRIPTION
## Summary

Closes #815.

- Dashboard widgets navigate to their full pages via the moo-ds Widget `to` prop. InOut, Breakdown and Top Tags widgets append `?period=1` so the report opens with Last Month pre-selected.
- `getPeriod()` and the period selector honour `?period=` as a one-shot initial state and do **not** write it back to localStorage, so the saved preference is untouched.
- Top Tags chart bars now navigate to a filtered transaction list for every bar (was previously a no-op for leaves because the backend hardcodes `HasChildren = false` for the AllTagAverage report — a separate, deeper fix).
- Breakdown report uses a new layout route (`breakdown/route.tsx`) that owns `BreakdownPage`, so drilling in/out keeps the chart mounted instead of unmount/remounting between `breakdown/index` and `breakdown/$tagId`. URL stays in sync via `navigate({ replace: true })`, and `useBreakdownReport` opts into `placeholderData: keepPreviousData` so chart.js animates between tags instead of blanking.
- Click handlers on TopTags, Breakdown, and BudgetReportYear migrated from the React `onClick` prop to Chart.js `options.onClick` so a global plugin can detect them.
- New global Chart.js plugin in `chartSetup.ts` sets the canvas cursor to `pointer` over data elements on any chart that declares `options.onClick` — non-interactive charts keep the default cursor.

## Test plan

- [ ] Dashboard widget headers (InOut, Budget, Summary, Breakdown, Top Tags, Forecast) navigate to the correct pages.
- [ ] Clicking an InOut / Breakdown / Top Tags widget opens the report with Last Month selected; the saved period preference (whatever the dropdown was set to before) is unchanged after navigating back.
- [ ] Top Tags chart bars navigate to a filtered transaction list with `?tag={id}&type={Debit|Credit}` (or `?untagged=true` for null tagId).
- [ ] Breakdown report drilldown and back-arrow keep the URL in sync (`/breakdown` ↔ `/breakdown/5`), refresh lands on the same tag, and the chart does not flash blank during transitions.
- [ ] Pointer cursor appears over bars/slices on TopTags, Breakdown and the year budget chart; default cursor over non-interactive charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)