### PR TITLE
fix(web): institution create posts and details view refreshes

### DIFF
--- a/src/MooBank.Web.App/src/routes/settings/institutions/-components/InstitutionForm.tsx
+++ b/src/MooBank.Web.App/src/routes/settings/institutions/-components/InstitutionForm.tsx
@@ -1,6 +1,6 @@
 import { Form, FormComboBox, SectionForm } from "@andrewmclachlan/moo-ds";
 import type { Institution } from "api/types.gen";
-import { institutionTypeOptions } from "models/institutions";
+import { emptyInstitution, institutionTypeOptions } from "models/institutions";
 import React from "react";
 import { Button } from "@andrewmclachlan/moo-ds";
 import { useForm } from "react-hook-form";
@@ -31,7 +31,7 @@ export const InstitutionForm: React.FC<InstitutionFormProps> = ({ institution = 
         navigate({ to: "/settings/institutions" });
     }
 
-    const form = useForm<Institution>({ defaultValues: institution });
+    const form = useForm<Institution>({ defaultValues: institution ?? emptyInstitution });
 
     return (
         <SectionForm form={form} onSubmit={handleSubmit}>

--- a/src/MooBank.Web.App/src/routes/settings/institutions/-components/InstitutionForm.tsx
+++ b/src/MooBank.Web.App/src/routes/settings/institutions/-components/InstitutionForm.tsx
@@ -31,7 +31,10 @@ export const InstitutionForm: React.FC<InstitutionFormProps> = ({ institution = 
         navigate({ to: "/settings/institutions" });
     }
 
-    const form = useForm<Institution>({ defaultValues: institution ?? emptyInstitution });
+    const form = useForm<Institution>({
+        values: institution ?? emptyInstitution,
+        resetOptions: { keepDirtyValues: true },
+    });
 
     return (
         <SectionForm form={form} onSubmit={handleSubmit}>

--- a/src/MooBank.Web.App/src/routes/settings/institutions/-hooks/useUpdateInstitution.ts
+++ b/src/MooBank.Web.App/src/routes/settings/institutions/-hooks/useUpdateInstitution.ts
@@ -21,7 +21,7 @@ export const useUpdateInstitution = () => {
             allInstitutions = allInstitutions.sort((t1, t2) => t1.name.localeCompare(t2.name));
             queryClient.setQueryData<Institution[]>(getAllInstitutionsQueryKey(), allInstitutions);
         },
-        onError: (_error, variables) => {
+        onSettled: (_data, _error, variables) => {
             queryClient.invalidateQueries({ queryKey: getAllInstitutionsQueryKey() });
             queryClient.invalidateQueries({ queryKey: getInstitutionQueryKey({ path: { id: variables.path.id } }) });
         }

--- a/src/MooBank.Web.App/src/routes/settings/institutions/add.tsx
+++ b/src/MooBank.Web.App/src/routes/settings/institutions/add.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { emptyInstitution } from "models/institutions";
 
 import { SettingsPage } from "../-components/SettingsPage";
 import { InstitutionForm } from "./-components/InstitutionForm";
@@ -12,7 +11,7 @@ function CreateInstitution() {
 
     return (
         <SettingsPage title="Institutions" breadcrumbs={[{ text: "Institutions", route: "/settings/institutions" }, { text: "Add", route: "/settings/institutions/add" }]}>
-            <InstitutionForm institution={emptyInstitution} />
+            <InstitutionForm />
         </SettingsPage>
     );
 }


### PR DESCRIPTION
Two bugs in institution settings:

1. **Add Institution performed a PATCH with id 0.** `add.tsx` passed `emptyInstitution` to `InstitutionForm`, whose create-vs-update check is `institution === null` — so the create path was unreachable and every add PATCHed `/institutions/0`. The add page now passes no institution and the form falls back to `emptyInstitution` for its default values, keeping the null discriminator honest.

2. **Details view stale after update.** `useInstitution` has a 7-day `staleTime`, and `useUpdateInstitution` only invalidated the single-institution query in `onError`. After a successful update the list showed the optimistic change but re-opening the details view served the cached pre-update data. Invalidation moved to `onSettled` so both the list and details queries refresh on success and error alike.

`npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)