### PR TITLE
refactor: unify on the .Specify() specification idiom

### DIFF
--- a/.claude/rules/backend/cqrs.md
+++ b/.claude/rules/backend/cqrs.md
@@ -66,7 +66,7 @@ internal class GetTransactionHandler(
     public async ValueTask<Transaction> Handle(GetTransaction query, CancellationToken cancellationToken)
     {
         var entity = await transactions
-            .Apply(new TransactionDetailsSpecification())
+            .Specify(new TransactionDetailsSpecification())
             .SingleAsync(t => t.Id == query.Id, cancellationToken);
         return entity.ToModel();
     }

--- a/.claude/rules/backend/csharp.md
+++ b/.claude/rules/backend/csharp.md
@@ -57,7 +57,9 @@ paths:
 - Located in `Specifications/` folders under entity folders
 - Implement `ISpecification<T>`
 - Should be composable and reusable
-- Common examples: `FilterSpecification`, `IncludeXxxSpecification`, `SortSpecification`
+- Applied to an `IQueryable<T>` via the ASM `.Specify()` extension method
+- Naming convention for new specifications: `XxxDetailsSpecification` for an include bundle
+  (eager-loading a set of navigations), verb-named (e.g. `GetWithMembers`) for a filtered load
 
 ### Repositories
 - Interface defined in `MooBank.Domain/Entities/`

--- a/.claude/rules/backend/entity-framework.md
+++ b/.claude/rules/backend/entity-framework.md
@@ -35,7 +35,7 @@ internal class GetPlanHandler(IQueryable<ForecastPlan> plans, ...) : IQueryHandl
     public async ValueTask<ForecastPlan> Handle(GetPlan query, ...)
     {
         var plan = await plans
-            .Apply(new ForecastPlanDetailsSpecification())
+            .Specify(new ForecastPlanDetailsSpecification())
             .SingleAsync(p => p.Id == query.Id, cancellationToken);
         return plan.ToModel();
     }
@@ -73,7 +73,7 @@ internal class UpdatePlanHandler(IForecastRepository forecastRepository, ...) : 
 
 - Used for complex query logic and filtering
 - Implement `ISpecification<T>`
-- Applied via `.Apply()` extension method
+- Applied via the ASM `.Specify()` extension method
 - Common patterns:
   - `IncludeXxxSpecification` - Eager loading related entities
   - `FilterSpecification` - Filtering criteria

--- a/src/MooBank.Domain/SpecificationExtensions.cs
+++ b/src/MooBank.Domain/SpecificationExtensions.cs
@@ -1,9 +1,0 @@
-using Asm.Domain;
-
-namespace Asm.MooBank.Domain;
-
-public static class SpecificationExtensions
-{
-    public static IQueryable<T> Apply<T>(this IQueryable<T> query, ISpecification<T> specification) where T : Entity =>
-        specification.Apply(query);
-}

--- a/src/MooBank.Modules.Accounts/Queries/GetAll.cs
+++ b/src/MooBank.Modules.Accounts/Queries/GetAll.cs
@@ -17,7 +17,7 @@ internal class GetAllHandler(IQueryable<DomainLogicalAccount> logicalAccounts, U
             .Include(a => a.InstitutionAccounts)
             .Include(a => a.VirtualInstruments)
             .Include(a => a.TagPurposes)
-            .Apply(new OpenAccessibleSpecification<DomainLogicalAccount>(user.Id, user.FamilyId))
+            .Specify(new OpenAccessibleSpecification<DomainLogicalAccount>(user.Id, user.FamilyId))
             .ToModelAsync(currencyConverter, cancellationToken)).ToList();
 
         var primary = accounts.SingleOrDefault(a => a.Id == user.PrimaryAccountId);

--- a/src/MooBank.Modules.Forecast/Commands/RunForecast.cs
+++ b/src/MooBank.Modules.Forecast/Commands/RunForecast.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using Asm.MooBank.Domain;
 using Asm.MooBank.Domain.Entities.Forecast.Specifications;
 using Asm.MooBank.Modules.Forecast.Models;
@@ -18,7 +18,7 @@ internal class RunForecastHandler(
     public async ValueTask<ForecastResult> Handle(RunForecast command, CancellationToken cancellationToken)
     {
         var plan = await plans
-            .Apply(new ForecastPlanDetailsSpecification())
+            .Specify(new ForecastPlanDetailsSpecification())
             .SingleAsync(p => p.Id == command.PlanId && p.FamilyId == user.FamilyId, cancellationToken);
 
         return await forecastEngine.Calculate(plan, cancellationToken);

--- a/src/MooBank.Modules.Forecast/Queries/GetPlan.cs
+++ b/src/MooBank.Modules.Forecast/Queries/GetPlan.cs
@@ -1,4 +1,4 @@
-using Asm.MooBank.Domain;
+﻿using Asm.MooBank.Domain;
 using Asm.MooBank.Domain.Entities.Forecast.Specifications;
 using Asm.MooBank.Modules.Forecast.Models;
 using DomainEntities = Asm.MooBank.Domain.Entities.Forecast;
@@ -12,7 +12,7 @@ internal class GetPlanHandler(IQueryable<DomainEntities.ForecastPlan> plans, Moo
     public async ValueTask<Models.ForecastPlan> Handle(GetPlan query, CancellationToken cancellationToken)
     {
         var plan = await plans
-            .Apply(new ForecastPlanDetailsSpecification())
+            .Specify(new ForecastPlanDetailsSpecification())
             .SingleAsync(p => p.Id == query.Id && p.FamilyId == user.FamilyId, cancellationToken);
 
         return plan.ToModel();

--- a/src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs
+++ b/src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs
@@ -18,17 +18,17 @@ internal class GetFormattedHandler(IQueryable<Domain.Entities.Account.LogicalAcc
         var logicalAccounts1 = await logicalAccounts.Include(a => a.VirtualInstruments)
                                                             .Include(a => a.Owners).ThenInclude(a => a.Group).Include(a => a.Owners).ThenInclude(a => a.User)
                                                             .Include(a => a.Viewers).ThenInclude(a => a.Group).Include(a => a.Viewers).ThenInclude(a => a.User)
-                                      .Apply(new OpenAccessibleSpecification<Domain.Entities.Account.LogicalAccount>(user.Id, user.FamilyId))
+                                      .Specify(new OpenAccessibleSpecification<Domain.Entities.Account.LogicalAccount>(user.Id, user.FamilyId))
                                       .ToListAsync(cancellationToken);
 
         var stockHoldings1 = await stockHoldings.Include(a => a.Owners).ThenInclude(a => a.Group).Include(a => a.Owners).ThenInclude(a => a.User)
                                                 .Include(a => a.Viewers).ThenInclude(a => a.Group).Include(a => a.Viewers).ThenInclude(a => a.User)
-                                      .Apply(new OpenAccessibleSpecification<Domain.Entities.StockHolding.StockHolding>(user.Id, user.FamilyId))
+                                      .Specify(new OpenAccessibleSpecification<Domain.Entities.StockHolding.StockHolding>(user.Id, user.FamilyId))
                                       .ToListAsync(cancellationToken);
 
         var assets1 = await assets.Include(a => a.Owners).ThenInclude(a => a.Group).Include(a => a.Owners).ThenInclude(a => a.User)
                                                 .Include(a => a.Viewers).ThenInclude(a => a.Group).Include(a => a.Viewers).ThenInclude(a => a.User)
-                                      .Apply(new OpenAccessibleSpecification<Domain.Entities.Asset.Asset>(user.Id, user.FamilyId))
+                                      .Specify(new OpenAccessibleSpecification<Domain.Entities.Asset.Asset>(user.Id, user.FamilyId))
                                       .ToListAsync(cancellationToken);
 
         var allGroups = logicalAccounts1.Select(g => g.GetGroup(userId))

--- a/src/MooBank.Modules.Instruments/Queries/Instruments/GetList.cs
+++ b/src/MooBank.Modules.Instruments/Queries/Instruments/GetList.cs
@@ -12,17 +12,17 @@ internal class GetListHandler(IQueryable<Domain.Entities.Account.LogicalAccount>
     public async ValueTask<IEnumerable<ListItem<Guid>>> Handle(GetList request, CancellationToken cancellationToken = default)
     {
         var logicalAccounts1 = await logicalAccounts
-                                      .Apply(new OpenAccessibleSpecification<Domain.Entities.Account.LogicalAccount>(user.Id, user.FamilyId))
+                                      .Specify(new OpenAccessibleSpecification<Domain.Entities.Account.LogicalAccount>(user.Id, user.FamilyId))
                                       .Select(a => new ListItem<Guid> { Id = a.Id, Name = a.Name })
                                       .ToListAsync(cancellationToken);
 
         var stockHoldings1 = await stockHoldings
-                                      .Apply(new OpenAccessibleSpecification<Domain.Entities.StockHolding.StockHolding>(user.Id, user.FamilyId))
+                                      .Specify(new OpenAccessibleSpecification<Domain.Entities.StockHolding.StockHolding>(user.Id, user.FamilyId))
                                       .Select(a => new ListItem<Guid> { Id = a.Id, Name = a.Name })
                                       .ToListAsync(cancellationToken);
 
         var assets1 = await assets
-                                      .Apply(new OpenAccessibleSpecification<Domain.Entities.Asset.Asset>(user.Id, user.FamilyId))
+                                      .Specify(new OpenAccessibleSpecification<Domain.Entities.Asset.Asset>(user.Id, user.FamilyId))
                                       .Select(a => new ListItem<Guid> { Id = a.Id, Name = a.Name })
                                       .ToListAsync(cancellationToken);
 

--- a/src/MooBank.Modules.Reports/Queries/GetUserSavingsBreakdown.cs
+++ b/src/MooBank.Modules.Reports/Queries/GetUserSavingsBreakdown.cs
@@ -1,4 +1,4 @@
-using Asm.MooBank.Domain;
+﻿using Asm.MooBank.Domain;
 using Asm.MooBank.Domain.Entities.Account;
 using Asm.MooBank.Domain.Entities.Asset;
 using Asm.MooBank.Domain.Entities.Instrument.Specifications;
@@ -72,7 +72,7 @@ internal class GetUserSavingsBreakdownHandler(
         }
 
         var stocks = await stockHoldings
-            .Apply(new OpenAccessibleSpecification<StockHolding>(user.Id, user.FamilyId))
+            .Specify(new OpenAccessibleSpecification<StockHolding>(user.Id, user.FamilyId))
             .Select(s => new { s.Id, s.Name, s.CurrentValue })
             .ToListAsync(cancellationToken);
 
@@ -89,7 +89,7 @@ internal class GetUserSavingsBreakdownHandler(
         }
 
         var assetsList = await assets
-            .Apply(new OpenAccessibleSpecification<Asset>(user.Id, user.FamilyId))
+            .Specify(new OpenAccessibleSpecification<Asset>(user.Id, user.FamilyId))
             .Select(a => new { a.Id, a.Name, a.Value })
             .ToListAsync(cancellationToken);
 

--- a/src/MooBank.Modules.Reports/Queries/UserReportQuery.cs
+++ b/src/MooBank.Modules.Reports/Queries/UserReportQuery.cs
@@ -1,4 +1,4 @@
-using Asm.MooBank.Domain;
+﻿using Asm.MooBank.Domain;
 using Asm.MooBank.Domain.Entities.Account;
 using Asm.MooBank.Domain.Entities.Instrument.Specifications;
 using Asm.MooBank.Models;
@@ -34,7 +34,7 @@ internal static class UserReportScope
     public static readonly AccountType[] TransactionalTypes = [AccountType.Transaction, AccountType.Credit];
 
     public static IQueryable<LogicalAccount> AccessibleTo(this IQueryable<LogicalAccount> accounts, User user) =>
-        accounts.Apply(new OpenAccessibleSpecification<LogicalAccount>(user.Id, user.FamilyId));
+        accounts.Specify(new OpenAccessibleSpecification<LogicalAccount>(user.Id, user.FamilyId));
 
     public static IQueryable<LogicalAccount> Transactional(this IQueryable<LogicalAccount> accounts) =>
         accounts.Where(a => TransactionalTypes.Contains(a.AccountType));


### PR DESCRIPTION
## Summary

First slice of Theme 4 (backend) from the [architecture remediation plan](.claude/plans/architecture-remediation.md) — the mechanical, no-judgement part, kept separate for easy review.

The codebase had **two extension methods for one concept**: MooBank's local `.Apply()` (`MooBank.Domain/SpecificationExtensions.cs`) and ASM's `.Specify()` (already used at 9 sites). They have identical signatures. Deleted the local extension and converted the 12 `.Apply(new ...Specification())` call sites to `.Specify()`. Rules docs (`cqrs.md`, `entity-framework.md`, `csharp.md`) updated, including a documented naming convention for new specifications.

## Verification
- Build clean, 2,005 passed / 0 failed, OpenAPI unchanged.
- `grep .Apply(` in src → 0 remaining.

## The rest of Theme 4 backend (separate PRs)
The plan's other Theme 4 backend items are genuinely different in risk and will land as their own PRs so each is reviewable in isolation:
- **Events into aggregates** + unify the balance-adjustment mechanism (+ the two hand-rolled `BindAsync` in the VirtualInstruments commands, since they touch the same files).
- **Budgets `Generate` refactor** (the five-`IQueryable` command → repository + specification + reader).
- **Audit all user mutations** — switching ~53 handlers to `IAuditingUnitOfWork`. This one needs a meaningful `(action, entityType, entityId)` per handler (not a mechanical type swap), so it warrants its own focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)