### PR TITLE
refactor(security): separate requirement evaluation from authorisation data

### DIFF
--- a/src/MooBank.Domain/IAuthorisationRepository.cs
+++ b/src/MooBank.Domain/IAuthorisationRepository.cs
@@ -1,0 +1,18 @@
+namespace Asm.MooBank.Domain;
+
+/// <summary>
+/// Data queries used by authorisation requirement handlers.
+/// </summary>
+/// <remarks>
+/// Implementations must not depend on the authorisation system: requirement handlers are
+/// constructed when <c>IAuthorizationService</c> is resolved, so any such dependency is circular.
+/// Authorisation decisions belong in the handlers; this repository only answers questions of fact.
+/// </remarks>
+public interface IAuthorisationRepository
+{
+    Task<bool> IsGroupOwner(Guid groupId, Guid userId, CancellationToken cancellationToken = default);
+
+    Task<Guid?> GetBudgetLineFamilyId(Guid budgetLineId, CancellationToken cancellationToken = default);
+
+    Task<IEnumerable<Guid>> GetOwnedInstrumentIds(Guid userId, CancellationToken cancellationToken = default);
+}

--- a/src/MooBank.Infrastructure/IServiceCollectionExtensions.cs
+++ b/src/MooBank.Infrastructure/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Asm.MooBank.Domain.Entities.Account;
+﻿using Asm.MooBank.Domain;
+using Asm.MooBank.Domain.Entities.Account;
 using Asm.MooBank.Domain.Entities.Asset;
 using Asm.MooBank.Domain.Entities.Budget;
 using Asm.MooBank.Domain.Entities.Family;
@@ -70,7 +71,7 @@ public static class IServiceCollectionExtensions
                 .AddScoped<IRecurringTransactionRepository, RecurringTransactionRepository>()
                 .AddScoped<IReferenceDataRepository, ReferenceDataRepository>()
                 .AddScoped<IReportRepository, ReportRepository>()
-                .AddScoped<ISecurity, SecurityRepository>()
+                .AddScoped<IAuthorisationRepository, SecurityRepository>()
                 .AddScoped<IStockHoldingRepository, StockHoldingRepository>()
                 .AddScoped<ITransactionRepository, TransactionRepository>()
                 .AddScoped<ITagRepository, TagRepository>()

--- a/src/MooBank.Infrastructure/Repositories/SecurityRepository.cs
+++ b/src/MooBank.Infrastructure/Repositories/SecurityRepository.cs
@@ -1,67 +1,15 @@
-﻿using Asm.MooBank.Audit;
-using Asm.MooBank.Domain.Entities.Group;
-using Asm.MooBank.Models;
-using Asm.MooBank.Security;
-using Asm.MooBank.Security.Authorisation;
-using Asm.Security;
-using Microsoft.AspNetCore.Authorization;
+using Asm.MooBank.Domain;
 
 namespace Asm.MooBank.Infrastructure.Repositories;
 
-public class SecurityRepository(MooBankContext mooBankContext, IAuthorizationService authorizationService, IPrincipalProvider principalProvider, User user, IAuditLogger audit) : ISecurity
+public class SecurityRepository(MooBankContext mooBankContext) : IAuthorisationRepository
 {
-    public async Task AssertGroupPermission(Guid groupId)
-    {
-        if (!await mooBankContext.Groups.AnyAsync(a => a.Id == groupId && a.OwnerId == user.Id))
-        {
-            audit.AuthorizationDenied(user, "Group", groupId, nameof(AssertGroupPermission));
-            throw new NotAuthorisedException("Not authorised to view this account group");
-        }
-    }
+    public async Task<bool> IsGroupOwner(Guid groupId, Guid userId, CancellationToken cancellationToken = default) =>
+        await mooBankContext.Groups.AnyAsync(g => g.Id == groupId && g.OwnerId == userId, cancellationToken);
 
-    public void AssertGroupPermission(Group group)
-    {
-        if (group.OwnerId != user.Id)
-        {
-            audit.AuthorizationDenied(user, "Group", group.Id, nameof(AssertGroupPermission));
-            throw new NotAuthorisedException("Not authorised to view this account group");
-        }
-    }
+    public async Task<Guid?> GetBudgetLineFamilyId(Guid budgetLineId, CancellationToken cancellationToken = default) =>
+        await mooBankContext.BudgetLines.Where(bl => bl.Id == budgetLineId).Select(bl => (Guid?)bl.Budget.FamilyId).SingleOrDefaultAsync(cancellationToken);
 
-    public async Task AssertFamilyPermission(Guid familyId)
-    {
-        var authResult = await authorizationService.AuthorizeAsync(principalProvider.Principal!, familyId, new FamilyMemberRequirement());
-
-        if (!authResult.Succeeded)
-        {
-            audit.AuthorizationDenied(user, "Family", familyId, nameof(FamilyMemberRequirement));
-            throw new NotAuthorisedException("Not authorised to view this family");
-        }
-    }
-
-    public async Task<bool> HasBudgetLinePermission(Guid id, CancellationToken cancellationToken = default)
-    {
-        var permitted = await mooBankContext.BudgetLines.AnyAsync(bl => bl.Id == id && bl.Budget.FamilyId == user.FamilyId, cancellationToken);
-
-        if (!permitted)
-        {
-            audit.AuthorizationDenied(user, "BudgetLine", id, nameof(BudgetLineRequirement));
-        }
-
-        return permitted;
-    }
-
-    public async Task<IEnumerable<Guid>> GetInstrumentIds(CancellationToken cancellationToken = default) =>
-        await mooBankContext.InstrumentOwners.Where(aah => aah.UserId == user.Id).Select(aah => aah.InstrumentId).ToListAsync(cancellationToken);
-
-    public async Task AssertAdministrator(CancellationToken cancellationToken = default)
-    {
-        var authResult = await authorizationService.AuthorizeAsync(principalProvider.Principal!, Policies.Admin);
-
-        if (!authResult.Succeeded)
-        {
-            audit.AuthorizationDenied(user, "Administrator", null, Policies.Admin);
-            throw new NotAuthorisedException("Not authorised");
-        }
-    }
+    public async Task<IEnumerable<Guid>> GetOwnedInstrumentIds(Guid userId, CancellationToken cancellationToken = default) =>
+        await mooBankContext.InstrumentOwners.Where(aah => aah.UserId == userId).Select(aah => aah.InstrumentId).ToListAsync(cancellationToken);
 }

--- a/src/MooBank.Modules.Groups/Commands/Delete.cs
+++ b/src/MooBank.Modules.Groups/Commands/Delete.cs
@@ -12,7 +12,7 @@ internal class DeleteHandler(IGroupRepository groupRepository, IUnitOfWork unitO
     {
         var group = await groupRepository.Get(request.Id, cancellationToken);
 
-        security.AssertGroupPermission(group);
+        await security.AssertGroupPermission(group);
 
         groupRepository.Delete(group);
 

--- a/src/MooBank.Modules.Groups/Commands/Update.cs
+++ b/src/MooBank.Modules.Groups/Commands/Update.cs
@@ -13,7 +13,7 @@ internal class UpdateHandler(IGroupRepository groupRepository, IUnitOfWork unitO
     {
         var entity = await groupRepository.Get(request.Group.Id, cancellationToken);
 
-        security.AssertGroupPermission(entity);
+        await security.AssertGroupPermission(entity);
 
         entity.Name = request.Group.Name;
         entity.Description = request.Group.Description;

--- a/src/MooBank.Security/Authorisation/BudgetLineAuthorisationHandler.cs
+++ b/src/MooBank.Security/Authorisation/BudgetLineAuthorisationHandler.cs
@@ -1,10 +1,24 @@
 using Asm.AspNetCore.Authorisation;
+using Asm.MooBank.Audit;
+using Asm.MooBank.Domain;
+using Asm.MooBank.Models;
 using Microsoft.AspNetCore.Http;
 
 namespace Asm.MooBank.Security.Authorisation;
 
-internal class BudgetLineAuthorisationHandler(IHttpContextAccessor httpContextAccessor, ISecurity security) : RouteParamAuthorisationHandler<BudgetLineRequirement>(httpContextAccessor)
+internal class BudgetLineAuthorisationHandler(IHttpContextAccessor httpContextAccessor, IAuthorisationRepository authorisationRepository, User user, IAuditLogger audit) : RouteParamAuthorisationHandler<BudgetLineRequirement>(httpContextAccessor)
 {
-    protected override async ValueTask<bool> IsAuthorised(object value) =>
-        Guid.TryParse(value.ToString(), out var id) && await security.HasBudgetLinePermission(id);
+    protected override async ValueTask<bool> IsAuthorised(object value)
+    {
+        if (!Guid.TryParse(value.ToString(), out var id)) return false;
+
+        var permitted = await authorisationRepository.GetBudgetLineFamilyId(id) == user.FamilyId;
+
+        if (!permitted)
+        {
+            audit.AuthorizationDenied(user, "BudgetLine", id, nameof(BudgetLineRequirement));
+        }
+
+        return permitted;
+    }
 }

--- a/src/MooBank.Security/Authorisation/BudgetLineAuthorisationHandler.cs
+++ b/src/MooBank.Security/Authorisation/BudgetLineAuthorisationHandler.cs
@@ -8,11 +8,14 @@ namespace Asm.MooBank.Security.Authorisation;
 
 internal class BudgetLineAuthorisationHandler(IHttpContextAccessor httpContextAccessor, IAuthorisationRepository authorisationRepository, User user, IAuditLogger audit) : RouteParamAuthorisationHandler<BudgetLineRequirement>(httpContextAccessor)
 {
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+
     protected override async ValueTask<bool> IsAuthorised(object value)
     {
         if (!Guid.TryParse(value.ToString(), out var id)) return false;
 
-        var permitted = await authorisationRepository.GetBudgetLineFamilyId(id) == user.FamilyId;
+        var cancellationToken = _httpContextAccessor.HttpContext?.RequestAborted ?? CancellationToken.None;
+        var permitted = await authorisationRepository.GetBudgetLineFamilyId(id, cancellationToken) == user.FamilyId;
 
         if (!permitted)
         {

--- a/src/MooBank.Security/Authorisation/GroupOwnerAuthorisationHandler.cs
+++ b/src/MooBank.Security/Authorisation/GroupOwnerAuthorisationHandler.cs
@@ -1,11 +1,9 @@
-﻿using Asm.AspNetCore.Authorisation;
 using Asm.MooBank.Models;
 using Microsoft.AspNetCore.Http;
 
 namespace Asm.MooBank.Security.Authorisation;
 
-internal class GroupOwnerAuthorisationHandler(IHttpContextAccessor httpContextAccessor, User user) : RouteParamAuthorisationHandler<GroupOwnerRequirement>(httpContextAccessor)
+internal class GroupOwnerAuthorisationHandler(IHttpContextAccessor httpContextAccessor, User user) : InstrumentRouteAuthorisationHandler<GroupOwnerRequirement>(httpContextAccessor)
 {
-    protected override ValueTask<bool> IsAuthorised(object value) =>
-        ValueTask.FromResult(Guid.TryParse(value.ToString(), out var groupId) && user is not null && user.Groups.Contains(groupId));
+    protected override bool IsAuthorised(Guid groupId) => user is not null && user.Groups.Contains(groupId);
 }

--- a/src/MooBank.Security/Authorisation/GroupOwnerResourceAuthorisationHandler.cs
+++ b/src/MooBank.Security/Authorisation/GroupOwnerResourceAuthorisationHandler.cs
@@ -1,0 +1,16 @@
+using Asm.MooBank.Domain;
+using Asm.MooBank.Models;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Asm.MooBank.Security.Authorisation;
+
+internal class GroupOwnerResourceAuthorisationHandler(IAuthorisationRepository authorisationRepository, User user) : AuthorizationHandler<GroupOwnerRequirement, Guid>
+{
+    protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, GroupOwnerRequirement requirement, Guid groupId)
+    {
+        if (await authorisationRepository.IsGroupOwner(groupId, user.Id))
+        {
+            context.Succeed(requirement);
+        }
+    }
+}

--- a/src/MooBank.Security/IServiceCollectionExtensions.cs
+++ b/src/MooBank.Security/IServiceCollectionExtensions.cs
@@ -14,12 +14,15 @@ public static class IServiceCollectionExtensions
 
     public static IServiceCollection AddAuthorisationHandlers(this IServiceCollection services)
     {
+        services.AddScoped<ISecurity, Security>();
+
         services.AddScoped<IAuthorizationHandler, InstrumentOwnerAuthorisationHandler>();
         services.AddScoped<IAuthorizationHandler, InstrumentViewerAuthorisationHandler>();
         services.AddScoped<IAuthorizationHandler, InstrumentViewerResourceAuthorisationHandler>();
         services.AddScoped<IAuthorizationHandler, InstrumentOwnerResourceAuthorisationHandler>();
         services.AddScoped<IAuthorizationHandler, FamilyMemberAuthorisationHandler>();
         services.AddScoped<IAuthorizationHandler, GroupOwnerAuthorisationHandler>();
+        services.AddScoped<IAuthorizationHandler, GroupOwnerResourceAuthorisationHandler>();
         services.AddScoped<IAuthorizationHandler, BudgetLineAuthorisationHandler>();
 
         return services;

--- a/src/MooBank.Security/Security.cs
+++ b/src/MooBank.Security/Security.cs
@@ -1,0 +1,46 @@
+using Asm.MooBank.Audit;
+using Asm.MooBank.Domain.Entities.Group;
+using Asm.MooBank.Models;
+using Asm.MooBank.Security.Authorisation;
+using Asm.Security;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Asm.MooBank.Security;
+
+public class Security(IAuthorizationService authorizationService, IPrincipalProvider principalProvider, User user, IAuditLogger audit) : ISecurity
+{
+    public async Task AssertGroupPermission(Guid groupId)
+    {
+        var authResult = await authorizationService.AuthorizeAsync(principalProvider.Principal!, groupId, new GroupOwnerRequirement());
+
+        if (!authResult.Succeeded)
+        {
+            audit.AuthorizationDenied(user, "Group", groupId, nameof(GroupOwnerRequirement));
+            throw new NotAuthorisedException("Not authorised to view this account group");
+        }
+    }
+
+    public Task AssertGroupPermission(Group group) => AssertGroupPermission(group.Id);
+
+    public async Task AssertFamilyPermission(Guid familyId)
+    {
+        var authResult = await authorizationService.AuthorizeAsync(principalProvider.Principal!, familyId, new FamilyMemberRequirement());
+
+        if (!authResult.Succeeded)
+        {
+            audit.AuthorizationDenied(user, "Family", familyId, nameof(FamilyMemberRequirement));
+            throw new NotAuthorisedException("Not authorised to view this family");
+        }
+    }
+
+    public async Task AssertAdministrator(CancellationToken cancellationToken = default)
+    {
+        var authResult = await authorizationService.AuthorizeAsync(principalProvider.Principal!, Policies.Admin);
+
+        if (!authResult.Succeeded)
+        {
+            audit.AuthorizationDenied(user, "Administrator", null, Policies.Admin);
+            throw new NotAuthorisedException("Not authorised to administer MooBank");
+        }
+    }
+}

--- a/src/MooBank/Security/ISecurity.cs
+++ b/src/MooBank/Security/ISecurity.cs
@@ -1,17 +1,18 @@
-﻿using Asm.MooBank.Domain.Entities.Group;
-using Asm.MooBank.Domain.Entities.Instrument;
+using Asm.MooBank.Domain.Entities.Group;
 
 namespace Asm.MooBank.Security;
 
+/// <summary>
+/// A friendly wrapper over requirement-based authorisation. Implementations evaluate
+/// requirements via <c>IAuthorizationService</c>, audit denials and throw; they contain
+/// no data access of their own.
+/// </summary>
 public interface ISecurity
 {
     Task AssertGroupPermission(Guid groupId);
-    void AssertGroupPermission(Group group);
+    Task AssertGroupPermission(Group group);
 
     Task AssertFamilyPermission(Guid familyId);
-
-    Task<bool> HasBudgetLinePermission(Guid id, CancellationToken cancellationToken = default);
-    Task<IEnumerable<Guid>> GetInstrumentIds(CancellationToken cancellationToken = default);
 
     Task AssertAdministrator(CancellationToken cancellationToken = default);
 }

--- a/tests/MooBank.Core.Tests/Security/AuthorisationDependencyTests.cs
+++ b/tests/MooBank.Core.Tests/Security/AuthorisationDependencyTests.cs
@@ -1,0 +1,52 @@
+#nullable enable
+using Asm.MooBank.Audit;
+using Asm.MooBank.Domain;
+using Asm.MooBank.Models;
+using Asm.Security;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Asm.MooBank.Core.Tests.Security;
+
+/// <summary>
+/// Guards the authorisation dependency architecture: requirement handlers depend on
+/// IAuthorisationRepository (data), never on ISecurity, whose implementation consumes
+/// IAuthorizationService. Resolving IAuthorizationService constructs every registered
+/// handler, so a handler depending on ISecurity is a circular dependency.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AuthorisationDependencyTests
+{
+    /// <summary>
+    /// Given the real handler and ISecurity registrations
+    /// When IAuthorizationService and ISecurity are resolved
+    /// Then no circular dependency occurs
+    /// </summary>
+    [Fact]
+    public void ResolvingAuthorisationServices_DoesNotCycle()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAuthorization();
+        services.AddHttpContextAccessor();
+        services.AddScoped(_ => new User
+        {
+            Id = Guid.NewGuid(),
+            EmailAddress = "test@test.com",
+            FamilyId = Guid.NewGuid(),
+            Currency = "AUD",
+        });
+        services.AddScoped(_ => new Mock<IAuthorisationRepository>().Object);
+        services.AddScoped(_ => new Mock<IAuditLogger>().Object);
+        services.AddScoped(_ => new Mock<IPrincipalProvider>().Object);
+        Asm.MooBank.Security.IServiceCollectionExtensions.AddAuthorisationHandlers(services);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        // Act & Assert
+        Assert.Null(Record.Exception(() => scope.ServiceProvider.GetRequiredService<IAuthorizationService>()));
+        Assert.Null(Record.Exception(() => scope.ServiceProvider.GetRequiredService<Asm.MooBank.Security.ISecurity>()));
+    }
+}

--- a/tests/MooBank.Core.Tests/Security/AuthorizationHandlerTests.cs
+++ b/tests/MooBank.Core.Tests/Security/AuthorizationHandlerTests.cs
@@ -492,63 +492,105 @@ public class RouteParamAuthorizationHandlerTests
     #region GroupOwnerAuthorisationHandler Tests
 
     [Fact]
-    public async Task GroupOwnerHandler_OwnedGroup_ReturnsTrue()
+    public async Task GroupOwnerHandler_OwnedGroupRouteValue_Succeeds()
     {
         // Arrange
         var user = CreateUser(groups: [OwnedGroupId]);
-        var httpContextAccessor = CreateHttpContextAccessor();
-        var handler = new TestableGroupOwnerHandler(httpContextAccessor, user);
+        var requirement = new GroupOwnerRequirement();
+        var handler = new GroupOwnerAuthorisationHandler(CreateHttpContextAccessor("groupId", OwnedGroupId.ToString()), user);
+        var context = CreateAuthorizationContext(requirement);
 
         // Act
-        var result = await handler.TestIsAuthorised(OwnedGroupId);
+        await handler.HandleAsync(context);
 
         // Assert
-        Assert.True(result);
+        Assert.True(context.HasSucceeded);
+        Assert.False(context.HasFailed);
     }
 
     [Fact]
-    public async Task GroupOwnerHandler_NonOwnedGroup_ReturnsFalse()
+    public async Task GroupOwnerHandler_NonOwnedGroupRouteValue_Fails()
     {
         // Arrange
         var user = CreateUser(groups: [OwnedGroupId]);
-        var httpContextAccessor = CreateHttpContextAccessor();
-        var handler = new TestableGroupOwnerHandler(httpContextAccessor, user);
+        var requirement = new GroupOwnerRequirement();
+        var handler = new GroupOwnerAuthorisationHandler(CreateHttpContextAccessor("groupId", Guid.NewGuid().ToString()), user);
+        var context = CreateAuthorizationContext(requirement);
 
         // Act
-        var result = await handler.TestIsAuthorised(Guid.NewGuid());
+        await handler.HandleAsync(context);
 
         // Assert
-        Assert.False(result);
+        Assert.False(context.HasSucceeded);
+        Assert.True(context.HasFailed);
     }
 
     [Fact]
-    public async Task GroupOwnerHandler_InvalidGuidString_ReturnsFalse()
+    public async Task GroupOwnerHandler_InvalidGuidRouteValue_Fails()
     {
         // Arrange
         var user = CreateUser(groups: [OwnedGroupId]);
-        var httpContextAccessor = CreateHttpContextAccessor();
-        var handler = new TestableGroupOwnerHandler(httpContextAccessor, user);
+        var requirement = new GroupOwnerRequirement();
+        var handler = new GroupOwnerAuthorisationHandler(CreateHttpContextAccessor("groupId", "not-a-guid"), user);
+        var context = CreateAuthorizationContext(requirement);
 
         // Act
-        var result = await handler.TestIsAuthorised("not-a-guid");
+        await handler.HandleAsync(context);
 
         // Assert
-        Assert.False(result);
+        Assert.False(context.HasSucceeded);
+        Assert.True(context.HasFailed);
     }
 
+    /// <summary>
+    /// Given no group route value and a resource-based evaluation for an owned group
+    /// When both group handlers run
+    /// Then the resource handler decides and authorization succeeds
+    /// </summary>
     [Fact]
-    public async Task GroupOwnerHandler_NullUser_ReturnsFalse()
+    public async Task GroupOwnerHandlers_NoRouteValue_OwnedGroupResource_Succeeds()
     {
         // Arrange
-        User? user = null;
-        var httpContextAccessor = CreateHttpContextAccessor();
-        var handler = new TestableGroupOwnerHandler(httpContextAccessor, user);
+        var user = CreateUser(groups: [OwnedGroupId]);
+        var repository = new Mock<Asm.MooBank.Domain.IAuthorisationRepository>();
+        repository.Setup(r => r.IsGroupOwner(OwnedGroupId, user.Id, It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var requirement = new GroupOwnerRequirement();
+        var routeHandler = new GroupOwnerAuthorisationHandler(CreateHttpContextAccessor(), user);
+        var resourceHandler = new GroupOwnerResourceAuthorisationHandler(repository.Object, user);
+        var context = CreateAuthorizationContext(requirement, OwnedGroupId);
 
         // Act
-        var result = await handler.TestIsAuthorised(OwnedGroupId);
+        await routeHandler.HandleAsync(context);
+        await resourceHandler.HandleAsync(context);
 
         // Assert
-        Assert.False(result);
+        Assert.True(context.HasSucceeded);
+        Assert.False(context.HasFailed);
+    }
+
+    /// <summary>
+    /// Given no group route value and a resource-based evaluation for a group the user does not own
+    /// When both group handlers run
+    /// Then authorization does not succeed (fail-closed)
+    /// </summary>
+    [Fact]
+    public async Task GroupOwnerHandlers_NoRouteValue_NonOwnedGroupResource_DoesNotSucceed()
+    {
+        // Arrange
+        var user = CreateUser();
+        var repository = new Mock<Asm.MooBank.Domain.IAuthorisationRepository>();
+        repository.Setup(r => r.IsGroupOwner(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(false);
+        var requirement = new GroupOwnerRequirement();
+        var routeHandler = new GroupOwnerAuthorisationHandler(CreateHttpContextAccessor(), user);
+        var resourceHandler = new GroupOwnerResourceAuthorisationHandler(repository.Object, user);
+        var context = CreateAuthorizationContext(requirement, Guid.NewGuid());
+
+        // Act
+        await routeHandler.HandleAsync(context);
+        await resourceHandler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
     }
 
     #endregion
@@ -595,45 +637,42 @@ public class RouteParamAuthorizationHandlerTests
 
     #endregion
 
-    #region Test Wrappers
-
-    /// <summary>
-    /// Test wrapper that exposes the protected IsAuthorised method.
-    /// </summary>
-    private class TestableGroupOwnerHandler : GroupOwnerAuthorisationHandler
-    {
-        public TestableGroupOwnerHandler(IHttpContextAccessor httpContextAccessor, User? user)
-            : base(httpContextAccessor, user!)
-        {
-        }
-
-        public ValueTask<bool> TestIsAuthorised(object value) => IsAuthorised(value);
-    }
-
-    #endregion
 }
 
 /// <summary>
 /// Tests for the BudgetLineAuthorisationHandler, which authorises the budget line route
-/// parameter via ISecurity.HasBudgetLinePermission.
+/// parameter via IAuthorisationRepository.
 /// </summary>
 [Trait("Category", "Unit")]
 public class BudgetLineAuthorisationHandlerTests
 {
     private static readonly Guid BudgetLineId = Guid.NewGuid();
+    private static readonly Guid FamilyId = Guid.NewGuid();
+
+    private readonly Mock<Asm.MooBank.Domain.IAuthorisationRepository> _repository = new();
+    private readonly Mock<Asm.MooBank.Audit.IAuditLogger> _audit = new();
+    private readonly User _user = new()
+    {
+        Id = Guid.NewGuid(),
+        EmailAddress = "test@test.com",
+        FamilyId = FamilyId,
+        Currency = "AUD",
+    };
+
+    private BudgetLineAuthorisationHandler CreateHandler(IHttpContextAccessor httpContextAccessor) =>
+        new(httpContextAccessor, _repository.Object, _user, _audit.Object);
 
     /// <summary>
-    /// Given a valid budget line id in the route and a user with permission
+    /// Given a valid budget line id in the route belonging to the user's family
     /// When the requirement is handled
-    /// Then authorization should succeed
+    /// Then authorization should succeed and nothing is audited
     /// </summary>
     [Fact]
-    public async Task BudgetLineHandler_ValidRouteValueWithPermission_Succeeds()
+    public async Task BudgetLineHandler_ValidRouteValueInUsersFamily_Succeeds()
     {
         // Arrange
-        var security = new Mock<Asm.MooBank.Security.ISecurity>();
-        security.Setup(s => s.HasBudgetLinePermission(BudgetLineId, It.IsAny<CancellationToken>())).ReturnsAsync(true);
-        var handler = new BudgetLineAuthorisationHandler(CreateHttpContextAccessor("id", BudgetLineId.ToString()), security.Object);
+        _repository.Setup(r => r.GetBudgetLineFamilyId(BudgetLineId, It.IsAny<CancellationToken>())).ReturnsAsync(FamilyId);
+        var handler = CreateHandler(CreateHttpContextAccessor("id", BudgetLineId.ToString()));
         var context = CreateAuthorizationContext(new BudgetLineRequirement());
 
         // Act
@@ -642,20 +681,20 @@ public class BudgetLineAuthorisationHandlerTests
         // Assert
         Assert.True(context.HasSucceeded);
         Assert.False(context.HasFailed);
+        _audit.Verify(a => a.AuthorizationDenied(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>
-    /// Given a valid budget line id in the route and a user without permission
+    /// Given a valid budget line id in the route belonging to another family
     /// When the requirement is handled
-    /// Then authorization should fail
+    /// Then authorization should fail and the denial is audited
     /// </summary>
     [Fact]
-    public async Task BudgetLineHandler_ValidRouteValueWithoutPermission_Fails()
+    public async Task BudgetLineHandler_ValidRouteValueInOtherFamily_FailsAndAudits()
     {
         // Arrange
-        var security = new Mock<Asm.MooBank.Security.ISecurity>();
-        security.Setup(s => s.HasBudgetLinePermission(BudgetLineId, It.IsAny<CancellationToken>())).ReturnsAsync(false);
-        var handler = new BudgetLineAuthorisationHandler(CreateHttpContextAccessor("id", BudgetLineId.ToString()), security.Object);
+        _repository.Setup(r => r.GetBudgetLineFamilyId(BudgetLineId, It.IsAny<CancellationToken>())).ReturnsAsync(Guid.NewGuid());
+        var handler = CreateHandler(CreateHttpContextAccessor("id", BudgetLineId.ToString()));
         var context = CreateAuthorizationContext(new BudgetLineRequirement());
 
         // Act
@@ -664,19 +703,41 @@ public class BudgetLineAuthorisationHandlerTests
         // Assert
         Assert.False(context.HasSucceeded);
         Assert.True(context.HasFailed);
+        _audit.Verify(a => a.AuthorizationDenied(_user, "BudgetLine", BudgetLineId, nameof(BudgetLineRequirement)), Times.Once);
+    }
+
+    /// <summary>
+    /// Given a budget line id that does not exist
+    /// When the requirement is handled
+    /// Then authorization should fail and the denial is audited
+    /// </summary>
+    [Fact]
+    public async Task BudgetLineHandler_UnknownBudgetLine_FailsAndAudits()
+    {
+        // Arrange
+        _repository.Setup(r => r.GetBudgetLineFamilyId(BudgetLineId, It.IsAny<CancellationToken>())).ReturnsAsync((Guid?)null);
+        var handler = CreateHandler(CreateHttpContextAccessor("id", BudgetLineId.ToString()));
+        var context = CreateAuthorizationContext(new BudgetLineRequirement());
+
+        // Act
+        await handler.HandleAsync(context);
+
+        // Assert
+        Assert.False(context.HasSucceeded);
+        Assert.True(context.HasFailed);
+        _audit.Verify(a => a.AuthorizationDenied(_user, "BudgetLine", BudgetLineId, nameof(BudgetLineRequirement)), Times.Once);
     }
 
     /// <summary>
     /// Given a route value that is not a valid GUID
     /// When the requirement is handled
-    /// Then authorization should fail without consulting security
+    /// Then authorization should fail without consulting the repository
     /// </summary>
     [Fact]
     public async Task BudgetLineHandler_InvalidGuidRouteValue_Fails()
     {
         // Arrange
-        var security = new Mock<Asm.MooBank.Security.ISecurity>();
-        var handler = new BudgetLineAuthorisationHandler(CreateHttpContextAccessor("id", "not-a-guid"), security.Object);
+        var handler = CreateHandler(CreateHttpContextAccessor("id", "not-a-guid"));
         var context = CreateAuthorizationContext(new BudgetLineRequirement());
 
         // Act
@@ -685,7 +746,7 @@ public class BudgetLineAuthorisationHandlerTests
         // Assert
         Assert.False(context.HasSucceeded);
         Assert.True(context.HasFailed);
-        security.Verify(s => s.HasBudgetLinePermission(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(r => r.GetBudgetLineFamilyId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     /// <summary>
@@ -697,8 +758,7 @@ public class BudgetLineAuthorisationHandlerTests
     public async Task BudgetLineHandler_MissingRouteValue_Fails()
     {
         // Arrange
-        var security = new Mock<Asm.MooBank.Security.ISecurity>();
-        var handler = new BudgetLineAuthorisationHandler(CreateHttpContextAccessor(), security.Object);
+        var handler = CreateHandler(CreateHttpContextAccessor());
         var context = CreateAuthorizationContext(new BudgetLineRequirement());
 
         // Act
@@ -707,7 +767,7 @@ public class BudgetLineAuthorisationHandlerTests
         // Assert
         Assert.False(context.HasSucceeded);
         Assert.True(context.HasFailed);
-        security.Verify(s => s.HasBudgetLinePermission(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repository.Verify(r => r.GetBudgetLineFamilyId(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static AuthorizationHandlerContext CreateAuthorizationContext(IAuthorizationRequirement requirement)

--- a/tests/MooBank.Core.Tests/Security/SecurityTests.cs
+++ b/tests/MooBank.Core.Tests/Security/SecurityTests.cs
@@ -1,0 +1,178 @@
+#nullable enable
+using System.Security.Claims;
+using Asm.MooBank.Audit;
+using Asm.MooBank.Models;
+using Asm.MooBank.Security;
+using Asm.MooBank.Security.Authorisation;
+using Asm.Security;
+using Microsoft.AspNetCore.Authorization;
+using DomainGroup = Asm.MooBank.Domain.Entities.Group.Group;
+
+namespace Asm.MooBank.Core.Tests.Security;
+
+/// <summary>
+/// Unit tests for the <see cref="Asm.MooBank.Security.Security"/> wrapper, which evaluates
+/// requirements via IAuthorizationService, audits denials and throws.
+/// </summary>
+[Trait("Category", "Unit")]
+public class SecurityTests
+{
+    private readonly Mock<IAuthorizationService> _authorizationService = new();
+    private readonly Mock<IPrincipalProvider> _principalProvider = new();
+    private readonly Mock<IAuditLogger> _audit = new();
+    private readonly ClaimsPrincipal _principal = new(new ClaimsIdentity("TestAuth"));
+    private readonly User _user = new()
+    {
+        Id = Guid.NewGuid(),
+        EmailAddress = "test@test.com",
+        FamilyId = Guid.NewGuid(),
+        Currency = "AUD",
+    };
+
+    public SecurityTests()
+    {
+        _principalProvider.Setup(p => p.Principal).Returns(_principal);
+    }
+
+    private Asm.MooBank.Security.Security CreateSecurity() =>
+        new(_authorizationService.Object, _principalProvider.Object, _user, _audit.Object);
+
+    private void SetupResourceAuthorization(bool succeeds) =>
+        _authorizationService
+            .Setup(a => a.AuthorizeAsync(_principal, It.IsAny<object?>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
+            .ReturnsAsync(succeeds ? AuthorizationResult.Success() : AuthorizationResult.Failed());
+
+    private void SetupPolicyAuthorization(bool succeeds) =>
+        _authorizationService
+            .Setup(a => a.AuthorizeAsync(_principal, It.IsAny<object?>(), It.IsAny<string>()))
+            .ReturnsAsync(succeeds ? AuthorizationResult.Success() : AuthorizationResult.Failed());
+
+    #region AssertGroupPermission
+
+    /// <summary>
+    /// Given the group owner requirement succeeds
+    /// When AssertGroupPermission is called
+    /// Then no exception is thrown and nothing is audited
+    /// </summary>
+    [Fact]
+    public async Task AssertGroupPermission_Authorised_DoesNotThrow()
+    {
+        // Arrange
+        SetupResourceAuthorization(true);
+
+        // Act & Assert
+        await CreateSecurity().AssertGroupPermission(Guid.NewGuid());
+        _audit.Verify(a => a.AuthorizationDenied(It.IsAny<User>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Given the group owner requirement fails
+    /// When AssertGroupPermission is called
+    /// Then NotAuthorisedException is thrown and the denial audited
+    /// </summary>
+    [Fact]
+    public async Task AssertGroupPermission_NotAuthorised_ThrowsAndAudits()
+    {
+        // Arrange
+        var groupId = Guid.NewGuid();
+        SetupResourceAuthorization(false);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotAuthorisedException>(() => CreateSecurity().AssertGroupPermission(groupId));
+        _audit.Verify(a => a.AuthorizationDenied(_user, "Group", groupId, nameof(GroupOwnerRequirement)), Times.Once);
+    }
+
+    /// <summary>
+    /// Given a group entity
+    /// When AssertGroupPermission is called with the entity
+    /// Then the requirement is evaluated for the group's id
+    /// </summary>
+    [Fact]
+    public async Task AssertGroupPermission_Entity_DelegatesToId()
+    {
+        // Arrange
+        var group = new DomainGroup(Guid.NewGuid()) { Name = "Test Group", OwnerId = _user.Id };
+        SetupResourceAuthorization(true);
+
+        // Act
+        await CreateSecurity().AssertGroupPermission(group);
+
+        // Assert
+        _authorizationService.Verify(
+            a => a.AuthorizeAsync(_principal, (object?)group.Id, It.IsAny<IEnumerable<IAuthorizationRequirement>>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region AssertFamilyPermission
+
+    /// <summary>
+    /// Given the family member requirement succeeds
+    /// When AssertFamilyPermission is called
+    /// Then no exception is thrown
+    /// </summary>
+    [Fact]
+    public async Task AssertFamilyPermission_Authorised_DoesNotThrow()
+    {
+        // Arrange
+        SetupResourceAuthorization(true);
+
+        // Act & Assert
+        await CreateSecurity().AssertFamilyPermission(_user.FamilyId);
+    }
+
+    /// <summary>
+    /// Given the family member requirement fails
+    /// When AssertFamilyPermission is called
+    /// Then NotAuthorisedException is thrown and the denial audited
+    /// </summary>
+    [Fact]
+    public async Task AssertFamilyPermission_NotAuthorised_ThrowsAndAudits()
+    {
+        // Arrange
+        var familyId = Guid.NewGuid();
+        SetupResourceAuthorization(false);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotAuthorisedException>(() => CreateSecurity().AssertFamilyPermission(familyId));
+        _audit.Verify(a => a.AuthorizationDenied(_user, "Family", familyId, nameof(FamilyMemberRequirement)), Times.Once);
+    }
+
+    #endregion
+
+    #region AssertAdministrator
+
+    /// <summary>
+    /// Given the Admin policy succeeds
+    /// When AssertAdministrator is called
+    /// Then no exception is thrown
+    /// </summary>
+    [Fact]
+    public async Task AssertAdministrator_Authorised_DoesNotThrow()
+    {
+        // Arrange
+        SetupPolicyAuthorization(true);
+
+        // Act & Assert
+        await CreateSecurity().AssertAdministrator(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Given the Admin policy fails
+    /// When AssertAdministrator is called
+    /// Then NotAuthorisedException is thrown and the denial audited
+    /// </summary>
+    [Fact]
+    public async Task AssertAdministrator_NotAuthorised_ThrowsAndAudits()
+    {
+        // Arrange
+        SetupPolicyAuthorization(false);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotAuthorisedException>(() => CreateSecurity().AssertAdministrator(TestContext.Current.CancellationToken));
+        _audit.Verify(a => a.AuthorizationDenied(_user, "Administrator", null, Policies.Admin), Times.Once);
+    }
+
+    #endregion
+}

--- a/tests/MooBank.Domain.Tests/Repositories/SecurityRepositoryTests.cs
+++ b/tests/MooBank.Domain.Tests/Repositories/SecurityRepositoryTests.cs
@@ -1,47 +1,26 @@
-﻿#nullable enable
-using System.Security.Claims;
-using Asm.MooBank.Audit;
+#nullable enable
 using Asm.MooBank.Domain.Entities.Budget;
 using Asm.MooBank.Domain.Entities.Group;
+using Asm.MooBank.Domain.Entities.Instrument;
 using Asm.MooBank.Domain.Tests.Support;
 using Asm.MooBank.Infrastructure.Repositories;
-using Asm.MooBank.Security;
-using Asm.MooBank.Security.Authorisation;
-using Asm.Security;
-using Microsoft.AspNetCore.Authorization;
-using SysClaims = System.Security.Claims;
 
 namespace Asm.MooBank.Domain.Tests.Repositories;
 
+/// <summary>
+/// Integration tests for the <see cref="SecurityRepository"/> data queries used by
+/// authorisation requirement handlers.
+/// </summary>
 [Trait("Category", "Integration")]
 public class SecurityRepositoryTests : IDisposable
 {
     private readonly Infrastructure.MooBankContext _context;
     private readonly Guid _userId = Guid.NewGuid();
     private readonly Guid _familyId = Guid.NewGuid();
-    private readonly Models.User _user;
-    private readonly Mock<IAuthorizationService> _authorizationService;
-    private readonly Mock<IPrincipalProvider> _principalProvider;
-    private readonly Mock<IAuditLogger> _auditLogger;
 
     public SecurityRepositoryTests()
     {
         _context = TestDbContextFactory.Create();
-        _user = new Models.User
-        {
-            Id = _userId,
-            EmailAddress = "test@test.com",
-            FamilyId = _familyId,
-            Currency = "AUD",
-        };
-        _authorizationService = new Mock<IAuthorizationService>();
-        _principalProvider = new Mock<IPrincipalProvider>();
-        _auditLogger = new Mock<IAuditLogger>();
-
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(
-            [new Claim(SysClaims.ClaimTypes.NameIdentifier, _userId.ToString())],
-            "TestAuth"));
-        _principalProvider.Setup(p => p.Principal).Returns(principal);
     }
 
     public void Dispose()
@@ -50,169 +29,128 @@ public class SecurityRepositoryTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    #region AssertGroupPermission (Guid overload)
+    private SecurityRepository CreateRepository() => new(_context);
 
+    #region IsGroupOwner
+
+    /// <summary>
+    /// Given a group owned by the user
+    /// When IsGroupOwner is called
+    /// Then true is returned
+    /// </summary>
     [Fact]
-    public async Task AssertGroupPermissionById_UserOwnsGroup_DoesNotThrow()
+    public async Task IsGroupOwner_UserOwnsGroup_ReturnsTrue()
     {
         // Arrange
         var groupId = Guid.NewGuid();
-        var group = new Group(groupId) { Name = "Test Group", OwnerId = _userId };
-        _context.Set<Group>().Add(group);
+        _context.Set<Group>().Add(new Group(groupId) { Name = "Test Group", OwnerId = _userId });
         _context.SaveChanges();
-
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        await repository.AssertGroupPermission(groupId);
-    }
-
-    [Fact]
-    public async Task AssertGroupPermissionById_UserDoesNotOwnGroup_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var groupId = Guid.NewGuid();
-        var otherUserId = Guid.NewGuid();
-        var group = new Group(groupId) { Name = "Other Group", OwnerId = otherUserId };
-        _context.Set<Group>().Add(group);
-        _context.SaveChanges();
-
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() => repository.AssertGroupPermission(groupId));
-    }
-
-    [Fact]
-    public async Task AssertGroupPermissionById_GroupDoesNotExist_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() => repository.AssertGroupPermission(Guid.NewGuid()));
-    }
-
-    #endregion
-
-    #region AssertGroupPermission (Group overload)
-
-    [Fact]
-    public void AssertGroupPermissionByEntity_UserOwnsGroup_DoesNotThrow()
-    {
-        // Arrange
-        var group = new Group(Guid.NewGuid()) { Name = "Test Group", OwnerId = _userId };
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        repository.AssertGroupPermission(group);
-    }
-
-    [Fact]
-    public void AssertGroupPermissionByEntity_UserDoesNotOwnGroup_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var otherUserId = Guid.NewGuid();
-        var group = new Group(Guid.NewGuid()) { Name = "Other Group", OwnerId = otherUserId };
-        var repository = CreateRepository();
-
-        // Act & Assert
-        Assert.Throws<NotAuthorisedException>(() => repository.AssertGroupPermission(group));
-    }
-
-    #endregion
-
-    #region AssertFamilyPermission
-
-    [Fact]
-    public async Task AssertFamilyPermission_UserIsFamilyMember_DoesNotThrow()
-    {
-        // Arrange
-        _authorizationService
-            .Setup(a => a.AuthorizeAsync(
-                It.IsAny<ClaimsPrincipal>(),
-                _familyId,
-                It.IsAny<IAuthorizationRequirement[]>()))
-            .ReturnsAsync(AuthorizationResult.Success());
-
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        await repository.AssertFamilyPermission(_familyId);
-    }
-
-    [Fact]
-    public async Task AssertFamilyPermission_UserIsNotFamilyMember_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        _authorizationService
-            .Setup(a => a.AuthorizeAsync(
-                It.IsAny<ClaimsPrincipal>(),
-                It.IsAny<Guid>(),
-                It.IsAny<IAuthorizationRequirement[]>()))
-            .ReturnsAsync(AuthorizationResult.Failed());
-
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() =>
-            repository.AssertFamilyPermission(Guid.NewGuid()));
-    }
-
-    #endregion
-
-    #region HasBudgetLinePermission
-
-    [Fact]
-    public async Task HasBudgetLinePermission_BudgetLineInUsersFamily_ReturnsTrueAndDoesNotAudit()
-    {
-        // Arrange
-        var lineId = AddBudgetLine(_familyId);
-        var repository = CreateRepository();
 
         // Act
-        var result = await repository.HasBudgetLinePermission(lineId, TestContext.Current.CancellationToken);
+        var result = await CreateRepository().IsGroupOwner(groupId, _userId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        _auditLogger.Verify(
-            a => a.AuthorizationDenied(It.IsAny<Models.User>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()),
-            Times.Never);
     }
 
+    /// <summary>
+    /// Given a group owned by another user
+    /// When IsGroupOwner is called
+    /// Then false is returned
+    /// </summary>
     [Fact]
-    public async Task HasBudgetLinePermission_BudgetLineInOtherFamily_ReturnsFalseAndAudits()
+    public async Task IsGroupOwner_UserDoesNotOwnGroup_ReturnsFalse()
     {
         // Arrange
-        var lineId = AddBudgetLine(Guid.NewGuid());
-        var repository = CreateRepository();
+        var groupId = Guid.NewGuid();
+        _context.Set<Group>().Add(new Group(groupId) { Name = "Other Group", OwnerId = Guid.NewGuid() });
+        _context.SaveChanges();
 
         // Act
-        var result = await repository.HasBudgetLinePermission(lineId, TestContext.Current.CancellationToken);
+        var result = await CreateRepository().IsGroupOwner(groupId, _userId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
-        _auditLogger.Verify(
-            a => a.AuthorizationDenied(_user, "BudgetLine", lineId, nameof(BudgetLineRequirement)),
-            Times.Once);
     }
 
+    /// <summary>
+    /// Given a group that does not exist
+    /// When IsGroupOwner is called
+    /// Then false is returned
+    /// </summary>
     [Fact]
-    public async Task HasBudgetLinePermission_BudgetLineNotFound_ReturnsFalseAndAudits()
+    public async Task IsGroupOwner_GroupDoesNotExist_ReturnsFalse()
     {
-        // Arrange
-        var nonExistentId = Guid.NewGuid();
-        var repository = CreateRepository();
-
         // Act
-        var result = await repository.HasBudgetLinePermission(nonExistentId, TestContext.Current.CancellationToken);
+        var result = await CreateRepository().IsGroupOwner(Guid.NewGuid(), _userId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(result);
-        _auditLogger.Verify(
-            a => a.AuthorizationDenied(_user, "BudgetLine", nonExistentId, nameof(BudgetLineRequirement)),
-            Times.Once);
     }
+
+    #endregion
+
+    #region GetBudgetLineFamilyId
+
+    /// <summary>
+    /// Given a budget line
+    /// When GetBudgetLineFamilyId is called
+    /// Then the owning budget's family id is returned
+    /// </summary>
+    [Fact]
+    public async Task GetBudgetLineFamilyId_LineExists_ReturnsFamilyId()
+    {
+        // Arrange
+        var lineId = AddBudgetLine(_familyId);
+
+        // Act
+        var result = await CreateRepository().GetBudgetLineFamilyId(lineId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(_familyId, result);
+    }
+
+    /// <summary>
+    /// Given no budget line with the supplied id
+    /// When GetBudgetLineFamilyId is called
+    /// Then null is returned
+    /// </summary>
+    [Fact]
+    public async Task GetBudgetLineFamilyId_LineDoesNotExist_ReturnsNull()
+    {
+        // Act
+        var result = await CreateRepository().GetBudgetLineFamilyId(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region GetOwnedInstrumentIds
+
+    /// <summary>
+    /// Given instruments owned by the user and by others
+    /// When GetOwnedInstrumentIds is called
+    /// Then only the user's instrument ids are returned
+    /// </summary>
+    [Fact]
+    public async Task GetOwnedInstrumentIds_ReturnsOnlyUsersInstruments()
+    {
+        // Arrange
+        var ownedId = Guid.NewGuid();
+        _context.Set<InstrumentOwner>().Add(new InstrumentOwner { InstrumentId = ownedId, UserId = _userId });
+        _context.Set<InstrumentOwner>().Add(new InstrumentOwner { InstrumentId = Guid.NewGuid(), UserId = Guid.NewGuid() });
+        _context.SaveChanges();
+
+        // Act
+        var result = await CreateRepository().GetOwnedInstrumentIds(_userId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([ownedId], result);
+    }
+
+    #endregion
 
     private Guid AddBudgetLine(Guid familyId)
     {
@@ -234,80 +172,4 @@ public class SecurityRepositoryTests : IDisposable
 
         return line.Id;
     }
-
-    #endregion
-
-    #region AssertAdministrator
-
-    [Fact]
-    public async Task AssertAdministrator_UserIsAdmin_DoesNotThrow()
-    {
-        // Arrange
-        _authorizationService
-            .Setup(a => a.AuthorizeAsync(
-                It.IsAny<ClaimsPrincipal>(),
-                null,
-                It.Is<string>(s => s == Policies.Admin)))
-            .ReturnsAsync(AuthorizationResult.Success());
-
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        await repository.AssertAdministrator(TestContext.Current.CancellationToken);
-    }
-
-    [Fact]
-    public async Task AssertAdministrator_UserIsNotAdmin_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        _authorizationService
-            .Setup(a => a.AuthorizeAsync(
-                It.IsAny<ClaimsPrincipal>(),
-                null,
-                It.IsAny<string>()))
-            .ReturnsAsync(AuthorizationResult.Failed());
-
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() =>
-            repository.AssertAdministrator(TestContext.Current.CancellationToken));
-    }
-
-    #endregion
-
-    #region GetInstrumentIds
-
-    [Fact]
-    public async Task GetInstrumentIds_ReturnsUserOwnedInstruments()
-    {
-        // Arrange
-        var instrumentId1 = Guid.NewGuid();
-        var instrumentId2 = Guid.NewGuid();
-        var otherInstrumentId = Guid.NewGuid();
-        var otherUserId = Guid.NewGuid();
-
-        _context.Set<Domain.Entities.Instrument.InstrumentOwner>().AddRange(
-            new Domain.Entities.Instrument.InstrumentOwner { InstrumentId = instrumentId1, UserId = _userId },
-            new Domain.Entities.Instrument.InstrumentOwner { InstrumentId = instrumentId2, UserId = _userId },
-            new Domain.Entities.Instrument.InstrumentOwner { InstrumentId = otherInstrumentId, UserId = otherUserId }
-        );
-        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
-
-        var repository = CreateRepository();
-
-        // Act
-        var result = await repository.GetInstrumentIds(TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Equal(2, result.Count());
-        Assert.Contains(instrumentId1, result);
-        Assert.Contains(instrumentId2, result);
-        Assert.DoesNotContain(otherInstrumentId, result);
-    }
-
-    #endregion
-
-    private SecurityRepository CreateRepository() =>
-        new(_context, _authorizationService.Object, _principalProvider.Object, _user, _auditLogger.Object);
 }

--- a/tests/MooBank.Infrastructure.Tests/Repositories/SecurityRepositoryTests.cs
+++ b/tests/MooBank.Infrastructure.Tests/Repositories/SecurityRepositoryTests.cs
@@ -1,36 +1,23 @@
-﻿#nullable enable
-using System.Security.Claims;
-using Asm.MooBank.Audit;
-using Asm.MooBank.Domain.Entities.Budget;
-using Asm.MooBank.Domain.Entities.Group;
+#nullable enable
 using Asm.MooBank.Infrastructure.Repositories;
 using Asm.MooBank.Infrastructure.Tests.Support;
-using Asm.MooBank.Security;
-using Asm.MooBank.Security.Authorisation;
-using Asm.Security;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Asm.MooBank.Infrastructure.Tests.Repositories;
 
+/// <summary>
+/// Unit tests for the <see cref="SecurityRepository"/> data queries used by
+/// authorisation requirement handlers.
+/// </summary>
 [Trait("Category", "Unit")]
 public class SecurityRepositoryTests : IDisposable
 {
     private readonly MooBankContext _context;
-    private readonly Mock<IAuthorizationService> _authorizationServiceMock;
-    private readonly Mock<IPrincipalProvider> _principalProviderMock;
-    private readonly Mock<IAuditLogger> _auditLoggerMock;
-    private readonly Models.User _user;
-    private readonly ClaimsPrincipal _principal;
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _familyId = Guid.NewGuid();
 
     public SecurityRepositoryTests()
     {
         _context = TestDbContextFactory.Create();
-        _authorizationServiceMock = new Mock<IAuthorizationService>();
-        _principalProviderMock = new Mock<IPrincipalProvider>();
-        _auditLoggerMock = new Mock<IAuditLogger>();
-        _user = TestEntities.CreateUserModel();
-        _principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(System.Security.Claims.ClaimTypes.NameIdentifier, _user.Id.ToString())]));
-        _principalProviderMock.Setup(p => p.Principal).Returns(_principal);
     }
 
     public void Dispose()
@@ -39,251 +26,105 @@ public class SecurityRepositoryTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    #region AssertGroupPermission(Guid)
+    private SecurityRepository CreateRepository() => new(_context);
 
+    #region IsGroupOwner
+
+    /// <summary>
+    /// Given a group owned by the user
+    /// When IsGroupOwner is called
+    /// Then true is returned
+    /// </summary>
     [Fact]
-    public async Task AssertGroupPermission_ById_UserOwnsGroup_DoesNotThrow()
+    public async Task IsGroupOwner_UserOwnsGroup_ReturnsTrue()
     {
         // Arrange
-        var group = TestEntities.CreateGroup(ownerId: _user.Id);
+        var group = TestEntities.CreateGroup(ownerId: _userId);
         _context.Groups.Add(group);
         _context.SaveChanges();
-
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        await repository.AssertGroupPermission(group.Id);
-    }
-
-    [Fact]
-    public async Task AssertGroupPermission_ById_UserDoesNotOwnGroup_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var otherUserId = Guid.NewGuid();
-        var group = TestEntities.CreateGroup(ownerId: otherUserId);
-        _context.Groups.Add(group);
-        _context.SaveChanges();
-
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() => repository.AssertGroupPermission(group.Id));
-    }
-
-    [Fact]
-    public async Task AssertGroupPermission_ById_GroupDoesNotExist_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var nonExistentGroupId = Guid.NewGuid();
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() => repository.AssertGroupPermission(nonExistentGroupId));
-    }
-
-    #endregion
-
-    #region AssertGroupPermission(Group)
-
-    [Fact]
-    public void AssertGroupPermission_ByGroup_UserOwnsGroup_DoesNotThrow()
-    {
-        // Arrange
-        var group = TestEntities.CreateGroup(ownerId: _user.Id);
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        repository.AssertGroupPermission(group);
-    }
-
-    [Fact]
-    public void AssertGroupPermission_ByGroup_UserDoesNotOwnGroup_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var otherUserId = Guid.NewGuid();
-        var group = TestEntities.CreateGroup(ownerId: otherUserId);
-        var repository = CreateRepository();
-
-        // Act & Assert
-        Assert.Throws<NotAuthorisedException>(() => repository.AssertGroupPermission(group));
-    }
-
-    #endregion
-
-    #region AssertFamilyPermission
-
-    [Fact]
-    public async Task AssertFamilyPermission_AuthorizationSucceeds_DoesNotThrow()
-    {
-        // Arrange
-        var familyId = _user.FamilyId;
-
-        // Mock the underlying interface method (extension method wraps requirement in IEnumerable)
-        _authorizationServiceMock
-            .Setup(a => a.AuthorizeAsync(_principal, familyId, It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
-            .ReturnsAsync(AuthorizationResult.Success());
-
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        await repository.AssertFamilyPermission(familyId);
-    }
-
-    [Fact]
-    public async Task AssertFamilyPermission_AuthorizationFails_ThrowsNotAuthorisedException()
-    {
-        // Arrange
-        var familyId = Guid.NewGuid();
-
-        // Mock the underlying interface method
-        _authorizationServiceMock
-            .Setup(a => a.AuthorizeAsync(_principal, familyId, It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
-            .ReturnsAsync(AuthorizationResult.Failed());
-
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() => repository.AssertFamilyPermission(familyId));
-    }
-
-    #endregion
-
-    #region HasBudgetLinePermission
-
-    [Fact]
-    public async Task HasBudgetLinePermission_BudgetLineInUsersFamily_ReturnsTrueAndDoesNotAudit()
-    {
-        // Arrange
-        var budget = TestEntities.CreateBudget(familyId: _user.FamilyId);
-        var line = TestEntities.CreateBudgetLine(budgetId: budget.Id);
-        _context.Add(budget);
-        _context.Add(line);
-        _context.SaveChanges();
-
-        var repository = CreateRepository();
 
         // Act
-        var result = await repository.HasBudgetLinePermission(line.Id, TestContext.Current.CancellationToken);
+        var result = await CreateRepository().IsGroupOwner(group.Id, _userId, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(result);
-        _auditLoggerMock.Verify(
-            a => a.AuthorizationDenied(It.IsAny<Models.User>(), It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<string>()),
-            Times.Never);
     }
 
+    /// <summary>
+    /// Given a group owned by another user
+    /// When IsGroupOwner is called
+    /// Then false is returned
+    /// </summary>
     [Fact]
-    public async Task HasBudgetLinePermission_BudgetLineInOtherFamily_ReturnsFalseAndAudits()
+    public async Task IsGroupOwner_UserDoesNotOwnGroup_ReturnsFalse()
     {
         // Arrange
-        var budget = TestEntities.CreateBudget(familyId: Guid.NewGuid());
+        var group = TestEntities.CreateGroup(ownerId: Guid.NewGuid());
+        _context.Groups.Add(group);
+        _context.SaveChanges();
+
+        // Act
+        var result = await CreateRepository().IsGroupOwner(group.Id, _userId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    /// <summary>
+    /// Given a group that does not exist
+    /// When IsGroupOwner is called
+    /// Then false is returned
+    /// </summary>
+    [Fact]
+    public async Task IsGroupOwner_GroupDoesNotExist_ReturnsFalse()
+    {
+        // Act
+        var result = await CreateRepository().IsGroupOwner(Guid.NewGuid(), _userId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    #endregion
+
+    #region GetBudgetLineFamilyId
+
+    /// <summary>
+    /// Given a budget line
+    /// When GetBudgetLineFamilyId is called
+    /// Then the owning budget's family id is returned
+    /// </summary>
+    [Fact]
+    public async Task GetBudgetLineFamilyId_LineExists_ReturnsFamilyId()
+    {
+        // Arrange
+        var budget = TestEntities.CreateBudget(familyId: _familyId);
         var line = TestEntities.CreateBudgetLine(budgetId: budget.Id);
         _context.Add(budget);
         _context.Add(line);
         _context.SaveChanges();
 
-        var repository = CreateRepository();
-
         // Act
-        var result = await repository.HasBudgetLinePermission(line.Id, TestContext.Current.CancellationToken);
+        var result = await CreateRepository().GetBudgetLineFamilyId(line.Id, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.False(result);
-        _auditLoggerMock.Verify(
-            a => a.AuthorizationDenied(_user, "BudgetLine", line.Id, nameof(BudgetLineRequirement)),
-            Times.Once);
+        Assert.Equal(_familyId, result);
     }
 
+    /// <summary>
+    /// Given no budget line with the supplied id
+    /// When GetBudgetLineFamilyId is called
+    /// Then null is returned
+    /// </summary>
     [Fact]
-    public async Task HasBudgetLinePermission_BudgetLineNotFound_ReturnsFalseAndAudits()
+    public async Task GetBudgetLineFamilyId_LineDoesNotExist_ReturnsNull()
     {
-        // Arrange
-        var nonExistentId = Guid.NewGuid();
-        var repository = CreateRepository();
-
         // Act
-        var result = await repository.HasBudgetLinePermission(nonExistentId, TestContext.Current.CancellationToken);
+        var result = await CreateRepository().GetBudgetLineFamilyId(Guid.NewGuid(), TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.False(result);
-        _auditLoggerMock.Verify(
-            a => a.AuthorizationDenied(_user, "BudgetLine", nonExistentId, nameof(BudgetLineRequirement)),
-            Times.Once);
+        Assert.Null(result);
     }
 
     #endregion
-
-    #region AssertAdministrator
-
-    [Fact]
-    public async Task AssertAdministrator_AuthorizationSucceeds_DoesNotThrow()
-    {
-        // Arrange - Mock the underlying interface method (resource is null, policyName is the string)
-        _authorizationServiceMock
-            .Setup(a => a.AuthorizeAsync(_principal, null, It.Is<string>(s => s == Policies.Admin)))
-            .ReturnsAsync(AuthorizationResult.Success());
-
-        var repository = CreateRepository();
-
-        // Act & Assert - should not throw
-        await repository.AssertAdministrator(TestContext.Current.CancellationToken);
-    }
-
-    [Fact]
-    public async Task AssertAdministrator_AuthorizationFails_ThrowsNotAuthorisedException()
-    {
-        // Arrange - Mock the underlying interface method
-        _authorizationServiceMock
-            .Setup(a => a.AuthorizeAsync(_principal, null, It.Is<string>(s => s == Policies.Admin)))
-            .ReturnsAsync(AuthorizationResult.Failed());
-
-        var repository = CreateRepository();
-
-        // Act & Assert
-        await Assert.ThrowsAsync<NotAuthorisedException>(() => repository.AssertAdministrator(TestContext.Current.CancellationToken));
-    }
-
-    #endregion
-
-    #region GetInstrumentIds
-
-    [Fact]
-    public async Task GetInstrumentIds_UserHasInstruments_ReturnsInstrumentIds()
-    {
-        // Arrange
-        var instrumentId1 = Guid.NewGuid();
-        var instrumentId2 = Guid.NewGuid();
-
-        _context.InstrumentOwners.Add(TestEntities.CreateInstrumentOwner(instrumentId1, _user.Id));
-        _context.InstrumentOwners.Add(TestEntities.CreateInstrumentOwner(instrumentId2, _user.Id));
-        _context.SaveChanges();
-
-        var repository = CreateRepository();
-
-        // Act
-        var result = await repository.GetInstrumentIds(TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Equal(2, result.Count());
-        Assert.Contains(instrumentId1, result);
-        Assert.Contains(instrumentId2, result);
-    }
-
-    [Fact]
-    public async Task GetInstrumentIds_UserHasNoInstruments_ReturnsEmpty()
-    {
-        // Arrange
-        var repository = CreateRepository();
-
-        // Act
-        var result = await repository.GetInstrumentIds(TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Empty(result);
-    }
-
-    #endregion
-
-    private SecurityRepository CreateRepository() =>
-        new(_context, _authorizationServiceMock.Object, _principalProviderMock.Object, _user, _auditLoggerMock.Object);
 }


### PR DESCRIPTION
Implements the authorisation architecture discussed in review, and fixes the `IAuthorizationService` circular dependency at its root (supersedes the tactical fix in #861).

**The problem:** `ISecurity` accumulated two different responsibilities over years of change — wrapping requirement-based authorisation (`AssertFamilyPermission`, `AssertAdministrator`) and performing direct DB checks (`AssertGroupPermission`, `HasBudgetLinePermission`). The wrapper half must sit above `IAuthorizationService`; the DB half is needed below it (by requirement handlers). One class cannot do both, which is how #845's budget-line handler created the cycle.

**The architecture:**
- **`ISecurity`** — a friendly wrapper over `IAuthorizationService`: evaluates requirements, audits denials, throws. Implemented by the new `Security` class in `MooBank.Security`. No data access.
- **`IAuthorisationRepository`** (Domain) — decision-free data queries (`IsGroupOwner`, `GetBudgetLineFamilyId`, `GetOwnedInstrumentIds`), implemented by `SecurityRepository` (Infrastructure), consumed only by requirement handlers. No dependency on the authorisation system.
- Dependency direction is one-way by construction: `modules → ISecurity → IAuthorizationService → handlers → IAuthorisationRepository → data`.

**Notable details:**
- `AssertGroupPermission` is requirement-backed: a new DB-backed `GroupOwnerResourceAuthorisationHandler` joins the claims-based route handler, which moves onto the tolerant route base so resource-based evaluation is not vetoed on routes without a `groupId` (the MCP-veto lesson).
- The group entity overload becomes `Task` and delegates to the id overload (two call sites updated).
- Budget-line denials are audited in the handler, preserving today's audit behaviour for the route policy path.
- New `AuthorisationDependencyTests` resolves `IAuthorizationService` + `ISecurity` from the real registrations — fails if a handler ever depends on `ISecurity` again.

Full solution build: 0 warnings/errors. Full suite: 2,008 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)