### PR TITLE
chore: remove dead BindAsync methods

### DIFF
--- a/src/MooBank.Modules.Institutions/Commands/Update.cs
+++ b/src/MooBank.Modules.Institutions/Commands/Update.cs
@@ -3,26 +3,11 @@ using Asm.MooBank.Commands;
 using Asm.MooBank.Domain.Entities.Institution;
 using Asm.MooBank.Models;
 using Asm.MooBank.Modules.Institutions.Models;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace Asm.MooBank.Modules.Institutions.Commands;
 
 [DisplayName("UpdateInstitution")]
-public sealed record Update(int Id, string Name, InstitutionType InstitutionType, int? ImporterTypeId = null) : ICommand<Models.Institution>
-{
-    public static async Task<Update> BindAsync(HttpContext httpContext)
-    {
-        var options = httpContext.RequestServices.GetRequiredService<IOptions<JsonOptions>>();
-
-        var id = (int)httpContext.Request.RouteValues["id"]!;
-
-        var update = await System.Text.Json.JsonSerializer.DeserializeAsync<Update>(httpContext.Request.Body, options.Value.SerializerOptions, cancellationToken: httpContext.RequestAborted);
-        return update! with { Id = id };
-    }
-}
+public sealed record Update(int Id, string Name, InstitutionType InstitutionType, int? ImporterTypeId = null) : ICommand<Models.Institution>;
 
 internal class UpdateHandler(IInstitutionRepository repository, IUnitOfWork unitOfWork, ISecurity security) : ICommandHandler<Update, Models.Institution>
 {

--- a/src/MooBank.Modules.Transactions/Commands/Create.cs
+++ b/src/MooBank.Modules.Transactions/Commands/Create.cs
@@ -5,15 +5,11 @@ using Asm.MooBank.Domain.Entities.Instrument;
 using Asm.MooBank.Domain.Entities.Transactions;
 using Asm.MooBank.Modules.Transactions.Models;
 using Asm.MooBank.Modules.Transactions.Models.Extensions;
-using Microsoft.AspNetCore.Http;
 
 namespace Asm.MooBank.Modules.Transactions.Commands;
 
 [DisplayName("CreateTransaction")]
-public record Create(Guid InstrumentId, CreateTransaction Transcation) : InstrumentIdCommand(InstrumentId), ICommand<MooBank.Models.Transaction>
-{
-    public static ValueTask<Create> BindAsync(HttpContext httpContext) => BindHelper.BindWithInstrumentIdAsync<Create>(httpContext);
-}
+public record Create(Guid InstrumentId, CreateTransaction Transcation) : InstrumentIdCommand(InstrumentId), ICommand<MooBank.Models.Transaction>;
 
 internal class CreateHandler(IInstrumentRepository accountRepository, ITransactionRepository transactionRepository, IUserIdProvider userIdProvider, IAuditingUnitOfWork unitOfWork) : ICommandHandler<Create, MooBank.Models.Transaction>
 {

--- a/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
@@ -30,7 +30,7 @@ internal class TransactionsEndpoints : EndpointGroupBase
 
         builder.MapCommand<Create, Transaction>("", CommandBinding.Parameters)
             .WithNames("Create Transaction")
-            .Accepts<Create>("application/json");
+            .Accepts<Models.CreateTransaction>("application/json");
 
         builder.MapCommand<UpdateBalance, Transaction>("/balance-adjustment", CommandBinding.Parameters)
             .WithNames("Set Balance");


### PR DESCRIPTION
Follow-up to the binding-path survey. ASM's simple `Map*Command` overloads and `CommandBinding.Parameters` bind commands with `[AsParameters]`, which binds constructor parameters individually and never invokes a type-level `BindAsync(HttpContext)`. Two commands carried dead `BindAsync` methods that misdescribe the real wire contract:

- **`Transactions/Commands/Create.cs`** — the dead binder deserialised the body as `Create` (a `{ "transcation": ... }` wrapper). The endpoint actually binds `InstrumentId` from the route and `Transcation` from the body root as a `CreateTransaction`. Deleted, and `.Accepts<Create>` corrected to `.Accepts<CreateTransaction>` so the OpenAPI body schema matches reality. Note the mapping must stay `CommandBinding.Parameters` — switching to `CommandBinding.None` would change the wire contract.
- **`Institutions/Commands/Update.cs`** — the dead binder (with its `(int)` route-value cast) never ran; the endpoint binds `Id` from the route and `Name`/`InstitutionType`/`ImporterTypeId` from the **query string** (which is why `useUpdateInstitution` sends them as query parameters). Deleted; no runtime change.

The other ten `BindAsync` methods in the codebase are live (`CommandBinding.None` paths) and untouched.

Both module builds clean; Transactions (66) and Institutions (43) test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)