### PR TITLE
feat(groups): assign a colour to a group and show it on the account list

### DIFF
--- a/.agents/plans/group-colours.md
+++ b/.agents/plans/group-colours.md
@@ -1,0 +1,388 @@
+# Feature: Group Colours (GitHub issue #801)
+
+IMPORTANT: Validate documentation and codebase patterns before implementing. Pay special attention to naming of existing utils, types, and models. Import from the correct files.
+
+## Feature Description
+
+Allow a user to assign a colour to a Group. The colour can be picked from a pre-defined palette of theme hues OR via a free-form colour picker (custom hex value). The account list page (the dashboard / "summary" account list) must visually surface the group colour — by colouring the group header and/or rendering a vertical stripe on the left edge of the group's table.
+
+This mirrors the **existing, fully-implemented Tag colour feature** end-to-end (SQL `CHAR(7)` column → `HexColour` domain value object → `HexColourConverter` EF conversion → model property → `type="color"` input on the frontend). The implementation should follow that precedent closely to minimise risk.
+
+## User Story
+
+As a MooBank user
+I want to assign a colour to each of my account groups
+So that I can visually distinguish groups at a glance on the account list / dashboard.
+
+## Feature Metadata
+
+**Feature Type**: Enhancement
+**Estimated Complexity**: Medium (full-stack: DB, domain, EF, module CQRS, API model, generated types, React form + display)
+**Primary Systems Affected**:
+- `MooBank.Database` (Group table schema)
+- `MooBank.Domain` (Group entity)
+- `MooBank.Infrastructure` (EF entity configuration for Group — new file)
+- `MooBank.Modules.Groups` (Model, Create/Update commands, GetAll/Get queries via model extension)
+- `MooBank.Modules.Instruments` (InstrumentsList `Group` model + `GetFormatted` query — to surface colour on the account list)
+- `MooBank.Web.App` (regenerated API types, GroupForm, AccountListGroup, CSS)
+- Tests: `MooBank.Modules.Groups.Tests`
+
+**Dependencies**: No new external libraries. Reuses `Asm.Drawing.HexColour` (already referenced via `MooBank.Models` / `MooBank.Infrastructure`).
+
+---
+
+## Context References
+
+### Mandatory Reading (READ BEFORE IMPLEMENTING)
+
+The Tag colour feature is the canonical pattern to mirror. Read these first:
+
+- `src/MooBank.Database/dbo/Tables/Tag.sql` (line 6) — Why: `[Colour] CHAR(7) NULL` column definition to copy into `Group.sql`.
+- `src/MooBank.Domain/Entities/Tag/Tag.cs` (line 22) — Why: `public HexColour? Colour { get; set; }` property pattern on a domain entity.
+- `src/MooBank.Infrastructure/EntityConfigurations/Tag.cs` (lines 12-16) — Why: shows the exact EF mapping `.HasConversion<HexColourConverter>().HasColumnType("char(7)").HasMaxLength(7)`. **A new `Group` EntityConfiguration must be created mirroring this.**
+- `src/MooBank.Infrastructure/ValueConverters/HexColourConverter.cs` — Why: the converter already exists and is reused as-is.
+- `src/MooBank.Models/Tag.cs` (line 18) — Why: `public HexColour? Colour { get; set; }` on a model record (serialised to the frontend).
+- `src/MooBank.Web.App/src/routes/tags/-components/TagDetails.tsx` (lines 34-35) — Why: `<Input id="colour" type="color" className="form-control-color" value={(tag.colour as string) ?? ""} onChange={...} />` — the colour picker pattern. Note `HexColour` serialises as a string at runtime but is typed `unknown` in generated types, hence the `as string` cast.
+
+Group feature files to modify:
+
+- `src/MooBank.Domain/Entities/Group/Group.cs` (lines 13-26) — Group aggregate root. Add `Colour` property.
+- `src/MooBank.Modules.Groups/Models/Group.cs` (whole file) — model record + `ToModel` mapping extension. Add `Colour`.
+- `src/MooBank.Modules.Groups/Commands/Create.cs` (lines 8, 16-22) — `Create` record + handler. Add `Colour`.
+- `src/MooBank.Modules.Groups/Commands/Update.cs` (lines 18-20) — handler copies model→entity. Add `Colour` copy.
+- `src/MooBank.Modules.Groups/Commands/Validators.cs` — `CreateValidator` / `GroupValidator`. Optionally validate colour format.
+- `src/MooBank.Infrastructure/MooBankContext.cs` (line 36) — `DbSet<Group> Groups`. Confirm EntityConfiguration is auto-applied (see Gotcha below).
+- `src/MooBank.Modules.Instruments/Models/Instruments/InstrumentsList.cs` (lines 14-26) — the `InstrumentGroup` (DisplayName) model used by the account list. Add `Colour`.
+- `src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs` (lines 47-55) — builds the account-list `Group`. Add `Colour = ag.Colour`.
+- `src/MooBank.Web.App/src/components/AccountList/AccountListGroup.tsx` (lines 16-41) — renders the group header + `SectionTable`. Add colour stripe/header styling.
+- `src/MooBank.Web.App/src/routes/groups/-components/GroupForm.tsx` (lines 45-63) — Group create/edit form. Add colour input.
+- `src/MooBank.Web.App/src/models/groups.ts` — `emptyGroup`. Add `colour` default (optional).
+- `src/MooBank.Web.App/src/css/components/accountlist.css` (lines 109-198) — `table.accounts` styles; add stripe/header colour rules here.
+
+Test references:
+
+- `tests/MooBank.Modules.Groups.Tests/Support/TestEntities.cs` — `CreateGroup` / `CreateGroupModel` factory helpers. Add `colour` parameter.
+- `tests/MooBank.Modules.Groups.Tests/Commands/UpdateTests.cs` — handler test pattern to extend with a colour assertion.
+- `tests/MooBank.Modules.Groups.Tests/Commands/CreateTests.cs` — create handler tests.
+
+### New Files to Create
+
+- `src/MooBank.Infrastructure/EntityConfigurations/Group.cs` — EF `IEntityTypeConfiguration<Group>` to map the `Colour` property via `HexColourConverter` (mirrors `Tag.cs`).
+
+### External Documentation
+
+None required — `HexColour` lives in the `Asm.Drawing` namespace from the ASM NuGet package and is already in use.
+
+### Patterns to Follow
+
+**EF HexColour mapping (from `EntityConfigurations/Tag.cs:12-16`):**
+```csharp
+entity.Property(e => e.Colour)
+    .HasConversion<HexColourConverter>()
+    .HasColumnType("char(7)")
+    .HasMaxLength(7);
+```
+
+**Domain entity property (from `Entities/Tag/Tag.cs:22`):**
+```csharp
+public HexColour? Colour { get; set; }
+```
+
+**Frontend colour input (from `tags/-components/TagDetails.tsx:34-35`):**
+```tsx
+<Input id="colour" type="color" className="form-control-color"
+       value={(group.colour as string) ?? ""}
+       onChange={(e) => /* set colour */} />
+```
+
+**Account-list group model build (from `Instruments/Queries/Instruments/GetFormatted.cs:47-55`):** the `new Group { ... }` projection where `ag` is the `Domain.Entities.Group.Group`.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Foundation (Database + Domain + EF)
+
+1. Add `[Colour] CHAR(7) NULL` to the `Group` SQL table.
+2. Add `HexColour? Colour` to the `Group` domain entity.
+3. Create `GroupConfiguration` EF config mapping the colour column via `HexColourConverter`.
+
+### Phase 2: Core Implementation (Module CQRS + Models)
+
+4. Add `Colour` to the Groups module `Group` model + `ToModel` mapping.
+5. Thread `Colour` through `Create` command + handler.
+6. Thread `Colour` through `Update` handler.
+7. (Optional) Add colour format validation.
+8. Add `Colour` to the Instruments `InstrumentGroup` model and `GetFormatted` projection (so the account list receives it).
+
+### Phase 3: Integration (Frontend)
+
+9. Regenerate frontend API types (or hand-update if generation is unavailable).
+10. Add a colour picker (+ predefined palette) to `GroupForm`.
+11. Render the group colour on `AccountListGroup` (header tint + left stripe) with supporting CSS.
+12. Update `emptyGroup` default.
+
+### Phase 4: Testing & Validation
+
+13. Update test factories + add colour-round-trip assertions to Create/Update handler tests.
+14. Run full validation suite (build, test, lint).
+
+---
+
+## Step-by-Step Tasks
+
+IMPORTANT: Execute every task in order, top to bottom. Each task is atomic and independently testable.
+
+### Task 1: UPDATE `src/MooBank.Database/dbo/Tables/Group.sql`
+
+- **IMPLEMENT**: Add a nullable colour column. Insert after the `[ShowPosition] BIT NOT NULL,` line:
+  ```sql
+  [Colour] CHAR(7) NULL,
+  ```
+- **PATTERN**: `src/MooBank.Database/dbo/Tables/Tag.sql:6` (`[Colour] CHAR(7) NULL`).
+- **GOTCHA**: This is a Database Project (DACPAC). Do NOT create an EF migration. The column must be NULLable (no default) because existing groups have no colour. Keep the existing column order; just add the new line before the `CONSTRAINT` block.
+- **VALIDATE**: `dotnet build src/MooBank.Database/MooBank.Database.sqlproj` (or build via `MooBank.slnx`).
+
+### Task 2: UPDATE `src/MooBank.Domain/Entities/Group/Group.cs`
+
+- **IMPLEMENT**: Add `public HexColour? Colour { get; set; }` to the `Group` class (e.g. after `ShowPosition`).
+- **PATTERN**: `src/MooBank.Domain/Entities/Tag/Tag.cs:22`.
+- **IMPORTS**: Add `using Asm.Drawing;` at the top of the file (the namespace for `HexColour`).
+- **GOTCHA**: `HexColour` is a value type/struct in `Asm.Drawing` — use the nullable `HexColour?`.
+- **VALIDATE**: `dotnet build src/MooBank.Domain/MooBank.Domain.csproj`.
+
+### Task 3: CREATE `src/MooBank.Infrastructure/EntityConfigurations/Group.cs`
+
+- **IMPLEMENT**: New `IEntityTypeConfiguration<Group>` that maps `Colour` via the converter:
+  ```csharp
+  using Asm.MooBank.Domain.Entities.Group;
+  using Asm.MooBank.Infrastructure.ValueConverters;
+
+  namespace Asm.MooBank.Infrastructure.EntityConfigurations;
+
+  internal class GroupConfiguration : IEntityTypeConfiguration<Group>
+  {
+      public void Configure(EntityTypeBuilder<Group> entity)
+      {
+          entity.Property(e => e.Colour)
+              .HasConversion<HexColourConverter>()
+              .HasColumnType("char(7)")
+              .HasMaxLength(7);
+      }
+  }
+  ```
+- **PATTERN**: `src/MooBank.Infrastructure/EntityConfigurations/Tag.cs:6-33` (use only the `Colour` mapping portion).
+- **GOTCHA**: Confirm `MooBankContext` applies configurations from the assembly (look for `ApplyConfigurationsFromAssembly` in `MooBankContext.cs`). If it does, this file is auto-discovered. If configurations are registered individually, register `GroupConfiguration` the same way the others are. **Verify before assuming.** Also confirm there isn't already inline configuration for `Group` in `MooBankContext.cs` (entity currently uses data annotations `[AggregateRoot]`, `[PrimaryKey]` only — no `Colour` config exists yet).
+- **VALIDATE**: `dotnet build src/MooBank.Infrastructure/MooBankInfrastructure.csproj` (or whole solution).
+
+### Task 4: UPDATE `src/MooBank.Modules.Groups/Models/Group.cs`
+
+- **IMPLEMENT**:
+  - Add `public HexColour? Colour { get; init; }` to the `Group` record.
+  - In `ToModel`, add `Colour = entity.Colour,`.
+- **PATTERN**: `src/MooBank.Models/Tag.cs:18` for the property; existing `ToModel` in same file (lines 13-20).
+- **IMPORTS**: Add `using Asm.Drawing;`.
+- **GOTCHA**: The model is serialised to the OpenAPI spec → frontend types. `HexColour` serialises as a JSON string at runtime but is generated as `unknown` in TS (consistent with Tag — see `types.gen.ts:351 export type HexColour = unknown`).
+- **VALIDATE**: `dotnet build src/MooBank.Modules.Groups/...csproj`.
+
+### Task 5: UPDATE `src/MooBank.Modules.Groups/Commands/Create.cs`
+
+- **IMPLEMENT**:
+  - Change the record to: `public record Create(string Name, string Description, bool ShowTotal, HexColour? Colour) : ICommand<Models.Group>;`
+  - In the handler, set `Colour = request.Colour` on the new `Group` entity.
+- **PATTERN**: existing handler body (lines 16-22).
+- **IMPORTS**: Add `using Asm.Drawing;`.
+- **GOTCHA**: Adding a required positional record parameter changes the constructor; the frontend `useCreateGroup` currently sends `{ name, description, showTotal }` (see `useCreateGroup.ts:17`) — colour will arrive as `undefined`/null which is fine for a nullable param. Confirm no other callers construct `Create` directly.
+- **VALIDATE**: `dotnet build` of the Groups module.
+
+### Task 6: UPDATE `src/MooBank.Modules.Groups/Commands/Update.cs`
+
+- **IMPLEMENT**: In `UpdateHandler.Handle`, after the existing property copies (lines 18-20) add:
+  ```csharp
+  entity.Colour = request.Group.Colour;
+  ```
+- **PATTERN**: lines 18-20 (entity.Name/Description/ShowPosition assignment).
+- **VALIDATE**: `dotnet build` of the Groups module.
+
+### Task 7: UPDATE `src/MooBank.Modules.Groups/Commands/Validators.cs` (optional but recommended)
+
+- **IMPLEMENT**: Since `HexColour` is a typed value object that throws on invalid input during binding, explicit string-format validation is largely unnecessary. If `HexColour` binds nullable safely, you may skip. Otherwise add no rule (leave colour unvalidated) to avoid over-engineering.
+- **PATTERN**: `GroupValidator` (lines 27-39).
+- **GOTCHA**: Do NOT add a `MaximumLength`/regex rule against a `HexColour?` property — it's not a string. Skip validation here unless a clear need arises.
+- **VALIDATE**: `dotnet build`.
+
+### Task 8: UPDATE `src/MooBank.Modules.Instruments/Models/Instruments/InstrumentsList.cs` AND `Queries/Instruments/GetFormatted.cs`
+
+- **IMPLEMENT**:
+  - In `InstrumentsList.cs`, add `public HexColour? Colour { get; init; }` to the `[DisplayName("InstrumentGroup")] record Group` (after `Name`, around line 19). Add `using Asm.Drawing;`.
+  - In `GetFormatted.cs`, in the `new Group { ... }` projection (lines 47-55), add `Colour = ag.Colour,`. `ag` is the `Domain.Entities.Group.Group`, which now has `Colour`.
+- **PATTERN**: existing projection at `GetFormatted.cs:47-55`.
+- **GOTCHA**: The "Other Accounts" pseudo-group (lines 57-67) has no backing entity (`Id = null`) — leave its `Colour` unset (null). Confirm `ag.Colour` is reachable: `GetGroup(userId)` returns the domain `Group` (see `Instrument.cs:52-53`), and `allGroups` is built from those, so `ag` carries the colour. Ensure the `LogicalAccount`/`StockHolding`/`Asset` group loading actually eager-loads the Group entity (it already does for Name/ShowPosition, so Colour comes along automatically).
+- **VALIDATE**: `dotnet build src/MooBank.Modules.Instruments/...csproj`.
+
+### Task 9: Regenerate / update frontend API types
+
+- **IMPLEMENT**: After backend builds (which regenerates `openapi-v1.json` at build time), run the frontend type generation:
+  ```bash
+  cd src/MooBank.Web.App && npm run generate
+  ```
+  This updates `src/api/types.gen.ts` so `Group` and `InstrumentGroup` gain `colour?: null | HexColour`.
+- **PATTERN**: existing Tag entries in `types.gen.ts:723,743,890` already show `colour?: null | HexColour`.
+- **GOTCHA**: `npm run generate` reads the freshly built OpenAPI doc (`src/MooBank.Api/openapi-v1.json`). Build the backend FIRST. If generation tooling is unavailable in the environment, hand-edit `types.gen.ts`: add `colour?: null | HexColour;` to both the `Group` and `InstrumentGroup` interfaces (HexColour type alias already exists at line 351).
+- **VALIDATE**: `cd src/MooBank.Web.App && npx tsc --noEmit` (or `npm run build`).
+
+### Task 10: UPDATE `src/MooBank.Web.App/src/routes/groups/-components/GroupForm.tsx`
+
+- **IMPLEMENT**: Add a colour `Form.Group` with BOTH a predefined-palette selector and a custom colour picker. Place it after the `showTotal` group (line 59), before the Save button. Minimal approach using react-hook-form's existing `form` + a `type="color"` input plus palette swatch buttons:
+  ```tsx
+  <Form.Group groupId="colour">
+      <Form.Label>Colour</Form.Label>
+      <div className="group-colour-picker">
+          {groupColourPalette.map((c) => (
+              <button
+                  type="button"
+                  key={c}
+                  className={`colour-swatch${form.watch("colour") === c ? " selected" : ""}`}
+                  style={{ backgroundColor: c }}
+                  aria-label={c}
+                  onClick={() => form.setValue("colour", c as any, { shouldDirty: true })}
+              />
+          ))}
+          <input
+              type="color"
+              className="form-control form-control-color"
+              value={(form.watch("colour") as string) ?? "#000000"}
+              onChange={(e) => form.setValue("colour", e.target.value as any, { shouldDirty: true })}
+          />
+      </div>
+  </Form.Group>
+  ```
+  Define the palette near the top of the file (or import from a shared util):
+  ```tsx
+  const groupColourPalette = ["#003f5c","#2f4b7c","#665191","#a05195","#d45087","#f95d6a","#ff7c43","#ffa600","#00876c","#d43d51"];
+  ```
+- **PATTERN**: colour input from `tags/-components/TagDetails.tsx:34-35`. Palette hues sourced from `src/MooBank.Web.App/src/utils/chartColours.ts:18-40` (`chartColours`) — you may import and reuse `chartColours` instead of redefining.
+- **IMPORTS**: `chartColours` from `utils/chartColours` if reusing. `Form` is already imported from `@andrewmclachlan/moo-ds`.
+- **GOTCHA**: `Group.colour` is typed `unknown` (HexColour) in generated types, so cast with `as any`/`as string` when reading/writing through react-hook-form (consistent with TagDetails). The form already spreads `data` on submit (`GroupForm.tsx:24-29`) so `colour` flows through automatically. Do NOT use Bootstrap utility classes — define `.group-colour-picker`, `.colour-swatch`, `.colour-swatch.selected` in CSS (Task 11).
+- **VALIDATE**: `cd src/MooBank.Web.App && npm run lint`.
+
+### Task 11: UPDATE `src/MooBank.Web.App/src/components/AccountList/AccountListGroup.tsx` + `src/css/components/accountlist.css`
+
+- **IMPLEMENT (component)**: Use the group colour for a left stripe and a header tint. The `SectionTable` likely forwards `style`/`className`; if `style` is not supported, wrap or apply a CSS custom property. Recommended low-risk approach — set a CSS variable on the SectionTable and let CSS draw the stripe:
+  ```tsx
+  const colourStyle = group.colour
+      ? ({ "--group-colour": group.colour as string } as React.CSSProperties)
+      : undefined;
+  // ...
+  <SectionTable
+      className={`accounts${group.colour ? " has-colour" : ""}`}
+      style={colourStyle}
+      hover header={headerContent} headerSize={2}
+      hidden={group.instruments.length === 0}>
+  ```
+  If `SectionTable` does NOT accept `style`/`className` passthrough, instead apply the variable/stripe to an inline `style` on the `<header>` element inside `headerContent` (header background tint) — verify the `SectionTable` prop surface in `@andrewmclachlan/moo-ds` before choosing.
+- **IMPLEMENT (CSS)** — add to `accountlist.css` inside/after the `table.accounts` block:
+  ```css
+  .section-table.accounts.has-colour {
+      border-left: 4px solid var(--group-colour);
+  }
+
+  .section-table.accounts.has-colour > header {
+      background-color: color-mix(in srgb, var(--group-colour) 12%, transparent);
+      border-left: 4px solid var(--group-colour);
+  }
+  ```
+  (Adjust selector to match the actual rendered DOM/class names produced by `SectionTable` — inspect at runtime or check moo-ds.)
+- **PATTERN**: existing `table.accounts` rules (`accountlist.css:109-198`); `color-mix` is already used in this file (lines 4, 196).
+- **GOTCHA**: `group.colour` is `unknown` (HexColour) — cast `as string`. The "Other Accounts" group has no colour (null) → the `has-colour` class is omitted and no stripe renders. Do NOT hard-code colours; drive everything from the `--group-colour` custom property. Confirm the exact class/element `SectionTable` renders (it may be `section.section-table` or similar) so the CSS selector matches.
+- **VALIDATE**: `cd src/MooBank.Web.App && npm run build` then visually confirm.
+
+### Task 12: UPDATE `src/MooBank.Web.App/src/models/groups.ts`
+
+- **IMPLEMENT**: Leave `emptyGroup` without a colour (colour is optional/nullable) — no change strictly required. If you want a default, add `colour: undefined`. Prefer leaving it absent to avoid forcing a colour on new groups.
+- **PATTERN**: existing `emptyGroup` (lines 4-8).
+- **VALIDATE**: `npm run build`.
+
+### Task 13: UPDATE test factories + add round-trip tests
+
+- **IMPLEMENT**:
+  - `tests/MooBank.Modules.Groups.Tests/Support/TestEntities.cs`: add a `HexColour? colour = null` parameter to `CreateGroup` and `CreateGroupModel`, and set `Colour = colour` in both. Add `using Asm.Drawing;`.
+  - `tests/MooBank.Modules.Groups.Tests/Commands/UpdateTests.cs`: add a test (or extend an existing one) asserting `entity.Colour` is updated to the model's colour after `Handle`.
+  - `tests/MooBank.Modules.Groups.Tests/Commands/CreateTests.cs`: add an assertion that the created entity/result carries the supplied colour.
+- **PATTERN**: `UpdateTests.cs:47-73` (`Handle_ValidCommand_ModifiesEntityProperties`).
+- **GOTCHA**: `HexColour` construction from a hex string is `new HexColour("#ff0000")`. Confirm the constructor signature against `Asm.Drawing` (the converter uses `new HexColour(v)` where `v` is the hex string — see `HexColourConverter.cs:10`).
+- **VALIDATE**: `dotnet test tests/MooBank.Modules.Groups.Tests --filter "Category=Unit"`.
+
+### Task 14: Full validation
+
+- **VALIDATE**: Run all Level 1–3 validation commands below.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+Mirror existing Groups handler tests (xUnit, Moq, Gherkin XML doc comments per `.claude/rules/testing/backend.md`):
+- `Create` handler persists `Colour` onto the new entity.
+- `Update` handler copies `Colour` from model to entity.
+- Round-trip: a `HexColour` set on the entity maps through `ToModel` to the model's `Colour`.
+
+### Integration Tests
+
+No new authorization surface — colour is set on an already-authorized Group via the existing `Update`/`Create` endpoints (already guarded by `Policies.GetGroupOwnerPolicy("id")`). No new integration tests required.
+
+### Edge Cases
+
+- Group with NULL colour (legacy data) → frontend renders no stripe, header untinted; account list "Other Accounts" group (Id null) has no colour.
+- Custom colour outside the predefined palette → still accepted (free-form picker).
+- Empty-string colour from the picker → ensure it maps to NULL (the converter already treats empty as null: `HexColourConverter.cs:10`). On the frontend, avoid sending `""`; send `undefined`/omit if cleared.
+- Dark/light theme → use `color-mix` with `transparent` so the tint adapts.
+
+---
+
+## Validation Commands
+
+### Level 1: Build
+
+```bash
+dotnet build MooBank.slnx
+cd src/MooBank.Web.App && npm run build
+```
+
+### Level 2: Tests
+
+```bash
+dotnet test tests/
+cd src/MooBank.Web.App && npm test
+```
+
+### Level 3: Lint
+
+```bash
+cd src/MooBank.Web.App && npm run lint
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] A colour can be assigned to a group via the Group form, choosing from a predefined palette OR a custom colour picker.
+- [ ] The chosen colour persists to the database (`Group.Colour` CHAR(7)) and round-trips through the API.
+- [ ] The account list page visually shows the group colour (left stripe and/or tinted header).
+- [ ] Groups without a colour render normally (no stripe), including the "Other Accounts" group.
+- [ ] All validation commands pass with zero errors and zero warnings.
+- [ ] Unit tests cover Create/Update colour persistence.
+- [ ] Code follows CQRS/DDD/module conventions; no Bootstrap utility classes in new CSS.
+
+---
+
+## Notes
+
+- **Strongest precedent**: The Tag feature already implements hex colour storage with `HexColour` + `HexColourConverter` + `CHAR(7)`. Reuse it verbatim — do not invent a new colour representation.
+- **Two surfaces consume Group**: (1) the Groups module model (`Modules.Groups/Models/Group.cs`) used by the Groups management pages, and (2) the Instruments `InstrumentGroup` model (`Modules.Instruments/.../InstrumentsList.cs`) used by the account list/dashboard. BOTH must expose `Colour`, but only the account-list one needs it for the visual stripe. Both flow from the same domain `Group.Colour`.
+- **`HexColour` serialisation**: serialises to a JSON string but the OpenAPI generator emits `type HexColour = unknown` in TS. Follow the Tag precedent and cast `as string` in the frontend.
+- **No EF migrations**: schema lives in the Database Project. Add the column to `Group.sql` only.
+- **EF config discovery**: Verify how `MooBankContext` registers entity configurations before assuming `GroupConfiguration` is auto-applied (look for `ApplyConfigurationsFromAssembly`). This is the single most likely silent-failure point — if the config isn't applied, EF will try to map `HexColour` directly and fail or store it incorrectly.
+- **`SectionTable` prop surface**: Confirm whether `SectionTable` (moo-ds) forwards `style`/`className` to the root element before finalising the stripe approach. If not, apply the colour to the inner `<header>` element instead.
+- **Design decision (header vs stripe)**: The issue offers both options. This plan implements the left vertical stripe as the primary visual plus a subtle header tint — cheap, theme-safe via `color-mix`, and non-intrusive. Drop the header tint if it looks busy.

--- a/src/MooBank.Api/openapi-v1.json
+++ b/src/MooBank.Api/openapi-v1.json
@@ -6012,7 +6012,8 @@
           },
           "showTotal": {
             "type": "boolean"
-          }
+          },
+          "colour": { }
         }
       },
       "CreateInstitution": {
@@ -6573,6 +6574,16 @@
           },
           "showTotal": {
             "type": "boolean"
+          },
+          "colour": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HexColour"
+              }
+            ]
           }
         }
       },
@@ -7065,6 +7076,16 @@
           },
           "name": {
             "type": "string"
+          },
+          "colour": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/HexColour"
+              }
+            ]
           },
           "instruments": {
             "type": "array",

--- a/src/MooBank.Database/dbo/Tables/Group.sql
+++ b/src/MooBank.Database/dbo/Tables/Group.sql
@@ -4,6 +4,7 @@ CREATE TABLE [Group] (
     [Description] NVARCHAR(4000) NOT NULL,
     [OwnerId] UNIQUEIDENTIFIER NOT NULL,
     [ShowPosition] BIT NOT NULL,
+    [Colour] CHAR(7) NULL,
 
     CONSTRAINT PK_Group PRIMARY KEY CLUSTERED (Id),
     CONSTRAINT FK_Group_AccountHolder FOREIGN KEY ([OwnerId]) REFERENCES [dbo].[User]([Id])

--- a/src/MooBank.Domain/Entities/Group/Group.cs
+++ b/src/MooBank.Domain/Entities/Group/Group.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
+using Asm.Drawing;
 using Microsoft.EntityFrameworkCore;
 
 namespace Asm.MooBank.Domain.Entities.Group;
@@ -18,6 +19,8 @@ public class Group([DisallowNull] Guid id) : KeyedEntity<Guid>(id)
     public Guid OwnerId { get; set; }
 
     public bool ShowPosition { get; set; }
+
+    public HexColour? Colour { get; set; }
 
     public virtual User.User Owner { get; set; } = null!;
 

--- a/src/MooBank.Infrastructure/EntityConfigurations/Group.cs
+++ b/src/MooBank.Infrastructure/EntityConfigurations/Group.cs
@@ -1,0 +1,15 @@
+using Asm.MooBank.Infrastructure.ValueConverters;
+
+namespace Asm.MooBank.Infrastructure.EntityConfigurations;
+
+internal class GroupConfiguration : IEntityTypeConfiguration<Domain.Entities.Group.Group>
+{
+    public void Configure(EntityTypeBuilder<Domain.Entities.Group.Group> entity)
+    {
+        // Configure HexColour conversion using dedicated converter
+        entity.Property(e => e.Colour)
+            .HasConversion<HexColourConverter>()
+            .HasColumnType("char(7)")
+            .HasMaxLength(7);
+    }
+}

--- a/src/MooBank.Modules.Groups/Commands/Create.cs
+++ b/src/MooBank.Modules.Groups/Commands/Create.cs
@@ -1,11 +1,12 @@
 ﻿using System.ComponentModel;
+using Asm.Drawing;
 using Asm.MooBank.Domain.Entities.Group;
 using Asm.MooBank.Modules.Groups.Models;
 
 namespace Asm.MooBank.Modules.Groups.Commands;
 
 [DisplayName("CreateGroup")]
-public record Create(string Name, string Description, bool ShowTotal) : ICommand<Models.Group>;
+public record Create(string Name, string Description, bool ShowTotal, HexColour? Colour = null) : ICommand<Models.Group>;
 
 internal class CreateHandler(IGroupRepository groupRepository, IUnitOfWork unitOfWork, MooBank.Models.User user) : ICommandHandler<Create, Models.Group>
 {
@@ -18,6 +19,7 @@ internal class CreateHandler(IGroupRepository groupRepository, IUnitOfWork unitO
             Name = request.Name,
             Description = request.Description,
             ShowPosition = request.ShowTotal,
+            Colour = request.Colour,
             OwnerId = user.Id
         };
 

--- a/src/MooBank.Modules.Groups/Commands/Update.cs
+++ b/src/MooBank.Modules.Groups/Commands/Update.cs
@@ -18,6 +18,7 @@ internal class UpdateHandler(IGroupRepository groupRepository, IUnitOfWork unitO
         entity.Name = request.Group.Name;
         entity.Description = request.Group.Description;
         entity.ShowPosition = request.Group.ShowTotal;
+        entity.Colour = request.Group.Colour;
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/src/MooBank.Modules.Groups/Models/Group.cs
+++ b/src/MooBank.Modules.Groups/Models/Group.cs
@@ -1,4 +1,6 @@
-﻿namespace Asm.MooBank.Modules.Groups.Models;
+﻿using Asm.Drawing;
+
+namespace Asm.MooBank.Modules.Groups.Models;
 
 public record Group
 {
@@ -6,6 +8,7 @@ public record Group
     public required string Name { get; init; }
     public string? Description { get; init; }
     public required bool ShowTotal { get; init; }
+    public HexColour? Colour { get; init; }
 }
 
 public static class GroupExtensions
@@ -17,6 +20,7 @@ public static class GroupExtensions
             Name = entity.Name,
             Description = entity.Description,
             ShowTotal = entity.ShowPosition,
+            Colour = entity.Colour,
         };
 
 

--- a/src/MooBank.Modules.Instruments/Models/Instruments/InstrumentsList.cs
+++ b/src/MooBank.Modules.Instruments/Models/Instruments/InstrumentsList.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Asm.Drawing;
 using Asm.MooBank.Models;
 
 namespace Asm.MooBank.Modules.Instruments.Models.Instruments;
@@ -17,6 +18,8 @@ public record Group
     public Guid? Id { get; init; }
 
     public required string Name { get; init; }
+
+    public HexColour? Colour { get; init; }
 
     public required IEnumerable<Instrument> Instruments { get; init; }
 

--- a/src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs
+++ b/src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs
@@ -48,6 +48,7 @@ internal class GetFormattedHandler(IQueryable<Domain.Entities.Account.LogicalAcc
             {
                 Id = ag!.Id,
                 Name = ag!.Name,
+                Colour = ag.Colour,
                 Instruments = matchingAccounts,
                 ShowTotal = ag.ShowPosition,
                 Total = matchingAccounts.Sum(a => a.CurrentBalanceLocalCurrency),

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9,16 +9,15 @@
       "version": "2025.4.0",
       "license": "MIT",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.1.160",
-        "@andrewmclachlan/moo-ds": "^5.1.160",
-        "@andrewmclachlan/moo-icons": "^5.1.160",
+        "@andrewmclachlan/moo-app": "^5.1.174",
+        "@andrewmclachlan/moo-ds": "^5.1.174",
+        "@andrewmclachlan/moo-icons": "^5.1.174",
         "@azure/msal-react": "^5.4.2",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",
         "@fortawesome/free-solid-svg-icons": "^7.2.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
         "@microsoft/applicationinsights-react-js": "^19.4.0",
         "@reduxjs/toolkit": "^2.12.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.61.0",
         "@tanstack/react-query": "^5.101.0",
         "@tanstack/react-router": "^1.169.1",
         "bootstrap": "^5.3.7",
@@ -78,43 +77,44 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.1.160",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.1.160/9784e4615acbeddd12a906a7b559e7ed13981bd4",
-      "integrity": "sha512-kVf4S2MooaJGLyCTPDoXBTnVd1FF/thjq3vPC63BXQht1mHRPPasF7UwQUi4coz01+e7ajj0043eVnrDo7jmbw==",
+      "version": "5.1.174",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.1.174/480af45b28cfa10f558a0a363947d67a63b0f0dd",
+      "integrity": "sha512-6M9WZA5a9XT7WM/p1eVryluQGL1AHRbsfMn/IZxNhXQi8gBzdJXR7Zv4XFMOV/lRjN2M7CeHS+z1Y+qY5ejdbA==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^5.10.1",
+        "@azure/msal-browser": "^5.11.0",
         "axios": "^1.16.1",
         "classnames": "^2.5.1",
-        "date-fns": "^4.1.0",
-        "react-error-boundary": "^6.1.1",
+        "date-fns": "^4.4.0",
+        "react-error-boundary": "^6.1.2",
         "react-toastify": "^11.1.0",
         "use-debounce": "^10.1.1"
       },
       "peerDependencies": {
         "@andrewmclachlan/moo-ds": ">=4.0.0",
-        "@azure/msal-react": "^5.4.1",
+        "@azure/msal-react": "^5.4.2",
         "@fortawesome/fontawesome-svg-core": ">=6.6.0",
         "@fortawesome/free-regular-svg-icons": ">=6.6.0",
         "@fortawesome/free-solid-svg-icons": ">=6.6.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
-        "@tanstack/react-query": "^5.100.10",
+        "@tanstack/react-query": "^5.100.14",
         "@tanstack/react-router": "^1.168.10",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-hook-form": "^7.76.0"
+        "react-hook-form": "^7.77.0"
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.1.160",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.1.160/f0496c856c3db7893826e1802a2bd59f222a6b79",
-      "integrity": "sha512-Sjp8omFbZda8Qjxk7w9d3CSR5azQ+AUHBqr5ZyKU+MN/klaoqxKjCYxAv0LBsO3azcwUndkM4Bt+3v+e1o4xLA==",
+      "version": "5.1.174",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.1.174/ecf10c1e60e4fe3e393e413d13007012beb3ec7c",
+      "integrity": "sha512-bkVs3lBG6qRE5aDNh+neqw0piuaVCwqz5Ak9bgB6NvlVkWcxWoVYlpSSg6sdnXm8zgou5xFaGh+YsnnPTDDNrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
         "classnames": "^2.5.1",
-        "date-fns": "^4.1.0",
-        "react-error-boundary": "^6.1.1",
+        "date-fns": "^4.4.0",
+        "react-error-boundary": "^6.1.2",
         "react-toastify": "^11.1.0",
         "use-debounce": "^10.1.1"
       },
@@ -125,13 +125,13 @@
         "@fortawesome/react-fontawesome": "^3.3.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-hook-form": "^7.76.0"
+        "react-hook-form": "^7.77.0"
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.1.160",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.1.160/6abf3a112a6feb71fb3882437fb2c9ea14ed8a27",
-      "integrity": "sha512-iVx5XY5oCp2MDRRxeWvV+YtC1dxy2QultnWjp9fgyccnDhcRD3MiOEp/9olwZz28eiIffyuIwS2b1EHSabY4EA==",
+      "version": "5.1.174",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.1.174/0b742dbd05f2090c47d4ef0b40ecd48accb7e1c8",
+      "integrity": "sha512-RkDh2veJ13KF4NrqfaPaqn1zgCVUBQmXiPbyAYhNNyYjM+o72tJpNXGpG7VWQRwz3DTQ4yD2DW445R0c/BqEbg==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.6",
@@ -143,6 +143,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
       "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@azure/msal-common": "16.6.2"
       },
@@ -164,6 +165,7 @@
       "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.4.2.tgz",
       "integrity": "sha512-UK4xVqwhdi0qKebb76Z9oI6lLnNPmpcSdoBcBBnLao4+GXPJNA1HP2Tj5mWQSwd0EPTBCcV4msNiepPdxLk+ng==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -196,6 +198,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -399,7 +402,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -444,29 +446,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1120,6 +1099,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.2.0.tgz",
       "integrity": "sha512-6639htZMjEkwskf3J+e6/iar+4cTNM9qhoWuRfj9F3eJD6r7iCzV1SWnQr2Mdv0QT0suuqU8BoJCZUyCtP9R4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.2.0"
       },
@@ -1145,6 +1125,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
       "integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
       "license": "(CC-BY-4.0 AND MIT)",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.2.0"
       },
@@ -1157,6 +1138,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
       "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -1408,7 +1390,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -2096,6 +2077,7 @@
       "version": "8.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -2196,6 +2178,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
       "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.101.0"
       },
@@ -2212,6 +2195,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.170.11.tgz",
       "integrity": "sha512-gP2vzdyaI8Ow/Uz/MRPfK2wN09YwRI0Y/oF74Wuy9R3KmjbfJv2tLrkM+Onu1xWklSn3ugZarMPJXRE0kzrJTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/history": "1.162.0",
         "@tanstack/react-store": "^0.9.3",
@@ -2485,7 +2469,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2496,7 +2479,6 @@
       "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -2537,6 +2519,7 @@
       "version": "19.2.13",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2584,7 +2567,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -2594,29 +2576,25 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2627,15 +2605,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2648,7 +2624,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -2658,7 +2633,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -2667,15 +2641,13 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2692,7 +2664,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -2706,7 +2677,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -2719,7 +2689,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -2734,7 +2703,6 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -2744,21 +2712,20 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2771,7 +2738,6 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -2811,6 +2777,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2827,7 +2794,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -2845,7 +2811,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2861,8 +2826,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -3049,6 +3013,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3067,8 +3032,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -3228,6 +3192,7 @@
     "node_modules/chart.js": {
       "version": "4.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3277,7 +3242,6 @@
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3780,7 +3744,6 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
       "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.0"
@@ -3794,7 +3757,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -3843,8 +3805,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3880,6 +3841,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3928,6 +3890,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3983,7 +3946,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -4192,7 +4154,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -4217,7 +4178,6 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -4270,8 +4230,7 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.16.0",
@@ -4604,8 +4563,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/global-modules": {
       "version": "2.0.0",
@@ -4963,7 +4921,6 @@
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -4977,7 +4934,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5352,7 +5309,6 @@
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
       "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -5444,8 +5400,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5526,8 +5481,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -5922,6 +5876,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5990,6 +5945,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5998,7 +5954,9 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "6.1.1",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.1.2.tgz",
+      "integrity": "sha512-3DpCr5HVdZ0caUjYE/kIHBEJN0mNP3ZCgf16c48uJ5TbWjorKVp+YG8W3XqlJ7vJAVNw6wNIImyPXmFydwmyng==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
@@ -6013,6 +5971,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6029,6 +5988,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6082,14 +6042,14 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6129,6 +6089,7 @@
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -6316,6 +6277,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -6399,7 +6361,6 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -6410,7 +6371,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6488,7 +6448,6 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6550,7 +6509,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -6569,7 +6527,6 @@
       "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.17.tgz",
       "integrity": "sha512-YR7PtUp6GMU91BgSJmlaX/rS2lGDbAF7D+Wtq7hRO+MiljNmodYvqslzCFiYVAgW+Qoaaia/QUIP4lGXufjdZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -6620,7 +6577,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -6632,15 +6588,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -6659,8 +6613,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -6705,6 +6658,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6728,7 +6682,8 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6746,6 +6701,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6868,6 +6824,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6973,7 +6930,6 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
       "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -7036,7 +6992,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
       "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -7070,7 +7025,6 @@
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -7082,15 +7036,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -7110,7 +7062,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -44,11 +44,14 @@
         "workbox-strategies": "^7.0.0"
       },
       "devDependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^10.0.1",
         "@hey-api/openapi-ts": "^0.98.1",
         "@svgr/plugin-svgo": "^8.1.0",
         "@tanstack/router-plugin": "^1.168.14",
+        "@tybys/wasm-util": "0.10.2",
         "@types/chartjs-plugin-trendline": "^1.0.1",
         "@types/md5": "^2.3.6",
         "@types/node": "^25.2.2",
@@ -448,13 +451,35 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2446,7 +2471,6 @@
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -14,9 +14,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.1.160",
-    "@andrewmclachlan/moo-ds": "^5.1.160",
-    "@andrewmclachlan/moo-icons": "^5.1.160",
+    "@andrewmclachlan/moo-app": "^5.1.174",
+    "@andrewmclachlan/moo-ds": "^5.1.174",
+    "@andrewmclachlan/moo-icons": "^5.1.174",
     "@azure/msal-react": "^5.4.2",
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
     "@fortawesome/free-solid-svg-icons": "^7.2.0",

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -60,11 +60,14 @@
     "eslint": "$eslint"
   },
   "devDependencies": {
+    "@emnapi/core": "1.10.0",
+    "@emnapi/runtime": "1.10.0",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
     "@hey-api/openapi-ts": "^0.98.1",
     "@svgr/plugin-svgo": "^8.1.0",
     "@tanstack/router-plugin": "^1.168.14",
+    "@tybys/wasm-util": "0.10.2",
     "@types/chartjs-plugin-trendline": "^1.0.1",
     "@types/md5": "^2.3.6",
     "@types/node": "^25.2.2",

--- a/src/MooBank.Web.App/src/api/types.gen.ts
+++ b/src/MooBank.Web.App/src/api/types.gen.ts
@@ -214,6 +214,7 @@ export type CreateGroup = {
     name: string;
     description: string;
     showTotal: boolean;
+    colour?: unknown;
 };
 
 export type CreateInstitution = {
@@ -346,6 +347,7 @@ export type Group = {
     name: string;
     description?: null | string;
     showTotal: boolean;
+    colour?: null | HexColour;
 };
 
 export type HexColour = unknown;
@@ -455,6 +457,7 @@ export type Instrument = {
 export type InstrumentGroup = {
     id?: null | string;
     name: string;
+    colour?: null | HexColour;
     instruments: Array<Instrument>;
     showTotal: boolean;
     total?: null | number;

--- a/src/MooBank.Web.App/src/components/AccountList/AccountListGroup.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/AccountListGroup.tsx
@@ -22,8 +22,12 @@ export const AccountListGroup: React.FC<AccountListGroupProps> = ({ group, isLoa
         }
     };
 
+    const colourStyle = group.colour
+        ? ({ "--group-colour": group.colour as string } as React.CSSProperties)
+        : undefined;
+
     const headerContent = (
-        <header>
+        <header className={group.colour ? "has-colour" : undefined} style={colourStyle}>
             <h3>{group?.name}</h3>
             {group.id && (
                 <Icon 
@@ -38,7 +42,7 @@ export const AccountListGroup: React.FC<AccountListGroupProps> = ({ group, isLoa
     );
 
     return (
-        <SectionTable className="accounts" hover header={headerContent} headerSize={2} hidden={group.instruments.length === 0}>
+        <SectionTable className={`accounts${group.colour ? " has-colour" : ""}`} style={colourStyle} hover header={headerContent} headerSize={2} hidden={group.instruments.length === 0}>
             <thead>
                 <tr>
                     <th className="expander d-none d-sm-table-cell"></th>

--- a/src/MooBank.Web.App/src/components/ColourPicker.tsx
+++ b/src/MooBank.Web.App/src/components/ColourPicker.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export const ColourPicker: React.FC<ColourPickerProps> = ({ id, value, onChange, disabled }) => (
+    <div className="colour-picker">
+        <button
+            type="button"
+            className={`no-colour${!value ? " selected" : ""}`}
+            aria-pressed={!value}
+            aria-label="No colour"
+            title="No colour"
+            disabled={disabled}
+            onClick={() => onChange(null)}
+        />
+        <input
+            id={id}
+            type="color"
+            className="form-control form-control-color"
+            aria-label="Custom colour"
+            title="Custom colour"
+            disabled={disabled}
+            value={value ?? "#000000"}
+            onChange={(e) => onChange(e.target.value)}
+        />
+    </div>
+);
+
+export interface ColourPickerProps {
+    id?: string;
+    value?: string | null;
+    onChange: (colour: string | null) => void;
+    disabled?: boolean;
+}

--- a/src/MooBank.Web.App/src/components/index.ts
+++ b/src/MooBank.Web.App/src/components/index.ts
@@ -4,6 +4,7 @@ export * from "./AccountProvider";
 export * from "./AccountSummary";
 export * from "./AccountTypeBadge";
 export * from "./Amount";
+export * from "./ColourPicker";
 export * from "./CurrencyInput";
 export * from "./CurrencySelector";
 export * from "./InstitutionSelector";

--- a/src/MooBank.Web.App/src/css/components.css
+++ b/src/MooBank.Web.App/src/css/components.css
@@ -1,5 +1,6 @@
 @import "components/accountlist.css";
 @import "components/amount.css";
+@import "components/colourpicker.css";
 @import "components/import.css";
 @import "components/summary.css";
 @import "components/monthselector.css";

--- a/src/MooBank.Web.App/src/css/components/accountlist.css
+++ b/src/MooBank.Web.App/src/css/components/accountlist.css
@@ -195,4 +195,13 @@ table.accounts {
     tbody tr.virtual:has(+ tr.virtual.total) > td {
         border-bottom-color: color-mix(in srgb, var(--border-colour) 80%, light-dark(#000, #fff));
     }
+
+    &.has-colour {
+        border-left: 4px solid var(--group-colour);
+    }
+}
+
+.section-table > header.has-colour {
+    background-color: color-mix(in srgb, var(--group-colour) 12%, transparent);
+    border-left: 4px solid var(--group-colour);
 }

--- a/src/MooBank.Web.App/src/css/components/colourpicker.css
+++ b/src/MooBank.Web.App/src/css/components/colourpicker.css
@@ -1,0 +1,25 @@
+.colour-picker {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .no-colour {
+        width: 2rem;
+        height: 2rem;
+        border: 1px solid var(--border-colour);
+        border-radius: 0.25rem;
+        padding: 0;
+        cursor: pointer;
+        background:
+            linear-gradient(to top left,
+                transparent calc(50% - 1px),
+                red calc(50% - 1px),
+                red calc(50% + 1px),
+                transparent calc(50% + 1px));
+
+        &.selected {
+            outline: 2px solid var(--body-colour);
+            outline-offset: 2px;
+        }
+    }
+}

--- a/src/MooBank.Web.App/src/css/transactions/transactionsHeader.css
+++ b/src/MooBank.Web.App/src/css/transactions/transactionsHeader.css
@@ -9,7 +9,7 @@
    Shared eyebrow label
    =========================================== */
 .eyebrow {
-    font-size: 10.5px;
+    font-size: 0.75rem;
     font-weight: 600;
     letter-spacing: 0.7px;
     text-transform: uppercase;
@@ -98,7 +98,7 @@
 
     .stat-block {
         .lbl {
-            font-size: 10.5px;
+            font-size: 0.75rem;
             font-weight: 600;
             letter-spacing: 0.5px;
             text-transform: uppercase;
@@ -165,7 +165,7 @@
     .widget .widget-value.strong { color: var(--body-colour-bold); font-size: 22px; }
 
     .widget-sub {
-        font-size: 10.5px;
+        font-size: 0.75rem;
         color: var(--body-colour-dim);
         margin-top: 2px;
     }

--- a/src/MooBank.Web.App/src/routes/bills/-components/BillFilterPanel.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/-components/BillFilterPanel.tsx
@@ -31,7 +31,7 @@ export const BillFilterPanel: React.FC<BillFilterPanelProps> = ({ accounts, filt
     };
 
     return (
-        <Section className="bill-filter-panel" header="Filter">
+        <Section className="bill-filter-panel">
             <div className="control-panel">
                 <FontAwesomeIcon
                     className="clickable"

--- a/src/MooBank.Web.App/src/routes/groups/-components/GroupForm.tsx
+++ b/src/MooBank.Web.App/src/routes/groups/-components/GroupForm.tsx
@@ -8,6 +8,7 @@ import { emptyGuid, Form, SectionForm } from "@andrewmclachlan/moo-ds";
 import type { NavItem } from "@andrewmclachlan/moo-ds";
 import { Button, } from "@andrewmclachlan/moo-ds";
 import { useForm } from "react-hook-form";
+import { ColourPicker } from "components/ColourPicker";
 
 export interface GroupFormProps {
     group?: Group
@@ -42,6 +43,9 @@ export const GroupForm: React.FC<GroupFormProps> = ({ group }) => {
 
     const form = useForm<Group>({ defaultValues: group });
 
+    const colour = form.watch("colour") as string | null | undefined;
+    const setColour = (value: string | null) => form.setValue("colour", value, { shouldDirty: true });
+
     return (
         <Page title={`${verb} Group`} breadcrumbs={[{ text: "Groups", route: "/groups" }, ...breadcrumb]}>
             <SectionForm form={form} onSubmit={handleSubmit}>
@@ -56,6 +60,10 @@ export const GroupForm: React.FC<GroupFormProps> = ({ group }) => {
                 <Form.Group groupId="showTotal" className="form-check">
                     <Form.Check />
                     <Form.Label className="form-check-label">Show Total for Group</Form.Label>
+                </Form.Group>
+                <Form.Group groupId="colour">
+                    <Form.Label>Colour</Form.Label>
+                    <ColourPicker id="colour" value={colour} onChange={setColour} />
                 </Form.Group>
                 <Button type="submit" variant="primary" disabled={isPending}>Save</Button>
             </SectionForm>

--- a/src/MooBank.Web.App/src/routes/groups/-hooks/useCreateGroup.ts
+++ b/src/MooBank.Web.App/src/routes/groups/-hooks/useCreateGroup.ts
@@ -14,7 +14,7 @@ export const useCreateGroup = () => {
 
     return {
         mutateAsync: (group: Group) => {
-            mutateAsync({ body: { name: group.name, description: group.description ?? "", showTotal: group.showTotal } });
+            mutateAsync({ body: { name: group.name, description: group.description ?? "", showTotal: group.showTotal, colour: group.colour } });
         }, ...rest,
     };
 };

--- a/src/MooBank.Web.App/src/routes/tags/-components/TagDetails.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/-components/TagDetails.tsx
@@ -5,6 +5,7 @@ import { Button, Input, Modal } from "@andrewmclachlan/moo-ds";
 import { useUpdateTag } from "../-hooks/useUpdateTag";
 import { TransactionTagTransactionTagPanel } from "./TagTagPanel";
 import { onKeyLeave } from "utils/onKeyLeave";
+import { ColourPicker } from "components/ColourPicker";
 
 export const TransactionTagDetails: React.FC<TransactionTagDetailsProps> = (props) => {
 
@@ -32,7 +33,7 @@ export const TransactionTagDetails: React.FC<TransactionTagDetailsProps> = (prop
                     <label htmlFor="name">Name</label>
                     <Input id="name" placeholder="Name" type="text" value={name} onChange={(e) => setName(e.currentTarget.value)} onBlur={(e) => updateName(e.currentTarget.value)} onKeyUp={(e) => onKeyLeave(e, updateName)} />
                     <label htmlFor="colour">Colour</label>
-                    <Input id="colour" type="color" className="form-control-color" value={(tag.colour as string) ?? ""} onChange={(e) => save({ ...tag, colour: e.target.value })} />
+                    <ColourPicker id="colour" value={(tag.colour as string) ?? null} onChange={(colour) => save({ ...tag, colour })} />
                     <label htmlFor="exclude">Exclude from Reporting</label>
                     <Input.Switch id="exclude" checked={tag.settings?.excludeFromReporting} onChange={(e) => updateExcludeFromReporting(e.currentTarget.checked)} />
                     <label htmlFor="smooth">Allow Smoothing<Tooltip id="smoothing">Provides an option to average non-monthly transactions in trend reports</Tooltip></label>

--- a/tests/MooBank.Modules.Groups.Tests/Commands/CreateTests.cs
+++ b/tests/MooBank.Modules.Groups.Tests/Commands/CreateTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Asm.Drawing;
 using Asm.MooBank.Modules.Groups.Commands;
 using Asm.MooBank.Modules.Groups.Tests.Support;
 using DomainGroup = Asm.MooBank.Domain.Entities.Group.Group;
@@ -130,6 +131,69 @@ public class CreateTests
         // Assert
         Assert.NotNull(capturedGroup);
         Assert.True(capturedGroup.ShowPosition);
+    }
+
+    /// <summary>
+    /// Given a create command with a colour
+    /// When the handler is invoked
+    /// Then the created entity and returned model should carry the supplied colour
+    /// </summary>
+    [Fact]
+    public async Task Handle_CommandWithColour_SetsColour()
+    {
+        // Arrange
+        DomainGroup? capturedGroup = null;
+
+        _mocks.GroupRepositoryMock
+            .Setup(r => r.Add(It.IsAny<DomainGroup>()))
+            .Callback<DomainGroup>(g => capturedGroup = g);
+
+        var handler = new CreateHandler(
+            _mocks.GroupRepositoryMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.User);
+
+        var colour = new HexColour("#ff7c43");
+        var command = new Create("New Group", "A test group", false, colour);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(capturedGroup);
+        Assert.Equal(colour, capturedGroup.Colour);
+        Assert.Equal(colour, result.Colour);
+    }
+
+    /// <summary>
+    /// Given a create command without a colour
+    /// When the handler is invoked
+    /// Then the created entity should have no colour
+    /// </summary>
+    [Fact]
+    public async Task Handle_CommandWithoutColour_LeavesColourNull()
+    {
+        // Arrange
+        DomainGroup? capturedGroup = null;
+
+        _mocks.GroupRepositoryMock
+            .Setup(r => r.Add(It.IsAny<DomainGroup>()))
+            .Callback<DomainGroup>(g => capturedGroup = g);
+
+        var handler = new CreateHandler(
+            _mocks.GroupRepositoryMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.User);
+
+        var command = new Create("New Group", "A test group", false);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(capturedGroup);
+        Assert.Null(capturedGroup.Colour);
+        Assert.Null(result.Colour);
     }
 
     [Fact]

--- a/tests/MooBank.Modules.Groups.Tests/Commands/UpdateTests.cs
+++ b/tests/MooBank.Modules.Groups.Tests/Commands/UpdateTests.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Asm.Drawing;
 using Asm.MooBank.Modules.Groups.Commands;
 using Asm.MooBank.Modules.Groups.Tests.Support;
 using DomainGroup = Asm.MooBank.Domain.Entities.Group.Group;
@@ -70,6 +71,71 @@ public class UpdateTests
         Assert.Equal("New Name", existingGroup.Name);
         Assert.Equal("New Description", existingGroup.Description);
         Assert.True(existingGroup.ShowPosition);
+    }
+
+    /// <summary>
+    /// Given an existing group without a colour
+    /// When the handler is invoked with a model that has a colour
+    /// Then the entity's colour should be updated to the model's colour
+    /// </summary>
+    [Fact]
+    public async Task Handle_ModelWithColour_UpdatesEntityColour()
+    {
+        // Arrange
+        var groupId = Guid.NewGuid();
+        var existingGroup = TestEntities.CreateGroup(id: groupId, ownerId: _mocks.User.Id);
+
+        _mocks.GroupRepositoryMock
+            .Setup(r => r.Get(groupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingGroup);
+
+        var handler = new UpdateHandler(
+            _mocks.GroupRepositoryMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.SecurityMock.Object);
+
+        var colour = new HexColour("#2f4b7c");
+        var groupModel = TestEntities.CreateGroupModel(id: groupId, name: "New Name", colour: colour);
+        var command = new Update(groupModel);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(colour, existingGroup.Colour);
+        Assert.Equal(colour, result.Colour);
+    }
+
+    /// <summary>
+    /// Given an existing group with a colour
+    /// When the handler is invoked with a model that has no colour
+    /// Then the entity's colour should be cleared
+    /// </summary>
+    [Fact]
+    public async Task Handle_ModelWithoutColour_ClearsEntityColour()
+    {
+        // Arrange
+        var groupId = Guid.NewGuid();
+        var existingGroup = TestEntities.CreateGroup(id: groupId, ownerId: _mocks.User.Id, colour: new HexColour("#d45087"));
+
+        _mocks.GroupRepositoryMock
+            .Setup(r => r.Get(groupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingGroup);
+
+        var handler = new UpdateHandler(
+            _mocks.GroupRepositoryMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.SecurityMock.Object);
+
+        var groupModel = TestEntities.CreateGroupModel(id: groupId, name: "New Name");
+        var command = new Update(groupModel);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(existingGroup.Colour);
+        Assert.Null(result.Colour);
     }
 
     [Fact]

--- a/tests/MooBank.Modules.Groups.Tests/Support/TestEntities.cs
+++ b/tests/MooBank.Modules.Groups.Tests/Support/TestEntities.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Asm.Drawing;
 using Bogus;
 using DomainGroup = Asm.MooBank.Domain.Entities.Group.Group;
 using ModelGroup = Asm.MooBank.Modules.Groups.Models.Group;
@@ -14,7 +15,8 @@ internal static class TestEntities
         string? name = null,
         string? description = null,
         Guid? ownerId = null,
-        bool showPosition = false)
+        bool showPosition = false,
+        HexColour? colour = null)
     {
         return new DomainGroup(id ?? Guid.NewGuid())
         {
@@ -22,6 +24,7 @@ internal static class TestEntities
             Description = description ?? Faker.Lorem.Sentence(),
             OwnerId = ownerId ?? Guid.NewGuid(),
             ShowPosition = showPosition,
+            Colour = colour,
         };
     }
 
@@ -29,7 +32,8 @@ internal static class TestEntities
         Guid? id = null,
         string? name = null,
         string? description = null,
-        bool showTotal = false)
+        bool showTotal = false,
+        HexColour? colour = null)
     {
         return new ModelGroup
         {
@@ -37,6 +41,7 @@ internal static class TestEntities
             Name = name ?? Faker.Commerce.Department(),
             Description = description ?? Faker.Lorem.Sentence(),
             ShowTotal = showTotal,
+            Colour = colour,
         };
     }
 


### PR DESCRIPTION
Closes #801

## Summary
- Adds a nullable `Colour` (`CHAR(7)` hex) to `Group`, mirroring the existing Tag colour pattern (`HexColour` value object + `HexColourConverter` EF conversion, schema change in the Database Project)
- Threads colour through the Groups module (Create/Update commands, model) and the Instruments `InstrumentGroup` read model so the account list receives it
- New reusable `ColourPicker` component (custom colour picker + a 'no colour' clear option), used by both the group form and the tag editor — tags can now have their colour cleared too
- Account list renders the group colour as a left stripe on the table plus a tinted group header (theme-safe via `color-mix` and a `--group-colour` CSS variable); groups without a colour (incl. 'Other Accounts') render unchanged
- Regenerated OpenAPI spec and frontend API types

## Test plan
- [x] Full backend test suite: 1,934 passed, 0 failed (4 new colour round-trip tests for Create/Update handlers)
- [x] `dotnet build MooBank.slnx`: 0 warnings, 0 errors
- [x] Frontend `npm run build` (tsc + vite): clean
- [ ] Manual: assign / clear a colour on a group and verify the account list stripe + header tint in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)