### PR TITLE
fix: display amounts in the correct currency

### DIFF
--- a/src/MooBank.Web.App/src/css/transactions/transactionsHeader.css
+++ b/src/MooBank.Web.App/src/css/transactions/transactionsHeader.css
@@ -54,12 +54,19 @@
         margin-top: 6px;
     }
 
+    .hero-balance-local {
+        font-size: 1.5rem;
+        letter-spacing: -1.8px;
+        margin-top: 6px;
+        font-weight: 600;
+    }
+
     .hero-subline {
-        font-size: 12px;
+        font-size: 0.8rem;
         color: var(--body-colour-dim);
         margin-top: 6px;
 
-        .strong { color: var(--body-colour); }
+        strong { color: var(--body-colour); font-weight: normal; }
         .sep { margin: 0 8px; opacity: 0.4; }
     }
 

--- a/src/MooBank.Web.App/src/routes/-dashboard/Forecast.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Forecast.tsx
@@ -6,6 +6,7 @@ import { Line } from "react-chartjs-2";
 import { useChartColours } from "utils/chartColours";
 import { formatCurrency } from "utils/currency";
 import { WidgetError } from "components/WidgetError";
+import { useUser } from "hooks/useUser";
 import { useForecastPlans } from "../forecast/-hooks/useForecastPlans";
 import { useForecastPlan } from "../forecast/-hooks/useForecastPlan";
 import { useForecastResult } from "../forecast/-hooks/useForecastResult";
@@ -19,9 +20,13 @@ export const ForecastWidget: React.FC = () => {
     const plan = plans?.[0];
     const planId = plan?.id ?? "";
 
-    const { isError: planError } = useForecastPlan(planId);
+    const { data: fullPlan, isError: planError } = useForecastPlan(planId);
     const { data: result, isFetching, isError: runError } = useForecastResult(planId);
+    const { data: user } = useUser();
     const colours = useChartColours();
+
+    // The forecast is denominated in the plan's currency, falling back to the user's preferred currency.
+    const currencyCode = fullPlan?.currencyCode ?? user?.currency ?? "AUD";
 
     // No forecast plan exists at all - don't render the widget
     if (!plansLoading && !plansError && plans && plans.length === 0) {
@@ -80,7 +85,7 @@ export const ForecastWidget: React.FC = () => {
                 callbacks: {
                     label: (context) => {
                         const value = context.parsed.y;
-                        return `${context.dataset.label}: ${formatCurrency(value)}`;
+                        return `${context.dataset.label}: ${formatCurrency(value, currencyCode)}`;
                     },
                 },
             },
@@ -89,7 +94,7 @@ export const ForecastWidget: React.FC = () => {
             y: {
                 grid: { color: colours.grid },
                 ticks: {
-                    callback: (value) => formatCurrency(Number(value), "AUD", 0),
+                    callback: (value) => formatCurrency(Number(value), currencyCode, 0),
                 },
             },
             x: {

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/components/TransactionsAccountCard.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/components/TransactionsAccountCard.tsx
@@ -7,26 +7,33 @@ import { formatDisplayDate } from "utils/dateFns";
 
 import { usePeriodLabel } from "../hooks/usePeriodLabel";
 import { useTransactionPeriodStats } from "../hooks/useTransactionPeriodStats";
+import { useUser } from "hooks/useUser";
 
 export const TransactionsAccountCard: React.FC = () => {
 
     const account = useAccount();
+    const { data: user } = useUser();
     const stats = useTransactionPeriodStats(account?.id ?? "");
     const periodLabel = usePeriodLabel();
 
     if (!account) return null;
 
-    const balance = (account as LogicalAccount).currentBalanceLocalCurrency ?? account.currentBalance ?? 0;
+    const balance = (account as LogicalAccount).currentBalance ?? 0;
     const instrumentType = (account as LogicalAccount).instrumentType ?? "Virtual";
 
     return (
         <Section className="tx-account-card accent-stripe">
             <div className="eyebrow">{account.name} · Balance</div>
             <div className="hero-balance"><Amount amount={balance} currencyCode={account.currency} minus /></div>
+            {account.currentBalanceLocalCurrency && account.currentBalanceLocalCurrency !== balance && (
+                <div className="hero-balance-local">
+                    <Amount amount={account.currentBalanceLocalCurrency} currencyCode={user?.currency} minus />
+                </div>
+            )}
             <div className="hero-subline">
-                Last transaction <span className="strong">{formatDisplayDate(account.lastTransaction)}</span>
+                Last transaction <strong>{formatDisplayDate(account.lastTransaction)}</strong>
                 <span className="sep">·</span>
-                Type <span className="strong">{instrumentType}</span>
+                Type <strong>{instrumentType}</strong>
             </div>
 
             <div className="period-block">

--- a/src/MooBank.Web.App/src/routes/forecast/-components/ForecastChart.tsx
+++ b/src/MooBank.Web.App/src/routes/forecast/-components/ForecastChart.tsx
@@ -10,9 +10,10 @@ import { formatCurrency } from "utils/currency";
 
 interface ForecastChartProps {
     months: ForecastMonth[];
+    currencyCode: string;
 }
 
-export const ForecastChart: React.FC<ForecastChartProps> = ({ months }) => {
+export const ForecastChart: React.FC<ForecastChartProps> = ({ months, currencyCode }) => {
 
     const labels = months.map(m => format(parseISO(m.monthStart), "MMM yy"));
 
@@ -59,7 +60,7 @@ export const ForecastChart: React.FC<ForecastChartProps> = ({ months }) => {
         scales: {
             y: {
                 ticks: {
-                    callback: (value) => formatCurrency(Number(value), "AUD", 0)
+                    callback: (value) => formatCurrency(Number(value), currencyCode, 0)
                 }
             }
         }

--- a/src/MooBank.Web.App/src/routes/forecast/-components/ForecastSettings.tsx
+++ b/src/MooBank.Web.App/src/routes/forecast/-components/ForecastSettings.tsx
@@ -12,9 +12,10 @@ interface ForecastSettingsProps {
     plan?: ForecastPlan;
     monthlyExpenses?: number;
     regression?: RegressionDiagnostics;
+    currencyCode: string;
 }
 
-export const ForecastSettings: React.FC<ForecastSettingsProps> = ({ plan, monthlyExpenses, regression }) => {
+export const ForecastSettings: React.FC<ForecastSettingsProps> = ({ plan, monthlyExpenses, regression, currencyCode }) => {
     const [isEditing, setIsEditing] = useState(false);
     const [name, setName] = useState(plan?.name);
     const [startDate, setStartDate] = useState(plan?.startDate);
@@ -104,7 +105,7 @@ export const ForecastSettings: React.FC<ForecastSettingsProps> = ({ plan, monthl
                         <div className="settings-item">
                             <div className="settings-label">Monthly Income</div>
                             <div className="settings-value">
-                                <Amount amount={plan?.incomeStrategy?.manualRecurring?.amount ?? 0} currencyCode="AUD" minus />
+                                <Amount amount={plan?.incomeStrategy?.manualRecurring?.amount ?? 0} currencyCode={currencyCode} minus />
                             </div>
                         </div>
                     </Col>
@@ -112,7 +113,7 @@ export const ForecastSettings: React.FC<ForecastSettingsProps> = ({ plan, monthl
                         <div className="settings-item">
                             <div className="settings-label">Monthly Expenses</div>
                             <div className="settings-value">
-                                <Amount amount={monthlyExpenses ?? 0} currencyCode="AUD" minus />
+                                <Amount amount={monthlyExpenses ?? 0} currencyCode={currencyCode} minus />
                             </div>
                             <div className="settings-sublabel">
                                 {plan?.outgoingStrategy?.mode === "IncomeCorrelated" && regression && !regression.fellBackToFlatAverage ? (

--- a/src/MooBank.Web.App/src/routes/forecast/-components/ForecastSummaryPanel.tsx
+++ b/src/MooBank.Web.App/src/routes/forecast/-components/ForecastSummaryPanel.tsx
@@ -6,9 +6,10 @@ import { Amount } from "components";
 
 interface ForecastSummaryPanelProps {
     summary: ForecastSummary;
+    currencyCode: string;
 }
 
-export const ForecastSummaryPanel: React.FC<ForecastSummaryPanelProps> = ({ summary }) => {
+export const ForecastSummaryPanel: React.FC<ForecastSummaryPanelProps> = ({ summary, currencyCode }) => {
     const lowestBalanceDate = summary && parseISO(summary?.lowestBalanceMonth);
 
     return (
@@ -18,7 +19,7 @@ export const ForecastSummaryPanel: React.FC<ForecastSummaryPanelProps> = ({ summ
                     <div className="summary-card">
                         <div className="summary-label">Lowest Balance</div>
                         <div className={`summary-value ${summary?.lowestBalance < 0 ? 'negative' : ''}`}>
-                            <Amount amount={summary?.lowestBalance} currencyCode="AUD" minus />
+                            <Amount amount={summary?.lowestBalance} currencyCode={currencyCode} minus />
                         </div>
                         <div className="summary-sublabel">
                            {summary && `in ${format(lowestBalanceDate, "MMMM yyyy")}`}
@@ -29,7 +30,7 @@ export const ForecastSummaryPanel: React.FC<ForecastSummaryPanelProps> = ({ summ
                     <div className="summary-card">
                         <div className="summary-label">Required Monthly Uplift</div>
                         <div className={`summary-value ${summary?.requiredMonthlyUplift > 0 ? 'negative' : ''}`}>
-                            <Amount amount={summary?.requiredMonthlyUplift} currencyCode="AUD" minus />
+                            <Amount amount={summary?.requiredMonthlyUplift} currencyCode={currencyCode} minus />
                         </div>
                         <div className="summary-sublabel">
                             {summary?.requiredMonthlyUplift > 0 ? 'to avoid negative balance' : 'no uplift required'}
@@ -53,7 +54,7 @@ export const ForecastSummaryPanel: React.FC<ForecastSummaryPanelProps> = ({ summ
                     <div className="summary-card">
                         <div className="summary-label">Total Projected Income</div>
                         <div className="summary-value">
-                            <Amount amount={summary?.totalIncome} currencyCode="AUD" minus />
+                            <Amount amount={summary?.totalIncome} currencyCode={currencyCode} minus />
                         </div>
                     </div>
                 </Col>
@@ -61,7 +62,7 @@ export const ForecastSummaryPanel: React.FC<ForecastSummaryPanelProps> = ({ summ
                     <div className="summary-card">
                         <div className="summary-label">Total Projected Outgoings</div>
                         <div className="summary-value">
-                            <Amount amount={summary?.totalOutgoings} currencyCode="AUD" minus />
+                            <Amount amount={summary?.totalOutgoings} currencyCode={currencyCode} minus />
                         </div>
                     </div>
                 </Col>

--- a/src/MooBank.Web.App/src/routes/forecast/-components/PlannedItemsTable.tsx
+++ b/src/MooBank.Web.App/src/routes/forecast/-components/PlannedItemsTable.tsx
@@ -10,9 +10,10 @@ import { Amount } from "components";
 
 interface PlannedItemsTableProps {
     plan?: ForecastPlan;
+    currencyCode: string;
 }
 
-export const PlannedItemsTable: React.FC<PlannedItemsTableProps> = ({ plan }) => {
+export const PlannedItemsTable: React.FC<PlannedItemsTableProps> = ({ plan, currencyCode }) => {
 
     const items = plan?.plannedItems ?? [];
     const planId = plan?.id;
@@ -22,8 +23,8 @@ export const PlannedItemsTable: React.FC<PlannedItemsTableProps> = ({ plan }) =>
 
     return (
         <>
-            <PlannedItemsSection planId={planId} title="Planned Income" items={incomeItems} itemType="Income" />
-            <PlannedItemsSection planId={planId} title="Planned Expenses" items={expenseItems} itemType="Expense" />
+            <PlannedItemsSection planId={planId} title="Planned Income" items={incomeItems} itemType="Income" currencyCode={currencyCode} />
+            <PlannedItemsSection planId={planId} title="Planned Expenses" items={expenseItems} itemType="Expense" currencyCode={currencyCode} />
         </>
     );
 };
@@ -33,9 +34,10 @@ interface PlannedItemsSectionProps {
     title: string;
     items: PlannedItem[];
     itemType: "Income" | "Expense";
+    currencyCode: string;
 }
 
-const PlannedItemsSection: React.FC<PlannedItemsSectionProps> = ({ planId, title, items, itemType }) => {
+const PlannedItemsSection: React.FC<PlannedItemsSectionProps> = ({ planId, title, items, itemType, currencyCode }) => {
     return (
         <SectionTable header={title} striped>
             <thead>
@@ -58,7 +60,7 @@ const PlannedItemsSection: React.FC<PlannedItemsSectionProps> = ({ planId, title
             <tfoot>
                 <tr>
                     <td>Total</td>
-                    <td className="amount"><Amount amount={items.reduce((sum, i) => sum + (i.isIncluded ? i.amount : 0), 0)} currencyCode="AUD" minus /></td>
+                    <td className="amount"><Amount amount={items.reduce((sum, i) => sum + (i.isIncluded ? i.amount : 0), 0)} currencyCode={currencyCode} minus /></td>
                     <td colSpan={5}></td>
                 </tr>
             </tfoot>

--- a/src/MooBank.Web.App/src/routes/forecast/index.tsx
+++ b/src/MooBank.Web.App/src/routes/forecast/index.tsx
@@ -6,6 +6,7 @@ import { useForecastPlans } from "./-hooks/useForecastPlans";
 import { useForecastPlan } from "./-hooks/useForecastPlan";
 import { useForecastResult } from "./-hooks/useForecastResult";
 import { useAccounts } from "hooks/useAccounts";
+import { useUser } from "hooks/useUser";
 import { ForecastPage } from "./-components/ForecastPage";
 import { ForecastChart } from "./-components/ForecastChart";
 import { ForecastSummaryPanel } from "./-components/ForecastSummaryPanel";
@@ -22,6 +23,7 @@ function Forecast() {
 
     const { data: plans, isLoading: plansLoading } = useForecastPlans();
     const { data: accounts, isLoading: accountsLoading } = useAccounts();
+    const { data: user } = useUser();
 
     // Set planId when plans are loaded and one exists
     useEffect(() => {
@@ -32,6 +34,9 @@ function Forecast() {
 
     const { data: plan, isLoading: planLoading } = useForecastPlan(planId);
     const { data: result, isFetching: resultLoading } = useForecastResult(planId);
+
+    // The forecast is denominated in the plan's currency, falling back to the user's preferred currency.
+    const currencyCode = plan?.currencyCode ?? user?.currency ?? "AUD";
 
     // Loading state
     if (plansLoading || accountsLoading) {
@@ -55,15 +60,15 @@ function Forecast() {
         <ForecastPage>
             {(
                 <>
-                    <ForecastSettings plan={plan} monthlyExpenses={result?.summary.monthlyBaselineOutgoings} regression={result?.summary.regression} />
+                    <ForecastSettings plan={plan} monthlyExpenses={result?.summary.monthlyBaselineOutgoings} regression={result?.summary.regression} currencyCode={currencyCode} />
 
-                    <ForecastSummaryPanel summary={result?.summary} />
+                    <ForecastSummaryPanel summary={result?.summary} currencyCode={currencyCode} />
                     <div>
-                        <ForecastChart months={result?.months ?? []} />
+                        <ForecastChart months={result?.months ?? []} currencyCode={currencyCode} />
                         {resultLoading && (<SpinnerContainer />)}
                     </div>
 
-                    <PlannedItemsTable plan={plan} />
+                    <PlannedItemsTable plan={plan} currencyCode={currencyCode} />
                 </>
             )}
 


### PR DESCRIPTION
## Summary

Fixes amounts being shown in the wrong currency for non-default-currency accounts and across the forecast feature.

- **Balances** (`d88917f7`): account balances now display in their own currency rather than the default.
- **Forecast** (`01009390`): the forecast page and dashboard forecast widget rendered every amount with a hard-coded `"AUD"`. They now derive the currency as **plan currency → user's preferred currency → `"AUD"` fallback** and thread it through all forecast components.

## Forecast detail

`forecast/index.tsx` derives:

```ts
const currencyCode = plan?.currencyCode ?? user?.currency ?? "AUD";
```

and passes it to `ForecastSettings`, `ForecastSummaryPanel`, `ForecastChart`, and `PlannedItemsTable`. The dashboard `ForecastWidget` does the same via `useUser` + the first plan. This also fixes the dashboard tooltip callback, which had been silently defaulting to AUD (`formatCurrency(value)` with no currency argument).

## Verification

- `npm run build` passes
- ESLint clean on touched files (0 errors; pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)