### PR TITLE
fix: small alignments — exchange-rate precision, import error propagation, route errors

### DIFF
--- a/src/MooBank.Database/dbo/Tables/ExchangeRates.sql
+++ b/src/MooBank.Database/dbo/Tables/ExchangeRates.sql
@@ -3,7 +3,7 @@
 	[Id] INT IDENTITY(1,1),
     [From] CHAR(3) NOT NULL,
     [To] CHAR(3) NOT NULL,
-    [Rate] DECIMAL(10, 4) NOT NULL,
+    [Rate] DECIMAL(12, 4) NOT NULL,
     [ReverseRate] AS 1.0/[Rate],
     [LastUpdated] DATETIME2 NOT NULL CONSTRAINT DF_ExchangeRate_DateTime DEFAULT SYSUTCDATETIME(),
     CONSTRAINT PK_ExchangeRate PRIMARY KEY (Id),

--- a/src/MooBank.Web.App/src/App.tsx
+++ b/src/MooBank.Web.App/src/App.tsx
@@ -4,6 +4,7 @@ import "utils/chartSetup";
 import { MooApp } from "@andrewmclachlan/moo-app";
 import { createRouter } from "@tanstack/react-router";
 import { Spinner } from "@andrewmclachlan/moo-ds";
+import { RouteError } from "components";
 import { routeTree } from "./routeTree.gen.ts";
 import { client } from "./api/client.gen";
 import { createIDBPersister, shouldPersistQuery } from "utils/queryPersister";
@@ -24,6 +25,7 @@ export const App = () => {
         defaultPreloadStaleTime: 0,
         scrollRestoration: true,
         defaultPendingComponent: Spinner,
+        defaultErrorComponent: RouteError,
     })
 
     return (

--- a/src/MooBank.Web.App/src/components/RouteError.tsx
+++ b/src/MooBank.Web.App/src/components/RouteError.tsx
@@ -1,0 +1,13 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export interface RouteErrorProps {
+    error?: Error;
+}
+
+export const RouteError: React.FC<RouteErrorProps> = ({ error }) => (
+    <div className="widget-error route-error">
+        <FontAwesomeIcon icon="triangle-exclamation" className="widget-error-icon" />
+        <div className="widget-error-message">Something went wrong. Try reloading the page.</div>
+        {import.meta.env.DEV && error?.message && <pre className="route-error-detail">{error.message}</pre>}
+    </div>
+);

--- a/src/MooBank.Web.App/src/components/index.ts
+++ b/src/MooBank.Web.App/src/components/index.ts
@@ -12,6 +12,7 @@ export * from "./InstrumentPage";
 export * from "./FormRow";
 export * from "./MonthSelector";
 export * from "./PeriodSelector";
+export * from "./RouteError";
 export * from "./TransactionSearch";
 export * from "./TransactionListProvider";
 export * from "./TagPanel";

--- a/src/MooBank/Services/ImportTransactionsService.cs
+++ b/src/MooBank/Services/ImportTransactionsService.cs
@@ -41,7 +41,10 @@ internal class ImportTransactionsService(IInstrumentRepository instrumentReposit
         }
         catch (Exception ex)
         {
+            // Log the rich context here, then rethrow so the failure isn't silently swallowed —
+            // the background queue loop catches it to stay alive (matching RunRulesService).
             logger.LogError(ex, "Error occurred importing transactions for instrument {InstrumentId}, account {AccountId}. File size: {FileSize} bytes.", workItem.InstrumentId, workItem.AccountId, workItem.FileData.Length);
+            throw;
         }
     }
 

--- a/tests/MooBank.Core.Tests/Services/ImportTransactionsServiceTests.cs
+++ b/tests/MooBank.Core.Tests/Services/ImportTransactionsServiceTests.cs
@@ -330,7 +330,7 @@ public class ImportTransactionsServiceTests
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Import_WhenInstrumentNotFound_DoesNotThrow()
+    public async Task Import_WhenInstrumentNotFound_Propagates()
     {
         // Arrange
         var workItem = CreateWorkItem();
@@ -342,10 +342,9 @@ public class ImportTransactionsServiceTests
 
         var service = CreateService();
 
-        // Act - Should complete without throwing
-        await service.Import(workItem, TestContext.Current.CancellationToken);
+        // Act & Assert - the failure propagates so the queue loop can log it and move on
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Import(workItem, TestContext.Current.CancellationToken));
 
-        // Assert - Save should not be called since we hit an error
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -356,7 +355,7 @@ public class ImportTransactionsServiceTests
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Import_WhenImporterNotSupported_DoesNotThrow()
+    public async Task Import_WhenImporterNotSupported_Propagates()
     {
         // Arrange
         var workItem = CreateWorkItem();
@@ -369,10 +368,9 @@ public class ImportTransactionsServiceTests
 
         var service = CreateService();
 
-        // Act - Should complete without throwing
-        await service.Import(workItem, TestContext.Current.CancellationToken);
+        // Act & Assert - the failure propagates so the queue loop can log it and move on
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Import(workItem, TestContext.Current.CancellationToken));
 
-        // Assert - Save should not be called since we hit an error
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -383,7 +381,7 @@ public class ImportTransactionsServiceTests
     /// </summary>
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Import_WhenImporterThrows_DoesNotThrow()
+    public async Task Import_WhenImporterThrows_Propagates()
     {
         // Arrange
         var workItem = CreateWorkItem();
@@ -397,10 +395,9 @@ public class ImportTransactionsServiceTests
 
         var service = CreateService();
 
-        // Act - Should complete without throwing
-        await service.Import(workItem, TestContext.Current.CancellationToken);
+        // Act & Assert - the failure propagates so the queue loop can log it and move on
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await service.Import(workItem, TestContext.Current.CancellationToken));
 
-        // Assert - Save should not be called since we hit an error
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 


### PR DESCRIPTION
## Summary

The tail-end alignments from Theme 7 of the [architecture remediation plan](.claude/plans/architecture-remediation.md) (the TVP report SPs were already delivered earlier, so this is what remained).

- **ExchangeRate precision drift**: the `Rate` column was `DECIMAL(10,4)` while the entity declares `[Precision(12,4)]`. Aligned the SQL to `DECIMAL(12,4)` (widening, safe).
- **Import error handling**: `ImportTransactionsService` swallowed all import failures, making them invisible to any caller — inconsistent with `RunRulesService`, which rethrows. It now logs the rich context (instrument, account, file size) and rethrows. The background queue loop already has a per-item try/catch, so it stays alive and logs; the failure is no longer silently dropped. Three tests retargeted from `DoesNotThrow` to `Propagates`.
- **Router error component**: added `defaultErrorComponent` (a small `RouteError`) to the router, symmetric to the existing `defaultPendingComponent: Spinner`. `WidgetError` stays for dashboard widgets.

## Verification
- `dotnet build MooBank.slnx` clean; Core tests green.
- `npm run build` clean; `npm run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)