### PR TITLE
Dashboard breakdown/top-tags drilldown + primary-account shortcut

### DIFF
--- a/db-publish.ps1
+++ b/db-publish.ps1
@@ -8,7 +8,7 @@ $profileFile = "$Environment.publish.xml"
 
 Write-Host "Building database project..."
 
-dotnet build src\MooBank.Database\MooBank.Database.sqlproj -c Release -v m
+dotnet build src\MooBank.Database\MooBank.Database.sqlproj -c Release -v m -nodeReuse:false
 
 Write-Host "Using environment: $Environment"
 Write-Host "Using publish profile: $profileFile"

--- a/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
@@ -1,18 +1,36 @@
 import { Widget } from "@andrewmclachlan/moo-ds";
+import { useNavigate } from "@tanstack/react-router";
 import { lastMonth, lastMonthName } from "utils/dateFns";
 import { Breakdown } from "../accounts/$id/reports/-components/Breakdown";
 import { useAccounts } from "hooks/useAccounts";
 import { WidgetError } from "components/WidgetError";
+import type { TagValue } from "api/types.gen";
+
+const reportType = "Debit" as const;
 
 export const BreakdownWidget: React.FC = () => {
 
     const {data: accounts, isLoading, isError } = useAccounts();
+    const navigate = useNavigate();
 
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
+    const selectedTagChanged = (clickedTag: TagValue) => {
+        // period=1 (Last Month) scopes the target page to the dashboard's period.
+        if (!clickedTag.hasChildren) {
+            const url = !clickedTag.tagId
+                ? `/accounts/${account!.id}?untagged=true&period=1`
+                : `/accounts/${account!.id}?tag=${clickedTag.tagId}&type=${reportType}&period=1`;
+            navigate({ to: url });
+            return;
+        }
+
+        navigate({ to: `/accounts/${account!.id}/reports/breakdown/${clickedTag.tagId}?period=1` });
+    };
+
     return (
         <Widget header={(account && `Breakdown - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading} to={account ? `/accounts/${account.id}/reports/breakdown?period=1` : undefined}>
-            {isError ? <WidgetError /> : account && <Breakdown accountId={account?.id} period={lastMonth} reportType={"Debit"} />}
+            {isError ? <WidgetError /> : account && <Breakdown accountId={account.id} period={lastMonth} reportType={reportType} selectedTagChanged={selectedTagChanged} />}
         </Widget>
     );
 };

--- a/src/MooBank.Web.App/src/routes/-dashboard/Dashboard.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Dashboard.tsx
@@ -18,7 +18,7 @@ export function Dashboard() {
     const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
 
     const actions = account ? [
-        <IconLinkButton key="primary-account" variant="primary" to={`/accounts/${account.id}/transactions`} icon={PiggyBank}>{account.name}</IconLinkButton>
+        <IconLinkButton badge key="primary-account" variant="primary" to={`/accounts/${account.id}/transactions`} icon={PiggyBank}>{account.name}</IconLinkButton>
     ] : [];
 
     return (

--- a/src/MooBank.Web.App/src/routes/-dashboard/Dashboard.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Dashboard.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 import { Dashboard as DashboardPage } from "@andrewmclachlan/moo-app";
-import type { DashboardProps } from "@andrewmclachlan/moo-app";
+import { IconLinkButton } from "@andrewmclachlan/moo-ds";
+import { PiggyBank } from "@andrewmclachlan/moo-icons";
+import { useAccounts } from "hooks/useAccounts";
 import { InOutWidget } from "./InOut";
 import { SummaryWidget } from "./Summary";
 import { BudgetWidget } from "./Budget";
@@ -9,13 +11,18 @@ import { TopTagsWidget } from "./TopTags";
 import { BreakdownWidget } from "./Breakdown";
 import { ForecastWidget } from "./Forecast";
 
-const props: DashboardProps = {
-    title: "Home",
-}
-
 export function Dashboard() {
+
+    const { data: accounts } = useAccounts();
+
+    const account = accounts?.find(a => a.isPrimary === true) ?? accounts?.[0];
+
+    const actions = account ? [
+        <IconLinkButton key="primary-account" variant="primary" to={`/accounts/${account.id}/transactions`} icon={PiggyBank}>{account.name}</IconLinkButton>
+    ] : [];
+
     return (
-        <DashboardPage {...props}>
+        <DashboardPage title="Home" actions={actions}>
             <InOutWidget />
             <BudgetWidget />
             <SummaryWidget />

--- a/src/MooBank.Web.App/src/routes/-dashboard/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/TopTags.tsx
@@ -12,7 +12,7 @@ export const TopTagsWidget: React.FC = () => {
 
     return (
         <Widget header={(account && `Top Tags - ${account.name} - ${lastMonthName}`) ?? lastMonthName} size="double" headerSize={2} className="report" loading={isLoading} to={account ? `/accounts/${account.id}/reports/all-tag-average?period=1` : undefined}>
-            {isError ? <WidgetError /> : account && <TopTags accountId={account?.id} period={lastMonth} reportType={"Debit"} top={10} />}
+            {isError ? <WidgetError /> : account && <TopTags accountId={account?.id} period={lastMonth} reportType={"Debit"} top={10} periodId="1" />}
         </Widget>
     );
 };

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { chartColours, desaturatedChartColours } from "utils/chartColours";
 import type { transactionTypeFilter } from "store/state";
 
-export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType, top = 20 }) => {
+export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType, top = 20, periodId }) => {
 
     const navigate = useNavigate();
     const [showGross] = useState<boolean>(false); //TODO: may make this an option
@@ -59,7 +59,8 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
             onClick: (_event, elements) => {
                 if (elements.length !== 1) return;
                 const tag = report.data!.tags[elements[0].index];
-                const url = !tag.tagId ? `/accounts/${accountId}?untagged=true` : `/accounts/${accountId}?tag=${tag.tagId}&type=${reportType}`;
+                const periodQuery = periodId ? `&period=${periodId}` : "";
+                const url = !tag.tagId ? `/accounts/${accountId}?untagged=true${periodQuery}` : `/accounts/${accountId}?tag=${tag.tagId}&type=${reportType}${periodQuery}`;
                 navigate({ to: url });
             },
         }}
@@ -72,4 +73,6 @@ export interface TopTagsProps {
     period: Period;
     reportType: transactionTypeFilter;
     top?: number;
+    /** When set, the period option id (e.g. "1" = Last Month) is appended to the transactions drilldown URL to scope it. */
+    periodId?: string;
 }


### PR DESCRIPTION
## Summary

Improves the Home dashboard drilldown experience and adds a quick shortcut to the primary account's transactions.

### Breakdown widget drilldown (bug fix)
The Breakdown widget never passed a `selectedTagChanged` callback, so clicking a chart segment did nothing. Now:
- **Leaf tag** → navigates to the filtered transactions page (`?tag=…&type=Debit`, or `?untagged=true`).
- **Tag with children** → opens the full breakdown report page scoped to that child (`…/reports/breakdown/{tagId}`).

### Period scoping
All dashboard drilldowns (breakdown → transactions, breakdown → child report, top-tags → transactions) now carry the widget's period (Last Month) via `period=1`, which `getPeriod` / `usePeriodSelector` already honour. `TopTags` gained an opt-in `periodId` prop so the shared full report page keeps its own period selection.

### Primary-account shortcut
A badge-style `IconLinkButton` in the Home breadcrumb-actions area links straight to the primary account's transactions page, saving a click. Uses the same `isPrimary`-then-first selection as the dashboard widgets.

## Testing
- `tsc --noEmit` passes clean.
- Manual testing of drilldown and shortcut on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)