### PR TITLE
fix(api): correct application name after project rename

### DIFF
--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -16,7 +16,7 @@ using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
 using ModelContextProtocol.AspNetCore.Authentication;
 
-var result = WebApplicationStart.Run(args, "Asm.MooBank.Web.Api", AddServices, AddApp, AddHealthChecks);
+var result = WebApplicationStart.Run(args, "Asm.MooBank.Api", AddServices, AddApp, AddHealthChecks);
 
 return result;
 


### PR DESCRIPTION
Fixes the exception logged at every startup:

```
System.InvalidOperationException: Startup assembly Asm.MooBank.Web.Api failed to execute.
 ---> System.IO.FileNotFoundException: Could not load file or assembly 'Asm.MooBank.Web.Api'
```

`Program.cs` passed the pre-rename assembly name to `WebApplicationStart.Run`, which ASM sets as `WebApplicationOptions.ApplicationName`. ASP.NET Core's hosting-startup mechanism loads the application assembly by that name at boot — non-fatally, but noisily — and the assembly has been `Asm.MooBank.Api` since the project rename. One-word fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)