### PR TITLE
test(web): Vitest + RTL frontend harness with comprehensive unit suite (#882)

### DIFF
--- a/.claude/rules/testing/frontend.md
+++ b/.claude/rules/testing/frontend.md
@@ -7,24 +7,40 @@ paths:
 
 # Frontend Testing Guidelines
 
-## Component Tests
+## Component / Unit Tests
 
-### Scope
-**Only test shared components** in `src/components/` that are used across multiple routes. Do not write tests for route-specific components.
+### Harness
+The Vitest + React Testing Library harness lives in `src/MooBank.Web.App`:
+- `vitest.config.ts` — standalone config (jsdom, `globals: true`, `resolve.tsconfigPaths` for bare
+  imports). It deliberately does **not** import `vite.config.ts`, whose top-level code generates
+  dev certificates via `dotnet dev-certs` (unavailable in CI).
+- `src/test/setup.ts` — registers `@testing-library/jest-dom` and cleans up after each test.
+- `src/test/matchers.d.ts` — makes the jest-dom matcher types visible to `tsgo`.
+- Scripts: `npm test` (`vitest run`), `npm run test:watch`, `npm run test:coverage`.
+- Test files (`*.test.ts[x]`) stay under `src/` and are type-checked by the production `tsgo` build,
+  so they must remain type-correct.
 
 ### Framework
 - **Vitest** - Test runner (Vite-native)
 - **React Testing Library** - Component testing
 
+### Scope — test by value, not by folder
+Write a test when it covers **genuinely high-value logic** and gives a fast, deterministic signal.
+That value, not a component's location, decides whether it is worth testing.
+
 ### What to Test
-- Shared components in `src/components/`
-- Custom hooks in `src/hooks/` with complex logic
-- Utility functions in `src/utils/`
+- Shared components in `src/components/` and hooks in `src/hooks/` with real logic
+- Utility functions in `src/utils/` (`currency.ts`, date helpers, key builders)
+- **High-value route-level logic** — a route component or co-located `-hooks/`/`-components/` file is
+  fair game when it carries real branching worth pinning. Examples that exist today:
+  `routes/accounts/-transactions/components/AddTransaction.tsx` (amount vs new-balance routing,
+  blank→undefined, Save enablement) and `routes/accounts/-hooks/transactionKeys.ts` (partial-key
+  matching). Mock the generated `@hey-api`/React Query hooks; provide context via the real providers.
 
 ### What NOT to Test
-- Route components and their co-located `-components/` (`src/routes/**`)
-- Simple wrapper components
-- Components only used in one place
+- Trivial wrapper components with no branching
+- Generated code (`src/api/**`, `src/routeTree.gen.ts`)
+- Purely presentational markup with no logic
 
 ### Running Component Tests
 ```bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,32 @@ jobs:
         name: coverage-${{ matrix.test-project.name }}
         path: testresults/${{ matrix.test-project.name }}/**/coverage.cobertura.xml
 
+  test-frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: read
+      contents: read
+    steps:
+    - uses: actions/checkout@v7
+    - name: Setup node and npm
+      uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: npm
+        cache-dependency-path: 'src/MooBank.Web.App/package-lock.json'
+        registry-url: "https://npm.pkg.github.com"
+    - name: Install App dependencies
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.CROSS_REPO_PACKAGE_TOKEN }}
+      run: npm ci --prefix src/MooBank.Web.App --force
+    - name: Test App
+      run: npm run test:coverage --prefix src/MooBank.Web.App
+    - name: Upload frontend coverage
+      uses: actions/upload-artifact@v7.0.1
+      with:
+        name: coverage-frontend
+        path: src/MooBank.Web.App/coverage/cobertura-coverage.xml
+
   coverage-report:
     runs-on: ubuntu-latest
     needs: test
@@ -165,7 +191,7 @@ jobs:
 
   docker-push:
     runs-on: ubuntu-latest
-    needs: [build, test]
+    needs: [build, test, test-frontend]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     permissions:
       packages: write
@@ -199,7 +225,7 @@ jobs:
     concurrency:
       group: moobank-deploy-group
       cancel-in-progress: true
-    needs: [build, test, docker-push]
+    needs: [build, test, test-frontend, docker-push]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/deploy-azure.yml@v4
     with:

--- a/src/MooBank.Web.App/CLAUDE.md
+++ b/src/MooBank.Web.App/CLAUDE.md
@@ -117,7 +117,7 @@ See `routes/settings/institutions/-components/InstitutionForm.tsx`. Validation g
 
 ### Critical Rules
 
-**NEVER use Bootstrap's utility CSS classes** such as:
+This app does **not** use Bootstrap (or any utility-CSS framework) — MooDS ships its own components and styles. Do not reach for atomic/utility class names; they are not defined and do nothing. **NEVER use utility CSS classes** such as:
 - `d-flex`, `d-block`, `d-none`, etc.
 - `justify-content-*`, `align-items-*`, `flex-*`
 - `m-*`, `mb-*`, `mt-*`, `mx-*`, `my-*` (margin utilities)
@@ -139,7 +139,7 @@ See `routes/settings/institutions/-components/InstitutionForm.tsx`. Validation g
 - Action columns: `row-action`
 - Negative values: `negative` class; amount formatting: `amount` class
 - Use nested CSS for component-scoped styles
-- Prefer CSS Grid over Bootstrap's grid system for layouts
+- Prefer CSS Grid for layouts
 
 ## Component Usage (moo-ds)
 

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -20,7 +20,6 @@
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-persist-client": "^5.101.2",
         "@tanstack/react-router": "^1.170.16",
-        "bootstrap": "^5.3.7",
         "chart.js": "^4.5.1",
         "chartjs-plugin-annotation": "^3.1.0",
         "chartjs-plugin-trendline": "^3.2.4",
@@ -3276,17 +3275,6 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
@@ -6022,23 +6010,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -46,6 +46,9 @@
         "@hey-api/openapi-ts": "^0.99.0",
         "@svgr/plugin-svgo": "^8.1.0",
         "@tanstack/router-plugin": "^1.168.19",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@tybys/wasm-util": "0.10.3",
         "@types/chartjs-plugin-trendline": "^1.0.1",
         "@types/md5": "^2.3.6",
@@ -54,16 +57,19 @@
         "@types/react-dom": "^19.2.3",
         "@typescript/native-preview": "^7.0.0-dev.20260706.1",
         "@vitejs/plugin-react": "^6.0.3",
+        "@vitest/coverage-v8": "^4.1.10",
         "esbuild": "^0.28.1",
         "eslint": "^10.6.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.7.0",
+        "jsdom": "^29.1.1",
         "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.63.0",
         "vite": "^8.1.3",
         "vite-plugin-pwa": "^1.3.0",
-        "vite-plugin-svgr": "^5.2.0"
+        "vite-plugin-svgr": "^5.2.0",
+        "vitest": "^4.1.10"
       },
       "optionalDependencies": {
         "@esbuild/linux-arm64": "0.28.1",
@@ -77,6 +83,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@andrewmclachlan/moo-app": {
       "version": "5.1.234",
@@ -139,6 +152,78 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@azure/msal-browser": {
       "version": "5.16.0",
@@ -1755,6 +1840,165 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@bramus/specificity/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -2527,6 +2771,24 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
@@ -2851,7 +3113,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3769,6 +4033,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "dev": true,
@@ -4303,6 +4574,96 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {
       "version": "3.0.0-pre1",
       "resolved": "https://registry.npmjs.org/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz",
@@ -4329,6 +4690,25 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chartjs-plugin-trendline": {
       "version": "1.0.4",
       "dev": true,
@@ -4339,6 +4719,13 @@
     },
     "node_modules/@types/chartjs-plugin-trendline/node_modules/chart.js": {
       "version": "3.9.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4876,6 +5263,160 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -5224,6 +5765,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -5269,6 +5820,45 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -5402,6 +5992,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -5656,6 +6256,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5991,6 +6601,13 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csso": {
       "version": "5.0.5",
       "dev": true,
@@ -6025,6 +6642,58 @@
       "version": "3.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -6104,6 +6773,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -6206,6 +6882,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -6268,6 +6954,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -6543,8 +7237,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -7098,6 +7791,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -7843,6 +8546,26 @@
         "@babel/runtime": "^7.7.6"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -7894,6 +8617,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -8277,6 +9010,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8482,6 +9222,58 @@
       "version": "2.0.0",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -8566,6 +9358,141 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsesc": {
@@ -9003,6 +9930,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -9011,6 +9949,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -9086,6 +10052,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9220,6 +10196,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -9347,6 +10337,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -9603,6 +10619,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "license": "MIT",
@@ -9768,6 +10814,14 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-toastify": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.1.0.tgz",
@@ -9799,6 +10853,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -10215,6 +11283,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "license": "MIT"
@@ -10432,6 +11513,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10511,6 +11599,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10703,6 +11805,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -10770,6 +11885,13 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "1.1.3",
@@ -10926,6 +12048,23 @@
       "version": "0.2.0",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10972,6 +12111,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "license": "MIT",
@@ -10980,6 +12149,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -11176,6 +12358,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -11491,6 +12683,122 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -11649,6 +12957,16 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
@@ -11761,6 +13079,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workbox-background-sync": {
@@ -12198,6 +13533,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -66,6 +66,9 @@
     "@hey-api/openapi-ts": "^0.99.0",
     "@svgr/plugin-svgo": "^8.1.0",
     "@tanstack/router-plugin": "^1.168.19",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@tybys/wasm-util": "0.10.3",
     "@types/chartjs-plugin-trendline": "^1.0.1",
     "@types/md5": "^2.3.6",
@@ -74,16 +77,19 @@
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "^7.0.0-dev.20260706.1",
     "@vitejs/plugin-react": "^6.0.3",
+    "@vitest/coverage-v8": "^4.1.10",
     "esbuild": "^0.28.1",
     "eslint": "^10.6.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
+    "jsdom": "^29.1.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.1.3",
     "vite-plugin-pwa": "^1.3.0",
-    "vite-plugin-svgr": "^5.2.0"
+    "vite-plugin-svgr": "^5.2.0",
+    "vitest": "^4.1.10"
   },
   "scripts": {
     "start": "vite --host",
@@ -93,6 +99,9 @@
     "trace": "tsgo --traceresolution",
     "generate": "openapi-ts",
     "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "update-moo": "npm install @andrewmclachlan/moo-app@latest @andrewmclachlan/moo-ds@latest @andrewmclachlan/moo-icons@latest"
   },
   "browserslist": {

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -25,7 +25,6 @@
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-query-persist-client": "^5.101.2",
     "@tanstack/react-router": "^1.170.16",
-    "bootstrap": "^5.3.7",
     "chart.js": "^4.5.1",
     "chartjs-plugin-annotation": "^3.1.0",
     "chartjs-plugin-trendline": "^3.2.4",

--- a/src/MooBank.Web.App/src/components/AccountTypeBadge.test.tsx
+++ b/src/MooBank.Web.App/src/components/AccountTypeBadge.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AccountTypeBadge } from "components/AccountTypeBadge";
+
+describe("AccountTypeBadge", () => {
+    it.each([
+        ["Transaction", "bg-blue"],
+        ["Savings", "bg-emerald"],
+        ["Credit", "bg-orange"],
+        ["Mortgage", "bg-rose"],
+        ["Loan", "bg-pink"],
+        ["Superannuation", "bg-indigo"],
+        ["Investment", "bg-teal"],
+        ["Broker", "bg-purple"],
+        ["Asset", "bg-amber"],
+        ["Shares", "bg-cyan"],
+        ["Virtual", "bg-slate"],
+        ["Reserved Sum", "bg-neutral"],
+    ])("renders %s with hue class %s", (type, hueClass) => {
+        render(<AccountTypeBadge type={type} />);
+        const badge = screen.getByText(type);
+        expect(badge).toHaveClass(hueClass);
+    });
+
+    it("falls back to the secondary badge for an unrecognised type", () => {
+        render(<AccountTypeBadge type="SomethingUnknown" />);
+        const badge = screen.getByText("SomethingUnknown");
+        expect(badge).toHaveClass("bg-secondary");
+    });
+
+    it("renders nothing when type is null", () => {
+        const { container } = render(<AccountTypeBadge type={null} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when type is undefined", () => {
+        const { container } = render(<AccountTypeBadge type={undefined} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it("renders nothing when type is an empty string", () => {
+        const { container } = render(<AccountTypeBadge type="" />);
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/src/MooBank.Web.App/src/components/Amount.test.tsx
+++ b/src/MooBank.Web.App/src/components/Amount.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { Amount } from "components/Amount";
+
+const renderAmount = (props: React.ComponentProps<typeof Amount>) => {
+    const { container } = render(<Amount {...props} />);
+    return container.querySelector("span.amount")!;
+};
+
+describe("Amount", () => {
+    it("renders a positive amount with two decimal places by default", () => {
+        const el = renderAmount({ amount: 42 });
+        expect(el).toHaveTextContent("42.00");
+        expect(el).toHaveClass("amount");
+        expect(el).not.toHaveClass("negative");
+        expect(el).not.toHaveClass("positive");
+    });
+
+    it("renders a negative amount as its absolute value without a sign by default", () => {
+        const el = renderAmount({ amount: -42 });
+        expect(el).toHaveTextContent("42.00");
+        expect(el).not.toHaveTextContent("-42.00");
+    });
+
+    it("applies the negative class when negativeColour is set and the amount is negative", () => {
+        const el = renderAmount({ amount: -10, negativeColour: true });
+        expect(el).toHaveClass("negative");
+    });
+
+    it("applies the positive class when positiveColour is set and the amount is positive", () => {
+        const el = renderAmount({ amount: 10, positiveColour: true });
+        expect(el).toHaveClass("positive");
+    });
+
+    it("does not colour a positive amount when only negativeColour is set", () => {
+        const el = renderAmount({ amount: 10, negativeColour: true });
+        expect(el).not.toHaveClass("negative");
+        expect(el).not.toHaveClass("positive");
+    });
+
+    it("prefixes a minus sign for negative amounts when minus is set", () => {
+        const el = renderAmount({ amount: -5, minus: true });
+        expect(el).toHaveTextContent("-5.00");
+    });
+
+    it("prefixes a plus sign for positive amounts when plus is set", () => {
+        const el = renderAmount({ amount: 5, plus: true });
+        expect(el).toHaveTextContent("+5.00");
+    });
+
+    it("does not add a plus sign to a negative amount", () => {
+        const el = renderAmount({ amount: -5, plus: true });
+        expect(el.textContent).not.toContain("+");
+    });
+
+    it("appends a DR suffix for negative amounts when creditdebit is set", () => {
+        const el = renderAmount({ amount: -5, creditdebit: true });
+        expect(el).toHaveTextContent("5.00DR");
+    });
+
+    it("appends a CR suffix for positive amounts when creditdebit is set", () => {
+        const el = renderAmount({ amount: 5, creditdebit: true });
+        expect(el).toHaveTextContent("5.00CR");
+    });
+
+    it("uses the currency symbol for the given currency code", () => {
+        const el = renderAmount({ amount: 10, currencyCode: "GBP" });
+        expect(el).toHaveTextContent("£10.00");
+    });
+
+    it("shows no currency symbol when no currency code is given", () => {
+        const el = renderAmount({ amount: 10 });
+        expect(el.textContent).toBe("10.00");
+    });
+
+    it("treats a zero amount as neutral by default (no colour class)", () => {
+        const el = renderAmount({ amount: 0, positiveColour: true, negativeColour: true });
+        expect(el).not.toHaveClass("positive");
+        expect(el).not.toHaveClass("negative");
+    });
+
+    it("colours a zero amount as negative when zeroShowsAs is negative", () => {
+        const el = renderAmount({ amount: 0, zeroShowsAs: "negative" });
+        expect(el).toHaveClass("negative");
+    });
+
+    it("colours a zero amount as positive when zeroShowsAs is positive", () => {
+        const el = renderAmount({ amount: 0, zeroShowsAs: "positive" });
+        expect(el).toHaveClass("positive");
+    });
+
+    it("treats a null amount as zero", () => {
+        const el = renderAmount({ amount: null });
+        expect(el).toHaveTextContent("0.00");
+    });
+
+    it("treats a NaN amount as zero", () => {
+        const el = renderAmount({ amount: NaN });
+        expect(el).toHaveTextContent("0.00");
+    });
+
+    it("respects a custom decimalPlaces value", () => {
+        const el = renderAmount({ amount: 42, decimalPlaces: 0 });
+        expect(el).toHaveTextContent("42");
+        expect(el.textContent).not.toContain(".");
+    });
+
+    it("applies prefix and suffix text", () => {
+        const el = renderAmount({ amount: 5, prefix: "~", suffix: " approx" });
+        expect(el).toHaveTextContent("~5.00 approx");
+    });
+});

--- a/src/MooBank.Web.App/src/components/CurrencyInput.test.tsx
+++ b/src/MooBank.Web.App/src/components/CurrencyInput.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FormProvider, useForm } from "react-hook-form";
+import { CurrencyInput } from "components/CurrencyInput";
+
+// CurrencyInput renders a moo-ds Form.Input, which reads `register` off react-hook-form's
+// FormContext. Provide a minimal real form context rather than mocking react-hook-form.
+const FormWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const form = useForm();
+    return <FormProvider {...form}>{children}</FormProvider>;
+};
+
+// react-hook-form's register() needs a real field name to wire its ref, so every render passes
+// an id (as CurrencyInput's real callers always do via Form.Group's groupId).
+const renderCurrencyInput = (props: Partial<React.ComponentProps<typeof CurrencyInput>> = {}) =>
+    render(<CurrencyInput id="amount" {...props} />, { wrapper: FormWrapper });
+
+describe("CurrencyInput", () => {
+    it("shows the symbol for a known currency", () => {
+        renderCurrencyInput({ currency: "GBP" });
+        expect(screen.getByText("£")).toBeInTheDocument();
+    });
+
+    it("falls back to $ when no currency is given", () => {
+        renderCurrencyInput();
+        expect(screen.getByText("$")).toBeInTheDocument();
+    });
+
+    it("falls back to $ when currency is an empty string", () => {
+        renderCurrencyInput({ currency: "" });
+        expect(screen.getByText("$")).toBeInTheDocument();
+    });
+
+    it("renders a number input", () => {
+        renderCurrencyInput({ currency: "AUD" });
+        const input = document.querySelector<HTMLInputElement>("#amount")!;
+        expect(input).toHaveAttribute("type", "number");
+    });
+});

--- a/src/MooBank.Web.App/src/components/CurrencyInput.test.tsx
+++ b/src/MooBank.Web.App/src/components/CurrencyInput.test.tsx
@@ -31,6 +31,11 @@ describe("CurrencyInput", () => {
         expect(screen.getByText("$")).toBeInTheDocument();
     });
 
+    it("falls back to $ for an unrecognised currency code", () => {
+        renderCurrencyInput({ currency: "XYZ" });
+        expect(screen.getByText("$")).toBeInTheDocument();
+    });
+
     it("renders a number input", () => {
         renderCurrencyInput({ currency: "AUD" });
         const input = document.querySelector<HTMLInputElement>("#amount")!;

--- a/src/MooBank.Web.App/src/components/CurrencyInput.tsx
+++ b/src/MooBank.Web.App/src/components/CurrencyInput.tsx
@@ -1,7 +1,7 @@
 import { Form } from "@andrewmclachlan/moo-ds";
 import type { InputProps } from "@andrewmclachlan/moo-ds";
 import { InputGroup } from "@andrewmclachlan/moo-ds";
-import { getCurrencySymbol } from "utils/currency";
+import { currencySymbols } from "utils/currency";
 
 export interface CurrencyInputProps extends Omit<InputProps, "type"> {
     /** ISO currency code (e.g. "AUD", "USD"). Drives the input-group symbol; falls back to "$". */
@@ -11,7 +11,7 @@ export interface CurrencyInputProps extends Omit<InputProps, "type"> {
 export const CurrencyInput: React.FC<CurrencyInputProps> = ({ currency, ...props }) => (
 
     <InputGroup>
-        <InputGroup.Text>{getCurrencySymbol(currency) || "$"}</InputGroup.Text>
+        <InputGroup.Text>{(currency && currencySymbols[currency.toUpperCase()]) || "$"}</InputGroup.Text>
         <Form.Input type="number" className="form-control" placeholder="0.00" maxLength={10} step={0.01} {...props} />
     </InputGroup>
 )

--- a/src/MooBank.Web.App/src/components/MonthSelector.test.tsx
+++ b/src/MooBank.Web.App/src/components/MonthSelector.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MonthSelector } from "components/MonthSelector";
+
+describe("MonthSelector", () => {
+    it("checks every month when value defaults to all months selected", () => {
+        render(<MonthSelector />);
+        expect(screen.getByRole("checkbox", { name: "January" })).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "December" })).toBeChecked();
+    });
+
+    it("checks no months when value is 0", () => {
+        render(<MonthSelector value={0} />);
+        expect(screen.getByRole("checkbox", { name: "January" })).not.toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "December" })).not.toBeChecked();
+    });
+
+    it("checks only the months set in the bitmask", () => {
+        // January (bit 0) and March (bit 2) selected: 0b101 = 5
+        render(<MonthSelector value={5} />);
+        expect(screen.getByRole("checkbox", { name: "January" })).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "February" })).not.toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "March" })).toBeChecked();
+    });
+
+    it("toggles the bit for the clicked month on", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<MonthSelector value={0} onChange={onChange} />);
+        await user.click(screen.getByRole("checkbox", { name: "January" }));
+        expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it("toggles the bit for the clicked month off", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<MonthSelector value={1} onChange={onChange} />);
+        await user.click(screen.getByRole("checkbox", { name: "January" }));
+        expect(onChange).toHaveBeenCalledWith(0);
+    });
+
+    it("selects all months when the All preset is clicked", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<MonthSelector value={0} onChange={onChange} />);
+        await user.click(screen.getByRole("button", { name: "All" }));
+        expect(onChange).toHaveBeenCalledWith(4095);
+    });
+
+    it("clears all months when the clear control is clicked", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<MonthSelector value={4095} onChange={onChange} />);
+        await user.click(screen.getByRole("button", { name: "Clear all months" }));
+        expect(onChange).toHaveBeenCalledWith(0);
+    });
+});

--- a/src/MooBank.Web.App/src/components/ReportTypeSelector.test.tsx
+++ b/src/MooBank.Web.App/src/components/ReportTypeSelector.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReportTypeSelector } from "components/ReportTypeSelector";
+
+describe("ReportTypeSelector", () => {
+    it("highlights Income as active when value is Credit", () => {
+        render(<ReportTypeSelector value="Credit" />);
+        expect(screen.getByRole("button", { name: "Income" })).toHaveClass("btn-primary");
+        expect(screen.getByRole("button", { name: "Expense" })).toHaveClass("btn-outline-primary");
+    });
+
+    it("highlights Expense as active when value is Debit", () => {
+        render(<ReportTypeSelector value="Debit" />);
+        expect(screen.getByRole("button", { name: "Expense" })).toHaveClass("btn-primary");
+        expect(screen.getByRole("button", { name: "Income" })).toHaveClass("btn-outline-primary");
+    });
+
+    it("neither button is active when value is undefined", () => {
+        render(<ReportTypeSelector />);
+        expect(screen.getByRole("button", { name: "Income" })).toHaveClass("btn-outline-primary");
+        expect(screen.getByRole("button", { name: "Expense" })).toHaveClass("btn-outline-primary");
+    });
+
+    it("calls onChange with Credit when Income is clicked", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<ReportTypeSelector value="Debit" onChange={onChange} />);
+        await user.click(screen.getByRole("button", { name: "Income" }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith("Credit");
+    });
+
+    it("calls onChange with Debit when Expense is clicked", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<ReportTypeSelector value="Credit" onChange={onChange} />);
+        await user.click(screen.getByRole("button", { name: "Expense" }));
+        expect(onChange).toHaveBeenCalledTimes(1);
+        expect(onChange).toHaveBeenCalledWith("Debit");
+    });
+
+    it("does not call onChange when clicking the already-selected option", async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        render(<ReportTypeSelector value="Credit" onChange={onChange} />);
+        await user.click(screen.getByRole("button", { name: "Income" }));
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});

--- a/src/MooBank.Web.App/src/hooks/period.test.ts
+++ b/src/MooBank.Web.App/src/hooks/period.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { parseISO } from "date-fns/parseISO";
+import { periodOptions } from "models/periodOptions";
+import { lastMonth } from "utils/dateFns";
+
+// Stable spy shared with the mocked module (hoisted above vi.mock).
+const mocks = vi.hoisted(() => ({
+    useLocalStorage: vi.fn(),
+}));
+
+vi.mock("@andrewmclachlan/moo-ds", () => ({
+    useLocalStorage: mocks.useLocalStorage,
+}));
+
+import { getPeriod, useCustomPeriod } from "hooks/period";
+
+const setUrlPeriod = (value: string | undefined) => {
+    window.history.pushState({}, "", value ? `?period=${value}` : "?");
+};
+
+beforeEach(() => {
+    localStorage.clear();
+    window.history.pushState({}, "", "?");
+});
+
+afterEach(() => {
+    localStorage.clear();
+    window.history.pushState({}, "", "?");
+    mocks.useLocalStorage.mockReset();
+    vi.restoreAllMocks();
+});
+
+describe("getPeriod", () => {
+    it("prefers a matching period from the URL query string over local storage", () => {
+        setUrlPeriod("3");
+        localStorage.setItem("period-id", JSON.stringify("5"));
+
+        const result = getPeriod();
+
+        expect(result).toBe(periodOptions.find(o => o.value === "3"));
+    });
+
+    it("falls back to period-id when the URL period does not match any option", () => {
+        setUrlPeriod("not-a-real-option");
+        localStorage.setItem("period-id", JSON.stringify("3"));
+
+        const result = getPeriod();
+
+        expect(result).toBe(periodOptions.find(o => o.value === "3"));
+    });
+
+    it("uses the stored period-id when there is no URL period", () => {
+        localStorage.setItem("period-id", JSON.stringify("3"));
+
+        const result = getPeriod();
+
+        expect(result).toBe(periodOptions.find(o => o.value === "3"));
+    });
+
+    it("defaults period-id to \"1\" (Last Month) when nothing is stored", () => {
+        const result = getPeriod();
+
+        expect(result).toBe(periodOptions.find(o => o.value === "1"));
+    });
+
+    it("falls back to the first period option when the stored period-id matches nothing", () => {
+        localStorage.setItem("period-id", JSON.stringify("not-a-real-option"));
+
+        const result = getPeriod();
+
+        expect(result).toBe(periodOptions[0]);
+    });
+
+    it("reads a stored custom period and hydrates ISO date strings to Date objects when period-id is -1", () => {
+        localStorage.setItem("period-id", JSON.stringify("-1"));
+        localStorage.setItem("period", JSON.stringify({
+            startDate: "2026-01-01T00:00:00.000Z",
+            endDate: "2026-01-31T00:00:00.000Z",
+        }));
+
+        const result = getPeriod();
+
+        expect(result.startDate).toBeInstanceOf(Date);
+        expect(result.endDate).toBeInstanceOf(Date);
+        expect(result.startDate).toEqual(parseISO("2026-01-01T00:00:00.000Z"));
+        expect(result.endDate).toEqual(parseISO("2026-01-31T00:00:00.000Z"));
+    });
+
+    it("falls back to last month when period-id is -1 but no custom period is stored", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
+
+        localStorage.setItem("period-id", JSON.stringify("-1"));
+
+        const result = getPeriod();
+
+        expect(result).toEqual(lastMonth());
+
+        vi.useRealTimers();
+    });
+});
+
+describe("useCustomPeriod", () => {
+    it("initialises useLocalStorage with the \"period\" key and a last-month default", () => {
+        mocks.useLocalStorage.mockReturnValue([{ startDate: new Date(), endDate: new Date() }, vi.fn()]);
+
+        renderHook(() => useCustomPeriod());
+
+        expect(mocks.useLocalStorage).toHaveBeenCalledWith("period", expect.objectContaining({
+            startDate: expect.any(Date),
+            endDate: expect.any(Date),
+        }));
+    });
+
+    it("hydrates ISO string dates from storage into Date objects", () => {
+        mocks.useLocalStorage.mockReturnValue([
+            { startDate: "2026-02-01T00:00:00.000Z", endDate: "2026-02-28T00:00:00.000Z" },
+            vi.fn(),
+        ]);
+
+        const { result } = renderHook(() => useCustomPeriod());
+        const [period] = result.current;
+
+        expect(period.startDate).toBeInstanceOf(Date);
+        expect(period.endDate).toBeInstanceOf(Date);
+        expect(period.startDate.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+        expect(period.endDate.toISOString()).toBe("2026-02-28T00:00:00.000Z");
+    });
+
+    it("leaves already-hydrated Date values untouched", () => {
+        const startDate = new Date("2026-03-01T00:00:00.000Z");
+        const endDate = new Date("2026-03-31T00:00:00.000Z");
+        mocks.useLocalStorage.mockReturnValue([{ startDate, endDate }, vi.fn()]);
+
+        const { result } = renderHook(() => useCustomPeriod());
+        const [period] = result.current;
+
+        expect(period.startDate).toBe(startDate);
+        expect(period.endDate).toBe(endDate);
+    });
+
+    it("returns the setter from useLocalStorage unchanged", () => {
+        const setPeriod = vi.fn();
+        mocks.useLocalStorage.mockReturnValue([{ startDate: new Date(), endDate: new Date() }, setPeriod]);
+
+        const { result } = renderHook(() => useCustomPeriod());
+        const [, setter] = result.current;
+
+        expect(setter).toBe(setPeriod);
+    });
+});

--- a/src/MooBank.Web.App/src/hooks/useHasRole.test.ts
+++ b/src/MooBank.Web.App/src/hooks/useHasRole.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// Stable spy shared with the mocked module (hoisted above vi.mock).
+const mocks = vi.hoisted(() => ({
+    getActiveAccount: vi.fn(),
+}));
+
+vi.mock("@azure/msal-react", () => ({
+    useMsal: () => ({ instance: { getActiveAccount: mocks.getActiveAccount } }),
+}));
+
+import { useHasRole } from "hooks/useHasRole";
+
+afterEach(() => {
+    mocks.getActiveAccount.mockReset();
+    vi.restoreAllMocks();
+});
+
+describe("useHasRole", () => {
+    it("returns true when the active account has the role", () => {
+        mocks.getActiveAccount.mockReturnValue({ idTokenClaims: { roles: ["Admin", "User"] } });
+
+        const { result } = renderHook(() => useHasRole());
+
+        expect(result.current("Admin")).toBe(true);
+    });
+
+    it("returns false when the active account does not have the role", () => {
+        mocks.getActiveAccount.mockReturnValue({ idTokenClaims: { roles: ["User"] } });
+
+        const { result } = renderHook(() => useHasRole());
+
+        expect(result.current("Admin")).toBe(false);
+    });
+
+    it("returns false when there is no active account", () => {
+        mocks.getActiveAccount.mockReturnValue(null);
+
+        const { result } = renderHook(() => useHasRole());
+
+        expect(result.current("Admin")).toBe(false);
+    });
+
+    it("returns false when the active account has no roles claim", () => {
+        mocks.getActiveAccount.mockReturnValue({ idTokenClaims: {} });
+
+        const { result } = renderHook(() => useHasRole());
+
+        expect(result.current("Admin")).toBe(false);
+    });
+});

--- a/src/MooBank.Web.App/src/hooks/useMediaQuery.test.ts
+++ b/src/MooBank.Web.App/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useMediaQuery, useIsDesktop } from "hooks/useMediaQuery";
+
+// Minimal controllable MediaQueryList mock - jsdom doesn't implement matchMedia.
+const createMatchMediaMock = (initialMatches: boolean) => {
+    const listeners: ((event: MediaQueryListEvent) => void)[] = [];
+
+    const mql = {
+        matches: initialMatches,
+        media: "",
+        addEventListener: vi.fn((_event: string, callback: (event: MediaQueryListEvent) => void) => {
+            listeners.push(callback);
+        }),
+        removeEventListener: vi.fn((_event: string, callback: (event: MediaQueryListEvent) => void) => {
+            const index = listeners.indexOf(callback);
+            if (index >= 0) listeners.splice(index, 1);
+        }),
+    };
+
+    const fire = (matches: boolean) => {
+        mql.matches = matches;
+        listeners.forEach(listener => listener({ matches } as MediaQueryListEvent));
+    };
+
+    return { mql: mql as unknown as MediaQueryList, fire };
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("useMediaQuery", () => {
+    it("returns the initial matches value from the mocked media query", () => {
+        const { mql } = createMatchMediaMock(true);
+        window.matchMedia = vi.fn().mockReturnValue(mql);
+
+        const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+
+        expect(result.current).toBe(true);
+    });
+
+    it("returns false when the query does not initially match", () => {
+        const { mql } = createMatchMediaMock(false);
+        window.matchMedia = vi.fn().mockReturnValue(mql);
+
+        const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+
+        expect(result.current).toBe(false);
+    });
+
+    it("updates when a change event fires", () => {
+        const { mql, fire } = createMatchMediaMock(false);
+        window.matchMedia = vi.fn().mockReturnValue(mql);
+
+        const { result } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+        expect(result.current).toBe(false);
+
+        act(() => fire(true));
+
+        expect(result.current).toBe(true);
+    });
+
+    it("removes the change listener on unmount", () => {
+        const { mql } = createMatchMediaMock(false);
+        window.matchMedia = vi.fn().mockReturnValue(mql);
+
+        const { unmount } = renderHook(() => useMediaQuery("(min-width: 768px)"));
+        expect(mql.removeEventListener).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(mql.removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+    });
+});
+
+describe("useIsDesktop", () => {
+    it("queries the md breakpoint and forwards the mocked matches value", () => {
+        const { mql } = createMatchMediaMock(true);
+        const matchMediaSpy = vi.fn().mockReturnValue(mql);
+        window.matchMedia = matchMediaSpy;
+
+        const { result } = renderHook(() => useIsDesktop());
+
+        expect(matchMediaSpy).toHaveBeenCalledWith("(min-width: 768px)");
+        expect(result.current).toBe(true);
+    });
+
+    it("returns false when the breakpoint does not match", () => {
+        const { mql } = createMatchMediaMock(false);
+        window.matchMedia = vi.fn().mockReturnValue(mql);
+
+        const { result } = renderHook(() => useIsDesktop());
+
+        expect(result.current).toBe(false);
+    });
+});

--- a/src/MooBank.Web.App/src/routes/accounts/-hooks/transactionKeys.test.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-hooks/transactionKeys.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import {
+    getTransactionsQueryKey,
+    getUntaggedTransactionsQueryKey,
+    getAccountsQueryKey,
+    getAccountQueryKey,
+    inOutReportQueryKey,
+    getTagsQueryKey,
+} from "api/@tanstack/react-query.gen";
+import { invalidateTransactionLists, invalidateAccountViews } from "./transactionKeys";
+
+// The generated query keys are single-element arrays of `{ _id, baseURL, path, query }`, so the
+// id-only partial keys these helpers use should match every seeded variant via TanStack Query's
+// partial deep matching. We seed real generated keys and assert which queries get invalidated —
+// this exercises the actual matching, not just the literal key shape.
+
+const seed = (queryClient: QueryClient, queryKey: unknown[]) =>
+    queryClient.setQueryData(queryKey, { seeded: true });
+
+const isInvalidated = (queryClient: QueryClient, queryKey: unknown[]) =>
+    queryClient.getQueryState(queryKey)?.isInvalidated === true;
+
+describe("invalidateTransactionLists", () => {
+    it("invalidates every transaction list query regardless of account, page, filter and sort", async () => {
+        const queryClient = new QueryClient();
+
+        const listA = getTransactionsQueryKey({ path: { instrumentId: "acc-1", pageSize: 50, pageNumber: 1 }, query: { SortDirection: "Descending" } });
+        const listB = getTransactionsQueryKey({ path: { instrumentId: "acc-2", pageSize: 20, pageNumber: 3 }, query: { SortDirection: "Ascending", Filter: "coffee" } });
+        const untagged = getUntaggedTransactionsQueryKey({ path: { instrumentId: "acc-1", pageSize: 50, pageNumber: 1 }, query: { SortDirection: "Descending" } });
+        seed(queryClient, listA);
+        seed(queryClient, listB);
+        seed(queryClient, untagged);
+
+        await invalidateTransactionLists(queryClient);
+
+        expect(isInvalidated(queryClient, listA)).toBe(true);
+        expect(isInvalidated(queryClient, listB)).toBe(true);
+        expect(isInvalidated(queryClient, untagged)).toBe(true);
+    });
+
+    it("does not invalidate account or reference-data queries", async () => {
+        const queryClient = new QueryClient();
+
+        const accounts = getAccountsQueryKey();
+        const tags = getTagsQueryKey();
+        seed(queryClient, accounts);
+        seed(queryClient, tags);
+
+        await invalidateTransactionLists(queryClient);
+
+        expect(isInvalidated(queryClient, accounts)).toBe(false);
+        expect(isInvalidated(queryClient, tags)).toBe(false);
+    });
+});
+
+describe("invalidateAccountViews", () => {
+    it("invalidates the accounts list, single-account and in/out report queries", async () => {
+        const queryClient = new QueryClient();
+
+        const accounts = getAccountsQueryKey();
+        const account = getAccountQueryKey({ path: { instrumentId: "acc-1" } });
+        const inOut = inOutReportQueryKey({ path: { accountId: "acc-1", start: "2026-01-01", end: "2026-12-31" } });
+        seed(queryClient, accounts);
+        seed(queryClient, account);
+        seed(queryClient, inOut);
+
+        await invalidateAccountViews(queryClient);
+
+        expect(isInvalidated(queryClient, accounts)).toBe(true);
+        expect(isInvalidated(queryClient, account)).toBe(true);
+        expect(isInvalidated(queryClient, inOut)).toBe(true);
+    });
+
+    it("does not invalidate transaction list or reference-data queries", async () => {
+        const queryClient = new QueryClient();
+
+        const list = getTransactionsQueryKey({ path: { instrumentId: "acc-1", pageSize: 50, pageNumber: 1 }, query: { SortDirection: "Descending" } });
+        const tags = getTagsQueryKey();
+        seed(queryClient, list);
+        seed(queryClient, tags);
+
+        await invalidateAccountViews(queryClient);
+
+        expect(isInvalidated(queryClient, list)).toBe(false);
+        expect(isInvalidated(queryClient, tags)).toBe(false);
+    });
+});

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/components/AddTransaction.test.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/components/AddTransaction.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { LogicalAccount } from "api/types.gen";
+
+// Stable spies shared with the mocked hook modules (hoisted above the vi.mock calls).
+const mocks = vi.hoisted(() => ({
+    createMutate: vi.fn(),
+    balanceMutate: vi.fn(),
+}));
+
+vi.mock("routes/accounts/-hooks/useCreateTransaction", () => ({
+    useCreateTransaction: () => ({ mutateAsync: mocks.createMutate, isPending: false }),
+}));
+vi.mock("routes/accounts/-hooks/useUpdateBalance", () => ({
+    useUpdateBalance: () => ({ mutateAsync: mocks.balanceMutate, isPending: false }),
+}));
+
+import { AddTransaction } from "./AddTransaction";
+import { AccountProvider } from "components";
+
+const account = (controller: string): LogicalAccount =>
+    ({ id: "acc-1", currency: "AUD", controller } as LogicalAccount);
+
+const renderModal = (controller = "Manual", onSave = vi.fn()) => {
+    const user = userEvent.setup();
+    render(
+        <AccountProvider account={account(controller)}>
+            <AddTransaction show onClose={vi.fn()} onSave={onSave} />
+        </AccountProvider>,
+    );
+    return { user, onSave };
+};
+
+const amountInput = () => document.querySelector<HTMLInputElement>("#amount")!;
+const newBalanceInput = () => document.querySelector<HTMLInputElement>("#newBalance")!;
+const saveButton = () => screen.getByRole("button", { name: "Save" });
+
+beforeEach(() => {
+    mocks.createMutate.mockReset().mockResolvedValue(undefined);
+    mocks.balanceMutate.mockReset().mockResolvedValue(undefined);
+});
+
+describe("AddTransaction", () => {
+    describe("Save button enablement", () => {
+        it("is disabled when neither amount nor new balance is entered", () => {
+            renderModal();
+            expect(saveButton()).toBeDisabled();
+        });
+
+        it("is enabled once an amount is entered", async () => {
+            const { user } = renderModal();
+            await user.type(amountInput(), "42");
+            expect(saveButton()).toBeEnabled();
+        });
+
+        it("is disabled again after the amount is cleared", async () => {
+            const { user } = renderModal();
+            await user.type(amountInput(), "42");
+            await user.clear(amountInput());
+            expect(saveButton()).toBeDisabled();
+        });
+    });
+
+    describe("amount / new-balance mutual exclusivity", () => {
+        it("disables the new-balance field once an amount is entered", async () => {
+            const { user } = renderModal();
+            await user.type(amountInput(), "42");
+            expect(newBalanceInput()).toBeDisabled();
+            expect(amountInput()).toBeEnabled();
+        });
+
+        it("disables the amount field once a new balance is entered", async () => {
+            const { user } = renderModal();
+            await user.type(newBalanceInput(), "100");
+            expect(amountInput()).toBeDisabled();
+            expect(newBalanceInput()).toBeEnabled();
+        });
+    });
+
+    describe("submit routing", () => {
+        it("routes an entered amount to create-transaction, not set-balance", async () => {
+            const { user, onSave } = renderModal();
+            await user.type(amountInput(), "42");
+            await user.click(saveButton());
+
+            expect(mocks.createMutate).toHaveBeenCalledTimes(1);
+            expect(mocks.createMutate).toHaveBeenCalledWith("acc-1", expect.objectContaining({ amount: 42 }));
+            expect(mocks.balanceMutate).not.toHaveBeenCalled();
+            expect(onSave).toHaveBeenCalledTimes(1);
+        });
+
+        it("routes an entered new balance to set-balance, not create-transaction", async () => {
+            const { user } = renderModal();
+            await user.type(newBalanceInput(), "1000");
+            await user.click(saveButton());
+
+            expect(mocks.balanceMutate).toHaveBeenCalledTimes(1);
+            expect(mocks.balanceMutate).toHaveBeenCalledWith("acc-1", expect.objectContaining({ amount: 1000 }));
+            expect(mocks.createMutate).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("blank optional fields", () => {
+        it("sends blank description and reference as undefined, not empty strings", async () => {
+            const { user } = renderModal();
+            await user.type(amountInput(), "42");
+            await user.click(saveButton());
+
+            const [, payload] = mocks.createMutate.mock.calls[0];
+            expect(payload.description).toBeUndefined();
+            expect(payload.reference).toBeUndefined();
+            // The date defaults to today (yyyy-MM-dd) and is always sent.
+            expect(payload.transactionTime).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        });
+
+        it("passes through a description that was entered", async () => {
+            const { user } = renderModal();
+            await user.type(amountInput(), "42");
+            await user.type(screen.getByRole("textbox", { name: /description/i }), "Coffee");
+            await user.click(saveButton());
+
+            const [, payload] = mocks.createMutate.mock.calls[0];
+            expect(payload.description).toBe("Coffee");
+        });
+    });
+
+    describe("non-balance accounts", () => {
+        it("shows no new-balance field and routes to create-transaction", async () => {
+            const { user } = renderModal("Import");
+            expect(newBalanceInput()).toBeNull();
+
+            await user.type(amountInput(), "5");
+            await user.click(saveButton());
+
+            expect(mocks.createMutate).toHaveBeenCalledWith("acc-1", expect.objectContaining({ amount: 5 }));
+            expect(mocks.balanceMutate).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/MooBank.Web.App/src/test/matchers.d.ts
+++ b/src/MooBank.Web.App/src/test/matchers.d.ts
@@ -1,0 +1,3 @@
+// Registers the @testing-library/jest-dom matcher types (e.g. toBeDisabled, toBeInTheDocument)
+// on Vitest's expect for the whole project, so test files type-check under `tsgo`.
+import "@testing-library/jest-dom/vitest";

--- a/src/MooBank.Web.App/src/test/setup.ts
+++ b/src/MooBank.Web.App/src/test/setup.ts
@@ -1,0 +1,9 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// React Testing Library does not auto-clean between tests under Vitest globals; do it explicitly
+// so each test renders into a fresh DOM.
+afterEach(() => {
+    cleanup();
+});

--- a/src/MooBank.Web.App/src/utils/chartColours.test.ts
+++ b/src/MooBank.Web.App/src/utils/chartColours.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { overUnderBudgetColours } from "utils/chartColours";
+
+const colours = { income: "green", expenses: "red" };
+
+describe("overUnderBudgetColours", () => {
+    it("returns the expenses colour when the actual exceeds the budgeted amount", () => {
+        expect(overUnderBudgetColours([100], [80], colours)).toEqual(["red"]);
+    });
+
+    it("returns the income colour when the actual is under the budgeted amount", () => {
+        expect(overUnderBudgetColours([40], [80], colours)).toEqual(["green"]);
+    });
+
+    it("returns the income colour when the actual exactly equals the budgeted amount", () => {
+        expect(overUnderBudgetColours([50], [50], colours)).toEqual(["green"]);
+    });
+
+    it("compares the absolute value of the actual against the budgeted amount", () => {
+        expect(overUnderBudgetColours([-100], [80], colours)).toEqual(["red"]);
+        expect(overUnderBudgetColours([-40], [80], colours)).toEqual(["green"]);
+    });
+
+    it("treats a missing budgeted entry as 0", () => {
+        expect(overUnderBudgetColours([0, -5], [80], colours)).toEqual(["green", "red"]);
+    });
+
+    it("maps each actual/budgeted pair independently across the arrays", () => {
+        expect(overUnderBudgetColours([100, 50, 50], [80, 50, 60], colours)).toEqual(["red", "green", "green"]);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/charts.test.ts
+++ b/src/MooBank.Web.App/src/utils/charts.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { getStepSize } from "utils/charts";
+
+describe("getStepSize", () => {
+    it("returns undefined for an empty array", () => {
+        expect(getStepSize([])).toBeUndefined();
+    });
+
+    it("returns undefined for an all-zero dataset", () => {
+        expect(getStepSize([0, 0, 0])).toBeUndefined();
+    });
+
+    it("returns roughly a tenth of the rounded magnitude for a typical dataset", () => {
+        // max = 90 -> magnitude = 10^floor(log10(90)) = 10
+        // roundedMax = ceil(90 / 10) * 10 = 90
+        // step = 90 / 10 = 9
+        expect(getStepSize([0, 45, 90])).toBe(9);
+    });
+
+    it("computes the step for a dataset that isn't already a round number", () => {
+        // max = 33 -> magnitude = 10^floor(log10(33)) = 10
+        // roundedMax = ceil(33 / 10) * 10 = 40
+        // step = 40 / 10 = 4
+        expect(getStepSize([5, 12, 33])).toBe(4);
+    });
+
+    it("uses the absolute value, so negative values behave the same as positive ones", () => {
+        expect(getStepSize([-90, 45, 0])).toBe(9);
+    });
+
+    it("returns undefined when the magnitude is not finite", () => {
+        expect(getStepSize([Number.POSITIVE_INFINITY, 1])).toBeUndefined();
+    });
+});

--- a/src/MooBank.Web.App/src/utils/classNameHelpers.test.ts
+++ b/src/MooBank.Web.App/src/utils/classNameHelpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { numberClassName } from "utils/classNameHelpers";
+
+describe("numberClassName", () => {
+    it("returns ' negative' for negative numbers", () => {
+        expect(numberClassName(-1)).toBe(" negative");
+        expect(numberClassName(-0.01)).toBe(" negative");
+    });
+
+    it("returns an empty string for zero", () => {
+        expect(numberClassName(0)).toBe("");
+    });
+
+    it("returns an empty string for positive numbers", () => {
+        expect(numberClassName(1)).toBe("");
+        expect(numberClassName(100)).toBe("");
+    });
+});

--- a/src/MooBank.Web.App/src/utils/currency.test.ts
+++ b/src/MooBank.Web.App/src/utils/currency.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { getCurrencySymbol, formatCurrency } from "utils/currency";
+
+describe("getCurrencySymbol", () => {
+    it("returns the known symbol for a currency code", () => {
+        expect(getCurrencySymbol("AUD")).toBe("$");
+        expect(getCurrencySymbol("GBP")).toBe("£");
+        expect(getCurrencySymbol("EUR")).toBe("€");
+        expect(getCurrencySymbol("JPY")).toBe("¥");
+    });
+
+    it("is case-insensitive", () => {
+        expect(getCurrencySymbol("gbp")).toBe("£");
+        expect(getCurrencySymbol("eur")).toBe("€");
+    });
+
+    it("returns an empty string for null/undefined/empty input", () => {
+        expect(getCurrencySymbol(null)).toBe("");
+        expect(getCurrencySymbol(undefined)).toBe("");
+        expect(getCurrencySymbol("")).toBe("");
+    });
+
+    it("falls back to the upper-cased code plus a space for unknown currencies", () => {
+        expect(getCurrencySymbol("xyz")).toBe("XYZ ");
+        expect(getCurrencySymbol("ZAR")).toBe("ZAR ");
+    });
+
+    it("renders CHF with its trailing space", () => {
+        expect(getCurrencySymbol("CHF")).toBe("CHF ");
+    });
+});
+
+describe("formatCurrency", () => {
+    it("formats a positive amount with the currency symbol and two decimals", () => {
+        expect(formatCurrency(1234.5, "AUD")).toBe("$1,234.50");
+    });
+
+    it("prefixes negatives with a minus sign before the symbol", () => {
+        expect(formatCurrency(-1234.5, "AUD")).toBe("-$1,234.50");
+    });
+
+    it("defaults to AUD when no currency code is given", () => {
+        expect(formatCurrency(10)).toBe("$10.00");
+    });
+
+    it("treats null/undefined/NaN amounts as zero", () => {
+        expect(formatCurrency(null, "AUD")).toBe("$0.00");
+        expect(formatCurrency(undefined, "AUD")).toBe("$0.00");
+        expect(formatCurrency(Number.NaN, "AUD")).toBe("$0.00");
+    });
+
+    it("respects a custom decimal-place count", () => {
+        expect(formatCurrency(5, "AUD", 0)).toBe("$5");
+        expect(formatCurrency(1.2345, "AUD", 4)).toBe("$1.2345");
+    });
+
+    it("uses the fallback symbol for unknown currencies", () => {
+        expect(formatCurrency(99, "ZAR")).toBe("ZAR 99.00");
+    });
+});

--- a/src/MooBank.Web.App/src/utils/currency.ts
+++ b/src/MooBank.Web.App/src/utils/currency.ts
@@ -1,4 +1,4 @@
-const SYMBOLS: Record<string, string> = {
+export const currencySymbols: Record<string, string> = {
     AUD: "$",
     USD: "$",
     NZD: "$",
@@ -17,7 +17,7 @@ const SYMBOLS: Record<string, string> = {
 export const getCurrencySymbol = (code: string | null | undefined): string => {
     if (!code) return "";
     const upper = code.toUpperCase();
-    return SYMBOLS[upper] ?? `${upper} `;
+    return currencySymbols[upper] ?? `${upper} `;
 };
 
 export const formatCurrency = (amount: number | null | undefined, currencyCode: string = "AUD", decimalPlaces = 2): string => {

--- a/src/MooBank.Web.App/src/utils/dateFns.test.ts
+++ b/src/MooBank.Web.App/src/utils/dateFns.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import {
+    formatISODate,
+    formatDisplayDate,
+    formatDateShort,
+    formatDateRange,
+    isMonthSelected,
+    numberOfMonths,
+    subtractYear,
+} from "utils/dateFns";
+
+describe("formatISODate", () => {
+    it("formats a Date as yyyy-MM-dd", () => {
+        expect(formatISODate(new Date(2026, 0, 5))).toBe("2026-01-05");
+    });
+});
+
+describe("formatDisplayDate", () => {
+    it("formats an ISO date string as dd/MM/yyyy", () => {
+        expect(formatDisplayDate("2026-01-05")).toBe("05/01/2026");
+    });
+
+    it("returns a dash for undefined input", () => {
+        expect(formatDisplayDate(undefined)).toBe("-");
+    });
+});
+
+describe("formatDateShort", () => {
+    it("formats an ISO date string as dd MMM yy", () => {
+        expect(formatDateShort("2026-01-05")).toBe("05 Jan 26");
+    });
+
+    it("returns a dash for undefined input", () => {
+        expect(formatDateShort(undefined)).toBe("-");
+    });
+});
+
+describe("formatDateRange", () => {
+    it("omits the year on the start date when both dates share a year", () => {
+        expect(formatDateRange("2026-01-05", "2026-01-20")).toBe("05 Jan - 20 Jan 2026");
+    });
+
+    it("includes the year on the start date when the years differ", () => {
+        expect(formatDateRange("2025-12-05", "2026-01-20")).toBe("05 Dec 2025 - 20 Jan 2026");
+    });
+
+    it("returns a dash when either date is missing", () => {
+        expect(formatDateRange(undefined, "2026-01-20")).toBe("-");
+        expect(formatDateRange("2026-01-05", undefined)).toBe("-");
+        expect(formatDateRange(undefined, undefined)).toBe("-");
+    });
+});
+
+describe("isMonthSelected", () => {
+    it("reads the bit for the given month from the bitmask", () => {
+        const months = 0b101; // months 0 and 2 selected
+        expect(isMonthSelected(months, 0)).toBe(true);
+        expect(isMonthSelected(months, 1)).toBe(false);
+        expect(isMonthSelected(months, 2)).toBe(true);
+    });
+});
+
+describe("numberOfMonths", () => {
+    it("counts the number of set bits across the 12 months", () => {
+        expect(numberOfMonths(0b101)).toBe(2);
+        expect(numberOfMonths(0)).toBe(0);
+        expect(numberOfMonths(0xFFF)).toBe(12);
+    });
+});
+
+describe("subtractYear", () => {
+    it("returns a period with both dates shifted back one year", () => {
+        const period = { startDate: new Date(2026, 0, 5), endDate: new Date(2026, 5, 15) };
+
+        const result = subtractYear(period);
+
+        expect(result.startDate.getFullYear()).toBe(2025);
+        expect(result.startDate.getMonth()).toBe(0);
+        expect(result.startDate.getDate()).toBe(5);
+        expect(result.endDate.getFullYear()).toBe(2025);
+        expect(result.endDate.getMonth()).toBe(5);
+        expect(result.endDate.getDate()).toBe(15);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/equals.test.ts
+++ b/src/MooBank.Web.App/src/utils/equals.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { equals, notEquals } from "utils/equals";
+
+describe("equals", () => {
+    it("is true for identical numbers", () => {
+        expect(equals(1, 1)).toBe(true);
+        expect(equals(0, 0)).toBe(true);
+        expect(equals(-5.5, -5.5)).toBe(true);
+    });
+
+    it("is true for differences within epsilon (1e-4)", () => {
+        expect(equals(1.00005, 1.0)).toBe(true);
+    });
+
+    it("is false for differences outside epsilon (1e-4)", () => {
+        expect(equals(1.0002, 1.0)).toBe(false);
+    });
+
+    it("is symmetric", () => {
+        expect(equals(1.0, 1.00005)).toBe(true);
+        expect(equals(1.0, 1.0002)).toBe(false);
+    });
+});
+
+describe("notEquals", () => {
+    it("is the inverse of equals", () => {
+        expect(notEquals(1.00005, 1.0)).toBe(false);
+        expect(notEquals(1.0002, 1.0)).toBe(true);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/onKeyLeave.test.ts
+++ b/src/MooBank.Web.App/src/utils/onKeyLeave.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { onKeyLeave } from "utils/onKeyLeave";
+
+const makeEvent = (key: string, value: string) =>
+    ({ key, currentTarget: { value } }) as unknown as React.KeyboardEvent<HTMLInputElement>;
+
+describe("onKeyLeave", () => {
+    it("calls the setter with the current value on Enter", () => {
+        const setter = vi.fn();
+        onKeyLeave(makeEvent("Enter", "hello"), setter);
+        expect(setter).toHaveBeenCalledWith("hello");
+        expect(setter).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls the setter with the current value on Tab", () => {
+        const setter = vi.fn();
+        onKeyLeave(makeEvent("Tab", "world"), setter);
+        expect(setter).toHaveBeenCalledWith("world");
+        expect(setter).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing for other keys", () => {
+        const setter = vi.fn();
+        onKeyLeave(makeEvent("a", "hello"), setter);
+        expect(setter).not.toHaveBeenCalled();
+    });
+});

--- a/src/MooBank.Web.App/src/utils/periodLabel.test.ts
+++ b/src/MooBank.Web.App/src/utils/periodLabel.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { getPeriodLabel } from "utils/periodLabel";
+import { periodOptions } from "models/periodOptions";
+
+describe("getPeriodLabel", () => {
+    it("returns an empty string for an undefined filter", () => {
+        expect(getPeriodLabel(undefined)).toBe("");
+    });
+
+    it("returns an empty string when the start is missing", () => {
+        expect(getPeriodLabel({ end: "2026-01-31T00:00:00.000Z" })).toBe("");
+    });
+
+    it("returns an empty string when the end is missing", () => {
+        expect(getPeriodLabel({ start: "2026-01-01T00:00:00.000Z" })).toBe("");
+    });
+
+    it("returns the matching period option's label when the filter matches a known option", () => {
+        const option = periodOptions[0];
+        const filter = {
+            start: option.startDate.toISOString(),
+            end: option.endDate.toISOString(),
+        };
+
+        expect(getPeriodLabel(filter)).toBe(option.label);
+    });
+
+    it("returns a formatted date range when the filter doesn't match any period option", () => {
+        expect(getPeriodLabel({ start: "2020-01-01", end: "2020-01-31" })).toBe("01 Jan 2020 → 31 Jan 2020");
+    });
+});

--- a/src/MooBank.Web.App/src/utils/rules.test.ts
+++ b/src/MooBank.Web.App/src/utils/rules.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import type { Rule } from "api/types.gen";
+import { sortRules } from "utils/rules";
+
+const makeRule = (id: number, contains: string): Rule => ({
+    id,
+    contains,
+    tags: [],
+});
+
+describe("sortRules", () => {
+    it("sorts ascending by contains, case-insensitively", () => {
+        const rules = [makeRule(1, "zebra"), makeRule(2, "Apple"), makeRule(3, "mango")];
+        const sorted = [...rules].sort(sortRules("Ascending"));
+        expect(sorted.map(r => r.contains)).toEqual(["Apple", "mango", "zebra"]);
+    });
+
+    it("sorts descending by contains, case-insensitively", () => {
+        const rules = [makeRule(1, "zebra"), makeRule(2, "Apple"), makeRule(3, "mango")];
+        const sorted = [...rules].sort(sortRules("Descending"));
+        expect(sorted.map(r => r.contains)).toEqual(["zebra", "mango", "Apple"]);
+    });
+
+    it("returns 0 for equal names regardless of case", () => {
+        expect(sortRules("Ascending")(makeRule(1, "Woolworths"), makeRule(2, "WOOLWORTHS"))).toBe(0);
+        expect(sortRules("Descending")(makeRule(1, "Woolworths"), makeRule(2, "woolworths"))).toBe(0);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/tags.test.ts
+++ b/src/MooBank.Web.App/src/utils/tags.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import type { Tag } from "api/types.gen";
+import { sortTags } from "utils/tags";
+
+const makeTag = (id: number, name: string): Tag => ({
+    id,
+    name,
+    tags: [],
+    settings: { applySmoothing: false, excludeFromReporting: false, budgetCategory: false },
+});
+
+describe("sortTags", () => {
+    it("sorts ascending by name, case-insensitively", () => {
+        const tags = [makeTag(1, "zebra"), makeTag(2, "Apple"), makeTag(3, "mango")];
+        const sorted = [...tags].sort(sortTags("Ascending"));
+        expect(sorted.map(t => t.name)).toEqual(["Apple", "mango", "zebra"]);
+    });
+
+    it("sorts descending by name, case-insensitively", () => {
+        const tags = [makeTag(1, "zebra"), makeTag(2, "Apple"), makeTag(3, "mango")];
+        const sorted = [...tags].sort(sortTags("Descending"));
+        expect(sorted.map(t => t.name)).toEqual(["zebra", "mango", "Apple"]);
+    });
+
+    it("returns 0 for equal names regardless of case", () => {
+        expect(sortTags("Ascending")(makeTag(1, "Groceries"), makeTag(2, "GROCERIES"))).toBe(0);
+        expect(sortTags("Descending")(makeTag(1, "Groceries"), makeTag(2, "groceries"))).toBe(0);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/transactions.test.ts
+++ b/src/MooBank.Web.App/src/utils/transactions.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import type { TransactionType, TransactionSplit } from "api/types.gen";
+import { isCredit, isDebit, getSplitTotal } from "utils/transactions";
+
+// The generated TransactionType union currently only includes "NotSet" | "Credit" | "Debit"
+// (see MooBank.Primitives/TransactionType.cs), but the implementation's internal enum also
+// defines RecurringCredit/RecurringDebit/BalanceAdjustment. Those values aren't reachable via
+// the real API today, so they're cast through `unknown` here to exercise the extra branches.
+const recurringCredit = "RecurringCredit" as unknown as TransactionType;
+const recurringDebit = "RecurringDebit" as unknown as TransactionType;
+const balanceAdjustment = "BalanceAdjustment" as unknown as TransactionType;
+
+describe("isCredit", () => {
+    it("is true for Credit", () => {
+        expect(isCredit("Credit")).toBe(true);
+    });
+
+    it("is false for Debit", () => {
+        expect(isCredit("Debit")).toBe(false);
+    });
+
+    it("is true for RecurringCredit (odd enum value)", () => {
+        expect(isCredit(recurringCredit)).toBe(true);
+    });
+
+    it("is false for RecurringDebit (even enum value)", () => {
+        expect(isCredit(recurringDebit)).toBe(false);
+    });
+
+    it("is true for BalanceAdjustment (odd enum value)", () => {
+        expect(isCredit(balanceAdjustment)).toBe(true);
+    });
+});
+
+describe("isDebit", () => {
+    it("is false for Credit", () => {
+        expect(isDebit("Credit")).toBe(false);
+    });
+
+    it("is true for Debit", () => {
+        expect(isDebit("Debit")).toBe(true);
+    });
+
+    it("is false for RecurringCredit (odd enum value)", () => {
+        expect(isDebit(recurringCredit)).toBe(false);
+    });
+
+    it("is true for RecurringDebit (even enum value)", () => {
+        expect(isDebit(recurringDebit)).toBe(true);
+    });
+
+    it("is false for BalanceAdjustment (odd enum value)", () => {
+        expect(isDebit(balanceAdjustment)).toBe(false);
+    });
+});
+
+const makeSplit = (amount: number | string): TransactionSplit => ({
+    id: "1",
+    tags: [],
+    amount: amount as number,
+    offsetBy: [],
+});
+
+describe("getSplitTotal", () => {
+    it("returns 0 for an empty array", () => {
+        expect(getSplitTotal([])).toBe(0);
+    });
+
+    it("sums numeric amounts", () => {
+        const splits = [makeSplit(10), makeSplit(20.5), makeSplit(-5)];
+        expect(getSplitTotal(splits)).toBe(25.5);
+    });
+
+    it("sums string amounts by coercing them to numbers", () => {
+        const splits = [makeSplit("10"), makeSplit("15.25"), makeSplit(4.75)];
+        expect(getSplitTotal(splits)).toBe(30);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/transactions.test.ts
+++ b/src/MooBank.Web.App/src/utils/transactions.test.ts
@@ -1,14 +1,8 @@
 import { describe, it, expect } from "vitest";
-import type { TransactionType, TransactionSplit } from "api/types.gen";
+import type { TransactionSplit } from "api/types.gen";
 import { isCredit, isDebit, getSplitTotal } from "utils/transactions";
 
-// The generated TransactionType union currently only includes "NotSet" | "Credit" | "Debit"
-// (see MooBank.Primitives/TransactionType.cs), but the implementation's internal enum also
-// defines RecurringCredit/RecurringDebit/BalanceAdjustment. Those values aren't reachable via
-// the real API today, so they're cast through `unknown` here to exercise the extra branches.
-const recurringCredit = "RecurringCredit" as unknown as TransactionType;
-const recurringDebit = "RecurringDebit" as unknown as TransactionType;
-const balanceAdjustment = "BalanceAdjustment" as unknown as TransactionType;
+// TransactionType is NotSet | Credit | Debit (see MooBank.Primitives/TransactionType.cs).
 
 describe("isCredit", () => {
     it("is true for Credit", () => {
@@ -19,16 +13,8 @@ describe("isCredit", () => {
         expect(isCredit("Debit")).toBe(false);
     });
 
-    it("is true for RecurringCredit (odd enum value)", () => {
-        expect(isCredit(recurringCredit)).toBe(true);
-    });
-
-    it("is false for RecurringDebit (even enum value)", () => {
-        expect(isCredit(recurringDebit)).toBe(false);
-    });
-
-    it("is true for BalanceAdjustment (odd enum value)", () => {
-        expect(isCredit(balanceAdjustment)).toBe(true);
+    it("is false for NotSet", () => {
+        expect(isCredit("NotSet")).toBe(false);
     });
 });
 
@@ -41,16 +27,8 @@ describe("isDebit", () => {
         expect(isDebit("Debit")).toBe(true);
     });
 
-    it("is false for RecurringCredit (odd enum value)", () => {
-        expect(isDebit(recurringCredit)).toBe(false);
-    });
-
-    it("is true for RecurringDebit (even enum value)", () => {
-        expect(isDebit(recurringDebit)).toBe(true);
-    });
-
-    it("is false for BalanceAdjustment (odd enum value)", () => {
-        expect(isDebit(balanceAdjustment)).toBe(false);
+    it("is false for NotSet", () => {
+        expect(isDebit("NotSet")).toBe(false);
     });
 });
 

--- a/src/MooBank.Web.App/src/utils/transactions.ts
+++ b/src/MooBank.Web.App/src/utils/transactions.ts
@@ -1,15 +1,9 @@
 import type { TransactionType, TransactionSplit } from "api/types.gen";
 
-enum TransactionTypesEnum {
-    Credit = 1,
-    Debit = 2,
-    RecurringCredit = 3,
-    RecurringDebit = 4,
-    BalanceAdjustment = 5,
-}
+// TransactionType is NotSet | Credit | Debit (see MooBank.Primitives/TransactionType.cs).
+// NotSet is neither a credit nor a debit.
+export const isCredit = (transactionType: TransactionType) => transactionType === "Credit";
 
-export const isCredit = (transactionType: TransactionType) => TransactionTypesEnum[transactionType as keyof typeof TransactionTypesEnum] % 2 === 1;
-
-export const isDebit = (transactionType: TransactionType) => TransactionTypesEnum[transactionType as keyof typeof TransactionTypesEnum] % 2 === 0;
+export const isDebit = (transactionType: TransactionType) => transactionType === "Debit";
 
 export const getSplitTotal = (splits: TransactionSplit[]) => splits.reduce((total, split) => total + Number(split.amount), 0);

--- a/src/MooBank.Web.App/src/utils/units.test.ts
+++ b/src/MooBank.Web.App/src/utils/units.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { getUnit } from "utils/units";
+
+describe("getUnit", () => {
+    it("returns kWh for Electricity", () => {
+        expect(getUnit("Electricity")).toBe("kWh");
+    });
+
+    it("returns kL for Water", () => {
+        expect(getUnit("Water")).toBe("kL");
+    });
+
+    it("returns an empty string for other utility types", () => {
+        expect(getUnit("Gas")).toBe("");
+        expect(getUnit("Phone")).toBe("");
+        expect(getUnit("Internet")).toBe("");
+        expect(getUnit("Other")).toBe("");
+    });
+});

--- a/src/MooBank.Web.App/src/utils/valueAsNumber.test.ts
+++ b/src/MooBank.Web.App/src/utils/valueAsNumber.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { valueAsNumber } from "utils/valueAsNumber";
+
+describe("valueAsNumber", () => {
+    it("returns the default value when value is undefined", () => {
+        expect(valueAsNumber({ value: undefined, valueAsNumber: 42 }, 7)).toBe(7);
+    });
+
+    it("returns the default value when value is null", () => {
+        expect(valueAsNumber({ value: null, valueAsNumber: 42 }, 7)).toBe(7);
+    });
+
+    it("returns the default value when value is an empty string", () => {
+        expect(valueAsNumber({ value: "", valueAsNumber: 42 }, 7)).toBe(7);
+    });
+
+    it("defaults to 0 when no default is provided", () => {
+        expect(valueAsNumber({ value: "", valueAsNumber: 42 })).toBe(0);
+    });
+
+    it("returns valueAsNumber when value is present", () => {
+        expect(valueAsNumber({ value: "123", valueAsNumber: 123 }, 7)).toBe(123);
+    });
+
+    it("returns valueAsNumber when value is 0 (falsy but not empty/null/undefined)", () => {
+        expect(valueAsNumber({ value: "0", valueAsNumber: 0 }, 7)).toBe(0);
+    });
+});

--- a/src/MooBank.Web.App/src/utils/virtualAccounts.test.ts
+++ b/src/MooBank.Web.App/src/utils/virtualAccounts.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import type { LogicalAccount, VirtualInstrument } from "api/types.gen";
+import { isVirtualInstrument } from "utils/virtualAccounts";
+
+describe("isVirtualInstrument", () => {
+    it("is true when parentId is present", () => {
+        const virtualInstrument = { id: "1", parentId: "parent-1" } as unknown as VirtualInstrument;
+        expect(isVirtualInstrument(virtualInstrument)).toBe(true);
+    });
+
+    it("is false when parentId is absent", () => {
+        const logicalAccount = { id: "1" } as unknown as LogicalAccount;
+        expect(isVirtualInstrument(logicalAccount)).toBe(false);
+    });
+
+    it("is false when parentId is an empty string", () => {
+        const virtualInstrument = { id: "1", parentId: "" } as unknown as VirtualInstrument;
+        expect(isVirtualInstrument(virtualInstrument)).toBe(false);
+    });
+});

--- a/src/MooBank.Web.App/vitest.config.ts
+++ b/src/MooBank.Web.App/vitest.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+// Standalone Vitest config (deliberately NOT importing vite.config.ts, whose top-level
+// code generates HTTPS dev certificates via `dotnet dev-certs` — unavailable in CI).
+export default defineConfig({
+    plugins: [react()],
+    test: {
+        environment: "jsdom",
+        globals: true,
+        setupFiles: ["./src/test/setup.ts"],
+        include: ["src/**/*.{test,spec}.{ts,tsx}"],
+        css: false,
+        coverage: {
+            provider: "v8",
+            reporter: ["text", "cobertura"],
+            reportsDirectory: "./coverage",
+            include: ["src/**/*.{ts,tsx}"],
+            exclude: [
+                "src/**/*.{test,spec}.{ts,tsx}",
+                "src/test/**",
+                "src/api/**",
+                "src/routeTree.gen.ts",
+                "src/**/*.d.ts",
+            ],
+        },
+    },
+    resolve: {
+        // Mirror the app build (vite.config.ts): resolve the tsconfig `paths` mapping
+        // `{ "*": ["./src/*"] }` so bare imports like "utils/currency" and "components" work.
+        tsconfigPaths: true,
+    },
+});


### PR DESCRIPTION
Closes #882.

Stands up frontend unit testing with **Vitest + React Testing Library** (local + CI) and covers the app's real logic surface — **168 tests across 24 files**.

## Harness
- **`vitest.config.ts`** — standalone (jsdom, `globals: true`, native `resolve.tsconfigPaths` for bare imports). Deliberately does **not** import `vite.config.ts`, whose top-level code runs `dotnet dev-certs` (unavailable in CI).
- **`src/test/setup.ts`** — registers `@testing-library/jest-dom`, cleans up per test.
- **`src/test/matchers.d.ts`** — exposes jest-dom matcher types to `tsgo` so tests stay type-checked by the production build.
- Scripts: `npm test`, `test:watch`, `test:coverage`.

## Coverage (test by value, not by folder)
- **utils** — currency, equals, transactions, units, virtualAccounts, classNameHelpers, rules/tags sorters, valueAsNumber, onKeyLeave, charts, chartColours, dateFns, periodLabel.
- **hooks** — useMediaQuery/useIsDesktop, useHasRole, period (getPeriod precedence + useCustomPeriod hydration).
- **components** — AddTransaction, Amount, AccountTypeBadge, CurrencyInput, ReportTypeSelector, MonthSelector.
- **transactionKeys** — invalidation asserted against real generated query keys in a QueryClient (partial-key matching).

Thin generated-query-hook wrappers and pure type/constant modules are left untested on purpose — testing them would test React Query, not our logic.

## CI
New **`test-frontend`** job runs `npm run test:coverage`, uploads `coverage-frontend`, and gates the deploy chain. No coverage threshold — coverage grows incrementally.

## Also in this PR
- **Removed the unused `bootstrap` dependency** — declared in package.json but referenced nowhere (no import, no CSS, not transitive via any moo-* package). MooDS ships fully custom components.
- Updated `.claude/rules/testing/frontend.md`: high-value route-level logic is now testable; harness documented.

## Verification
- `npm test` → 24 files, 168 passed (deterministic)
- `npx tsgo --noEmit` → clean
- `npm run lint` → 0 errors (new files add 0 warnings)
- `@emnapi` override pins intact; lockfile CI-installable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
