### PR TITLE
build(deps): uplift ASM library to v4.0.0-beta.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,14 +45,14 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="3.8.169" />
-    <PackageVersion Include="Asm.AspNetCore" Version="3.8.169" />
-    <PackageVersion Include="Asm.AspNetCore.Api" Version="3.8.169" />
-    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="3.8.169" />
-    <PackageVersion Include="Asm.Domain" Version="3.8.169" />
-    <PackageVersion Include="Asm.Domain.Infrastructure" Version="3.8.169" />
-    <PackageVersion Include="Asm.ModelContextProtocol" Version="3.8.169" />
-    <PackageVersion Include="Asm.Testing.Domain" Version="3.8.169" />
+    <PackageVersion Include="Asm" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.AspNetCore" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.AspNetCore.Api" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.Domain" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.Domain.Infrastructure" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.ModelContextProtocol" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm.Testing.Domain" Version="4.0.0-beta.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,24 +35,24 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.85.2" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.86.0" />
     <PackageVersion Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.9" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.9.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.9" />
-    <PackageVersion Include="ModelContextProtocol" Version="1.4.0" />
+    <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.AspNetCore" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.AspNetCore.Api" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.Domain" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.Domain.Infrastructure" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.ModelContextProtocol" Version="4.0.0-beta.0" />
-    <PackageVersion Include="Asm.Testing.Domain" Version="4.0.0-beta.0" />
+    <PackageVersion Include="Asm" Version="4.0.18" />
+    <PackageVersion Include="Asm.AspNetCore" Version="4.0.18" />
+    <PackageVersion Include="Asm.AspNetCore.Api" Version="4.0.18" />
+    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.18" />
+    <PackageVersion Include="Asm.Domain" Version="4.0.18" />
+    <PackageVersion Include="Asm.Domain.Infrastructure" Version="4.0.18" />
+    <PackageVersion Include="Asm.ModelContextProtocol" Version="4.0.18" />
+    <PackageVersion Include="Asm.Testing.Domain" Version="4.0.18" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -125,7 +125,7 @@ void AddServices(WebApplicationBuilder builder)
         options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
 
-    services.AddProblemDetailsFactory();
+    services.AddAsmExceptionHandler();
 
     services.AddMooBankDbContext(builder.Environment, builder.Configuration);
 
@@ -220,8 +220,9 @@ void AddServices(WebApplicationBuilder builder)
             .AddAbs()
             .AddIntegrationServices();
 
-    var headerPolicies = services.AddStandardSecurityHeaders()
-        .AddContentSecurityPolicy(options =>
+    services.AddStandardSecurityHeaders(policies =>
+    {
+        policies.AddContentSecurityPolicy(options =>
         {
             options.AddDefaultSrc().Self();
             options.AddConnectSrc().Self().From("https://login.microsoftonline.com").From("https://graph.microsoft.com");
@@ -231,14 +232,16 @@ void AddServices(WebApplicationBuilder builder)
             options.AddFontSrc().Self().From("https://cdn.mclachlan.family");
             options.AddStyleSrc().Self().UnsafeInline();
             options.AddScriptSrc().Self().UnsafeInline();
-        })
-        .AddPermissionsPolicyWithDefaultSecureDirectives();
+        });
 
-    // MSAL loads Microsoft's authorize endpoint in a hidden iframe and that response
-    // does not include Cross-Origin-Resource-Policy. With COEP=require-corp the browser
-    // blocks it. We don't use SharedArrayBuffer or any other COEP-gated feature, so
-    // remove the header entirely rather than relying on UnsafeNone overriding the default.
-    headerPolicies.Remove("Cross-Origin-Embedder-Policy");
+        policies.AddPermissionsPolicyWithDefaultSecureDirectives();
+
+        // MSAL loads Microsoft's authorize endpoint in a hidden iframe and that response
+        // does not include Cross-Origin-Resource-Policy. With COEP=require-corp the browser
+        // blocks it. We don't use SharedArrayBuffer or any other COEP-gated feature, so
+        // remove the header entirely rather than relying on UnsafeNone overriding the default.
+        policies.Remove("Cross-Origin-Embedder-Policy");
+    });
 
     // Register WebJobs SDK for in-process background jobs
     builder.Host.ConfigureWebJobs(webJobsBuilder =>

--- a/src/MooBank.Api/appsettings.json
+++ b/src/MooBank.Api/appsettings.json
@@ -6,6 +6,9 @@
     }
   },
   "OAuth": {
-    "Domain": "https://login.microsoftonline.com"
+    "Domain": "https://login.microsoftonline.com",
+    "TenantId": "30efefb9-9034-4e0c-8c69-17f4578f5924",
+    "Audience": "045f8afa-70f2-4700-ab75-77ac41b306f7",
+    "ClientId": "045f8afa-70f2-4700-ab75-77ac41b306f7"
   }
 }

--- a/src/MooBank.Api/openapi-v1.json
+++ b/src/MooBank.Api/openapi-v1.json
@@ -4690,6 +4690,16 @@
         ],
         "summary": "Create a tag by name",
         "operationId": "create-tag-by-name",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -10037,7 +10047,7 @@
       "oidc": {
         "type": "openIdConnect",
         "description": "OIDC",
-        "openIdConnectUrl": "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0/.well-known/openid-configuration"
+        "openIdConnectUrl": "https://login.microsoftonline.com/30efefb9-9034-4e0c-8c69-17f4578f5924/v2.0/.well-known/openid-configuration"
       }
     }
   },

--- a/src/MooBank.Domain/Entities/Transactions/ITransactionRepository.cs
+++ b/src/MooBank.Domain/Entities/Transactions/ITransactionRepository.cs
@@ -20,6 +20,4 @@ public interface ITransactionRepository : IWritableRepository<Transaction, Guid>
     /// Gets the ID and description of each transaction for an instrument without loading or tracking the entities.
     /// </summary>
     Task<IEnumerable<TransactionDescription>> GetTransactionDescriptions(Guid instrumentId, CancellationToken cancellationToken = default);
-
-    void AddRange(IEnumerable<Transaction> transactions);
 }

--- a/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
 internal class Accounts : EndpointGroupBase
 {
-    public override string Name => "Accounts";
-
     public override string Path => "/accounts";
 
-    public override string Tags => "Accounts";
+    public override string[] Tags => ["Accounts"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
@@ -13,7 +13,7 @@ internal class Accounts : EndpointGroupBase
 {
     public override string Path => "/accounts";
 
-    public override string[] Tags => ["Accounts"];
+    public override string? Tag => "Accounts";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Accounts/Endpoints/InstitutionAccounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/InstitutionAccounts.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
 internal class InstitutionAccounts : EndpointGroupBase
 {
-    public override string Name => "Accounts";
-
     public override string Path => "/accounts/{instrumentId}/institution-accounts";
 
-    public override string Tags => "Accounts";
+    public override string[] Tags => ["Accounts"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Accounts/Endpoints/InstitutionAccounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/InstitutionAccounts.cs
@@ -13,7 +13,7 @@ internal class InstitutionAccounts : EndpointGroupBase
 {
     public override string Path => "/accounts/{instrumentId}/institution-accounts";
 
-    public override string[] Tags => ["Accounts"];
+    public override string? Tag => "Accounts";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Accounts/Endpoints/Recurring.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Recurring.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
 internal class RecurringEndpoints : EndpointGroupBase
 {
-    public override string Name => "Recurring Transactions";
-
     public override string Path => "accounts/{accountId}/recurring";
 
-    public override string Tags => "Recurring Transactions";
+    public override string[] Tags => ["Recurring Transactions"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {
@@ -33,7 +31,7 @@ internal class RecurringEndpoints : EndpointGroupBase
             .Produces<RecurringTransaction>();
 
 
-        routeGroupBuilder.MapPatchCommand<Update, RecurringTransaction>("/{recurringTransactionId}", CommandBinding.None)
+        routeGroupBuilder.MapPatchCommand<Update, RecurringTransaction>("/{recurringTransactionId}", binding: CommandBinding.None)
             .WithNames("Update Recurring Transaction")
             .Accepts<Update>("application/json")
             .Produces<RecurringTransaction>();

--- a/src/MooBank.Modules.Accounts/Endpoints/Recurring.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Recurring.cs
@@ -13,7 +13,7 @@ internal class RecurringEndpoints : EndpointGroupBase
 {
     public override string Path => "accounts/{accountId}/recurring";
 
-    public override string[] Tags => ["Recurring Transactions"];
+    public override string? Tag => "Recurring Transactions";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Accounts/Endpoints/VirtualRecurring.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/VirtualRecurring.cs
@@ -11,7 +11,7 @@ internal class VirtualRecurringEndpoints : EndpointGroupBase
 {
     public override string Path => "accounts/{accountId}/virtual/{virtualAccountId}/recurring";
 
-    public override string[] Tags => ["Recurring Transactions"];
+    public override string? Tag => "Recurring Transactions";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Accounts/Endpoints/VirtualRecurring.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/VirtualRecurring.cs
@@ -9,11 +9,9 @@ namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
 internal class VirtualRecurringEndpoints : EndpointGroupBase
 {
-    public override string Name => "Recurring Transactions";
-
     public override string Path => "accounts/{accountId}/virtual/{virtualAccountId}/recurring";
 
-    public override string Tags => "Recurring Transactions";
+    public override string[] Tags => ["Recurring Transactions"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Assets/Endpoints/Assets.cs
+++ b/src/MooBank.Modules.Assets/Endpoints/Assets.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Assets.Endpoints;
 
 internal class Assets : EndpointGroupBase
 {
-    public override string Name => "Assets";
-
     public override string Path => "/assets";
 
-    public override string Tags => "Assets";
+    public override string[] Tags => ["Assets"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
@@ -26,7 +24,7 @@ internal class Assets : EndpointGroupBase
         builder.MapPostCreate<Create, Asset>("/", "Get Asset".ToMachine(), a => new { a.Id }, CommandBinding.Body)
             .WithNames("Create Asset");
 
-        builder.MapPatchCommand<Update, Asset>("/{id}", CommandBinding.None)
+        builder.MapPatchCommand<Update, Asset>("/{id}", binding: CommandBinding.None)
             .WithNames("Update Asset")
             .Accepts<Update>("application/json")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy("id"));

--- a/src/MooBank.Modules.Assets/Endpoints/Assets.cs
+++ b/src/MooBank.Modules.Assets/Endpoints/Assets.cs
@@ -13,7 +13,7 @@ internal class Assets : EndpointGroupBase
 {
     public override string Path => "/assets";
 
-    public override string[] Tags => ["Assets"];
+    public override string? Tag => "Assets";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Bills/Endpoints/BillAccounts.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/BillAccounts.cs
@@ -8,11 +8,9 @@ namespace Asm.MooBank.Modules.Bills.Endpoints;
 
 internal class BillAccounts : EndpointGroupBase
 {
-    public override string Name => "Bill Accounts";
-
     public override string Path => "/bills/accounts/{instrumentId}";
 
-    public override string Tags => "Bills";
+    public override string[] Tags => ["Bills"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Bills/Endpoints/BillAccounts.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/BillAccounts.cs
@@ -10,7 +10,7 @@ internal class BillAccounts : EndpointGroupBase
 {
     public override string Path => "/bills/accounts/{instrumentId}";
 
-    public override string[] Tags => ["Bills"];
+    public override string? Tag => "Bills";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Bills/Endpoints/BillReports.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/BillReports.cs
@@ -9,7 +9,7 @@ internal class BillReports : EndpointGroupBase
 {
     public override string Path => "/bills/reports";
 
-    public override string[] Tags => ["Bills"];
+    public override string? Tag => "Bills";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Bills/Endpoints/BillReports.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/BillReports.cs
@@ -7,11 +7,9 @@ namespace Asm.MooBank.Modules.Bills.Endpoints;
 
 internal class BillReports : EndpointGroupBase
 {
-    public override string Name => "Bill Reports";
-
     public override string Path => "/bills/reports";
 
-    public override string Tags => "Bills";
+    public override string[] Tags => ["Bills"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Bills/Endpoints/Bills.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/Bills.cs
@@ -9,7 +9,7 @@ internal class Bills : EndpointGroupBase
 {
     public override string Path => "/bills";
 
-    public override string[] Tags => ["Bills"];
+    public override string? Tag => "Bills";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Bills/Endpoints/Bills.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/Bills.cs
@@ -7,11 +7,9 @@ namespace Asm.MooBank.Modules.Bills.Endpoints;
 
 internal class Bills : EndpointGroupBase
 {
-    public override string Name => "Bills";
-
     public override string Path => "/bills";
 
-    public override string Tags => "Bills";
+    public override string[] Tags => ["Bills"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
@@ -27,13 +25,13 @@ internal class Bills : EndpointGroupBase
         builder.MapQuery<Queries.Accounts.GetAll, IEnumerable<Models.Account>>("/accounts")
             .WithNames("Get Bill Accounts");
 
-        builder.MapPostCreate<Commands.Accounts.Create, Models.Account>("/accounts", "Get Bill Account".ToMachine(), a => new { InstrumentId = a.Id })
+        builder.MapPostCreate<Commands.Accounts.Create, Models.Account>("/accounts", "Get Bill Account".ToMachine(), a => new { InstrumentId = a.Id }, CommandBinding.Body)
             .WithNames("Create Bill Account");
 
         builder.MapPagedQuery<Queries.Bills.GetByUtilityType, Models.Bill>("/types/{utilityType}/bills")
             .WithNames("Get Bills By Utility Type");
 
-        builder.MapCommand<Commands.Bills.Import, Models.ImportResult>("/import", CommandBinding.Body)
+        builder.MapCommand<Commands.Bills.Import, Models.ImportResult>("/import", binding: CommandBinding.Body)
             .WithNames("Import Bills");
     }
 }

--- a/src/MooBank.Modules.Budgets/Endpoints/Budget.cs
+++ b/src/MooBank.Modules.Budgets/Endpoints/Budget.cs
@@ -13,7 +13,7 @@ public class Budget : EndpointGroupBase
 {
     public override string Path => "/budget";
 
-    public override string[] Tags => ["Budget"];
+    public override string? Tag => "Budget";
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Budgets/Endpoints/Budget.cs
+++ b/src/MooBank.Modules.Budgets/Endpoints/Budget.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Budgets.Endpoints;
 
 public class Budget : EndpointGroupBase
 {
-    public override string Name => "Budget";
-
     public override string Path => "/budget";
 
-    public override string Tags => "Budget";
+    public override string[] Tags => ["Budget"];
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Budgets/Endpoints/Reports.cs
+++ b/src/MooBank.Modules.Budgets/Endpoints/Reports.cs
@@ -9,11 +9,9 @@ namespace Asm.MooBank.Modules.Budgets.Endpoints;
 
 public class ReportEndpoint : EndpointGroupBase
 {
-    public override string Name => "Budget";
-
     public override string Path => "/budget/{year}/report";
 
-    public override string Tags => "Budget Report";
+    public override string[] Tags => ["Budget Report"];
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
@@ -25,10 +23,10 @@ public class ReportEndpoint : EndpointGroupBase
         routeGroupBuilder.MapQuery<ReportForMonth, BudgetReportValueMonth?>("{month}")
             .WithNames("Get Budget Report for Month");
 
-        routeGroupBuilder.MapQuery<ReportForMonthBreakdown, BudgetReportByMonthBreakdown?>("{month}/breakdown")
+        routeGroupBuilder.MapQuery<ReportForMonthBreakdown, BudgetReportByMonthBreakdown>("{month}/breakdown")
             .WithNames("Get Budget Report Breakdown for Month");
 
-        routeGroupBuilder.MapQuery<ReportForMonthBreakdownUnbudgeted, BudgetReportByMonthBreakdown?>("{month}/breakdown/unbudgeted")
+        routeGroupBuilder.MapQuery<ReportForMonthBreakdownUnbudgeted, BudgetReportByMonthBreakdown>("{month}/breakdown/unbudgeted")
             .WithNames("Get Budget Report Breakdown for Month for Unbudgeted Items");
     }
 }

--- a/src/MooBank.Modules.Budgets/Endpoints/Reports.cs
+++ b/src/MooBank.Modules.Budgets/Endpoints/Reports.cs
@@ -11,7 +11,7 @@ public class ReportEndpoint : EndpointGroupBase
 {
     public override string Path => "/budget/{year}/report";
 
-    public override string[] Tags => ["Budget Report"];
+    public override string? Tag => "Budget Report";
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Families/Endpoints/Families.cs
+++ b/src/MooBank.Modules.Families/Endpoints/Families.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Families.Endpoints;
 
 internal class Families : EndpointGroupBase
 {
-    public override string Name => "Families";
-
     public override string Path => "/families";
 
-    public override string Tags => "Families";
+    public override string[] Tags => ["Families"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Families/Endpoints/Families.cs
+++ b/src/MooBank.Modules.Families/Endpoints/Families.cs
@@ -12,7 +12,7 @@ internal class Families : EndpointGroupBase
 {
     public override string Path => "/families";
 
-    public override string[] Tags => ["Families"];
+    public override string? Tag => "Families";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Families/Endpoints/FamiliesAdmin.cs
+++ b/src/MooBank.Modules.Families/Endpoints/FamiliesAdmin.cs
@@ -12,7 +12,7 @@ internal class FamiliesAdmin : EndpointGroupBase
 {
     public override string Path => "/families/admin";
 
-    public override string[] Tags => ["Families"];
+    public override string? Tag => "Families";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Families/Endpoints/FamiliesAdmin.cs
+++ b/src/MooBank.Modules.Families/Endpoints/FamiliesAdmin.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Families.Endpoints;
 
 internal class FamiliesAdmin : EndpointGroupBase
 {
-    public override string Name => "Families Admin";
-
     public override string Path => "/families/admin";
 
-    public override string Tags => "Families";
+    public override string[] Tags => ["Families"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Forecast/Endpoints/ForecastPlans.cs
+++ b/src/MooBank.Modules.Forecast/Endpoints/ForecastPlans.cs
@@ -13,11 +13,9 @@ namespace Asm.MooBank.Modules.Forecast.Endpoints;
 
 public class ForecastPlans : EndpointGroupBase
 {
-    public override string Name => "Forecast Plans";
-
     public override string Path => "/forecast/plans";
 
-    public override string Tags => "Forecast";
+    public override string[] Tags => ["Forecast"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Forecast/Endpoints/ForecastPlans.cs
+++ b/src/MooBank.Modules.Forecast/Endpoints/ForecastPlans.cs
@@ -15,7 +15,7 @@ public class ForecastPlans : EndpointGroupBase
 {
     public override string Path => "/forecast/plans";
 
-    public override string[] Tags => ["Forecast"];
+    public override string? Tag => "Forecast";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Forecast/Endpoints/PlannedItems.cs
+++ b/src/MooBank.Modules.Forecast/Endpoints/PlannedItems.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Forecast.Endpoints;
 
 public class PlannedItems : EndpointGroupBase
 {
-    public override string Name => "Planned Items";
-
     public override string Path => "/forecast/plans/{planId}/items";
 
-    public override string Tags => "Forecast";
+    public override string[] Tags => ["Forecast"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Forecast/Endpoints/PlannedItems.cs
+++ b/src/MooBank.Modules.Forecast/Endpoints/PlannedItems.cs
@@ -12,7 +12,7 @@ public class PlannedItems : EndpointGroupBase
 {
     public override string Path => "/forecast/plans/{planId}/items";
 
-    public override string[] Tags => ["Forecast"];
+    public override string? Tag => "Forecast";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Groups/Endpoints/Groups.cs
+++ b/src/MooBank.Modules.Groups/Endpoints/Groups.cs
@@ -12,7 +12,7 @@ public class Groups : EndpointGroupBase
 {
     public override string Path => "/groups";
 
-    public override string[] Tags => ["Groups"];
+    public override string? Tag => "Groups";
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Groups/Endpoints/Groups.cs
+++ b/src/MooBank.Modules.Groups/Endpoints/Groups.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Groups.Endpoints;
 
 public class Groups : EndpointGroupBase
 {
-    public override string Name => "Groups";
-
     public override string Path => "/groups";
 
-    public override string Tags => "Groups";
+    public override string[] Tags => ["Groups"];
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
@@ -26,7 +24,7 @@ public class Groups : EndpointGroupBase
             .WithNames("Get Group")
             .RequireAuthorization(Policies.GetGroupOwnerPolicy("id"));
 
-        routeGroupBuilder.MapPostCreate<Create, Models.Group>("/", "Get Group".ToMachine(), (group) => new { id = group.Id })
+        routeGroupBuilder.MapPostCreate<Create, Models.Group>("/", "Get Group".ToMachine(), (group) => new { id = group.Id }, CommandBinding.Body)
             .WithNames("Create Group")
             .WithValidation<Create>();
 

--- a/src/MooBank.Modules.Institutions/Endpoints/Institutions.cs
+++ b/src/MooBank.Modules.Institutions/Endpoints/Institutions.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Institutions.Endpoints;
 
 internal class Institutions : EndpointGroupBase
 {
-    public override string Name => "Institutions";
-
     public override string Path => "/institutions";
 
-    public override string Tags => "Institutions";
+    public override string[] Tags => ["Institutions"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {
@@ -24,7 +22,7 @@ internal class Institutions : EndpointGroupBase
         routeGroupBuilder.MapQuery<Get, Models.Institution>("/{id}")
             .WithNames("Get Institution");
 
-        routeGroupBuilder.MapPostCreate<Create, Models.Institution>("/", "Get Institution".ToMachine(), (i) => new { i.Id })
+        routeGroupBuilder.MapPostCreate<Create, Models.Institution>("/", "Get Institution".ToMachine(), (i) => new { i.Id }, CommandBinding.Body)
             .WithNames("Create Institution")
             .RequireAuthorization(Policies.Admin)
             .WithValidation<Create>();

--- a/src/MooBank.Modules.Institutions/Endpoints/Institutions.cs
+++ b/src/MooBank.Modules.Institutions/Endpoints/Institutions.cs
@@ -12,7 +12,7 @@ internal class Institutions : EndpointGroupBase
 {
     public override string Path => "/institutions";
 
-    public override string[] Tags => ["Institutions"];
+    public override string? Tag => "Institutions";
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)
     {

--- a/src/MooBank.Modules.Instruments/Endpoints/Import.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Import.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
 internal class Import : EndpointGroupBase
 {
-    public override string Name => "Import";
-
     public override string Path => "/instruments/{instrumentId}/accounts/{accountId}/import";
 
-    public override string Tags => "Import";
+    public override string[] Tags => ["Import"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
@@ -28,7 +26,7 @@ internal class Import : EndpointGroupBase
             }
 
             using Stream stream = file.OpenReadStream();
-            await commandDispatcher.Dispatch(new Commands.Import.Import(instrumentId, accountId, stream), cancellationToken);
+            await commandDispatcher.Execute(new Commands.Import.Import(instrumentId, accountId, stream), cancellationToken);
             return Results.NoContent();
         })
             .WithMetadata(new RequireAntiforgeryTokenAttribute(false))

--- a/src/MooBank.Modules.Instruments/Endpoints/Import.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Import.cs
@@ -13,7 +13,7 @@ internal class Import : EndpointGroupBase
 {
     public override string Path => "/instruments/{instrumentId}/accounts/{accountId}/import";
 
-    public override string[] Tags => ["Import"];
+    public override string? Tag => "Import";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Instruments/Endpoints/Instruments.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Instruments.cs
@@ -13,7 +13,7 @@ internal class Instruments : EndpointGroupBase
 {
     public override string Path => "/instruments";
 
-    public override string[] Tags => ["Instruments"];
+    public override string? Tag => "Instruments";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Instruments/Endpoints/Instruments.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Instruments.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
 internal class Instruments : EndpointGroupBase
 {
-    public override string Name => "Instruments";
-
     public override string Path => "/instruments";
 
-    public override string Tags => "Instruments";
+    public override string[] Tags => ["Instruments"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Instruments/Endpoints/Rules.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Rules.cs
@@ -12,11 +12,9 @@ namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
 public class RulesEndpoints : EndpointGroupBase
 {
-    public override string Name => "Rules";
-
     public override string Path => "instruments/{instrumentId}/rules";
 
-    public override string Tags => "Rules";
+    public override string[] Tags => ["Rules"];
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Instruments/Endpoints/Rules.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Rules.cs
@@ -14,7 +14,7 @@ public class RulesEndpoints : EndpointGroupBase
 {
     public override string Path => "instruments/{instrumentId}/rules";
 
-    public override string[] Tags => ["Rules"];
+    public override string? Tag => "Rules";
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Instruments/Endpoints/VirtualInstruments.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/VirtualInstruments.cs
@@ -14,7 +14,7 @@ internal class VirtualInstruments : EndpointGroupBase
 {
     public override string Path => "/instruments/{instrumentId}/virtual";
 
-    public override string[] Tags => ["Virtual Instruments"];
+    public override string? Tag => "Virtual Instruments";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Instruments/Endpoints/VirtualInstruments.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/VirtualInstruments.cs
@@ -12,11 +12,9 @@ namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
 internal class VirtualInstruments : EndpointGroupBase
 {
-    public override string Name => "Virtual Instruments";
-
     public override string Path => "/instruments/{instrumentId}/virtual";
 
-    public override string Tags => Name;
+    public override string[] Tags => ["Virtual Instruments"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
@@ -29,11 +27,11 @@ internal class VirtualInstruments : EndpointGroupBase
         builder.MapPostCreate<Create, VirtualInstrument>("/", "Get Virtual Instrument".ToMachine(), a => new { VirtualInstrumentId = a.Id }, CommandBinding.Parameters)
             .WithNames("Create Virtual Instrument");
 
-        builder.MapPatchCommand<Update, VirtualInstrument>("/{virtualInstrumentId}", CommandBinding.None)
+        builder.MapPatchCommand<Update, VirtualInstrument>("/{virtualInstrumentId}", binding: CommandBinding.None)
             .WithNames("Update Virtual Instrument")
             .Accepts<Update>("application/json");
 
-        builder.MapPatchCommand<UpdateBalance, VirtualInstrument>("/{virtualInstrumentId}/balance", CommandBinding.None)
+        builder.MapPatchCommand<UpdateBalance, VirtualInstrument>("/{virtualInstrumentId}/balance", binding: CommandBinding.None)
             .WithNames("Update Virtual Instrument Balance")
             .Accepts<UpdateBalance>("application/json");
 

--- a/src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs
+++ b/src/MooBank.Modules.Instruments/Queries/Instruments/GetFormatted.cs
@@ -34,7 +34,7 @@ internal class GetFormattedHandler(IQueryable<Domain.Entities.Account.LogicalAcc
         var allGroups = logicalAccounts1.Select(g => g.GetGroup(userId))
             .Union(stockHoldings1.Select(g => g.GetGroup(userId)))
             .Union(assets1.Select(a => a.GetGroup(userId)))
-            .Distinct(new IIdentifiableEqualityComparer<Domain.Entities.Group.Group, Guid>()!);
+            .Distinct(new IdentifiableEqualityComparer<Domain.Entities.Group.Group, Guid>()!);
 
         List<Group> groups = [];
 

--- a/src/MooBank.Modules.ReferenceData/Endpoints/ReferenceData.cs
+++ b/src/MooBank.Modules.ReferenceData/Endpoints/ReferenceData.cs
@@ -11,7 +11,7 @@ internal class ReferenceData : EndpointGroupBase
 {
     public override string Path => "/reference-data";
 
-    public override string[] Tags => ["Reference Data"];
+    public override string? Tag => "Reference Data";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.ReferenceData/Endpoints/ReferenceData.cs
+++ b/src/MooBank.Modules.ReferenceData/Endpoints/ReferenceData.cs
@@ -9,11 +9,9 @@ namespace Asm.MooBank.Modules.ReferenceData.Endpoints;
 
 internal class ReferenceData : EndpointGroupBase
 {
-    public override string Name => "Reference Data";
-
     public override string Path => "/reference-data";
 
-    public override string Tags => "Reference Data";
+    public override string[] Tags => ["Reference Data"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Reports/Endpoints/GroupReports.cs
+++ b/src/MooBank.Modules.Reports/Endpoints/GroupReports.cs
@@ -11,7 +11,7 @@ internal class GroupReports : EndpointGroupBase
 {
     public override string Path => "groups/{groupId}/reports";
 
-    public override string[] Tags => ["Group Reports"];
+    public override string? Tag => "Group Reports";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Reports/Endpoints/GroupReports.cs
+++ b/src/MooBank.Modules.Reports/Endpoints/GroupReports.cs
@@ -9,11 +9,9 @@ namespace Asm.MooBank.Modules.Reports.Endpoints;
 
 internal class GroupReports : EndpointGroupBase
 {
-    public override string Name => "Group Reports";
-
     public override string Path => "groups/{groupId}/reports";
 
-    public override string Tags => "Group Reports";
+    public override string[] Tags => ["Group Reports"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Reports/Endpoints/Reports.cs
+++ b/src/MooBank.Modules.Reports/Endpoints/Reports.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Reports.Endpoints;
 
 internal class Reports : EndpointGroupBase
 {
-    public override string Name => "Reports";
-
     public override string Path => "accounts/{accountId}/reports";
 
-    public override string Tags => "Reports";
+    public override string[] Tags => ["Reports"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Reports/Endpoints/Reports.cs
+++ b/src/MooBank.Modules.Reports/Endpoints/Reports.cs
@@ -12,7 +12,7 @@ internal class Reports : EndpointGroupBase
 {
     public override string Path => "accounts/{accountId}/reports";
 
-    public override string[] Tags => ["Reports"];
+    public override string? Tag => "Reports";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Stocks/Endpoints/StockHoldings.cs
+++ b/src/MooBank.Modules.Stocks/Endpoints/StockHoldings.cs
@@ -13,7 +13,7 @@ internal class StockHoldings : EndpointGroupBase
 {
     public override string Path => "/stocks";
 
-    public override string[] Tags => ["Stock Holding"];
+    public override string? Tag => "Stock Holding";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Stocks/Endpoints/StockHoldings.cs
+++ b/src/MooBank.Modules.Stocks/Endpoints/StockHoldings.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Stocks.Endpoints;
 
 internal class StockHoldings : EndpointGroupBase
 {
-    public override string Name => "Stock Holdings";
-
     public override string Path => "/stocks";
 
-    public override string Tags => "Stock Holding";
+    public override string[] Tags => ["Stock Holding"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
@@ -30,7 +28,7 @@ internal class StockHoldings : EndpointGroupBase
         builder.MapPostCreate<Create, StockHolding>("/", "Get Stock Holding".ToMachine(), a => new { InstrumentId = a.Id }, CommandBinding.Body)
             .WithNames("Create Stock Holding");
 
-        builder.MapPatchCommand<Update, StockHolding>("/{instrumentId}", CommandBinding.None)
+        builder.MapPatchCommand<Update, StockHolding>("/{instrumentId}", binding: CommandBinding.None)
             .WithNames("Update Stock Holding")
             .Accepts<Update>("application/json")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy());

--- a/src/MooBank.Modules.Stocks/Endpoints/StockTransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Stocks/Endpoints/StockTransactionsEndpoints.cs
@@ -11,18 +11,16 @@ namespace Asm.MooBank.Modules.Stocks.Endpoints;
 
 internal class StockTransactionsEndpoints : EndpointGroupBase
 {
-    public override string Name => "Stock Transactions";
-
     public override string Path => "/stocks/{instrumentId}/transactions";
 
-    public override string Tags => "Transactions";
+    public override string[] Tags => ["Transactions"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
         builder.MapPagedQuery<Get, StockTransaction>("{pageSize}/{pageNumber}")
             .WithNames("Get Stock Transactions");
 
-        builder.MapCommand<Create, StockTransaction>("/", CommandBinding.None)
+        builder.MapCommand<Create, StockTransaction>("/", binding: CommandBinding.None)
             .WithNames("Create Stock Transaction")
             .Accepts<Create>("application/json");
     }

--- a/src/MooBank.Modules.Stocks/Endpoints/StockTransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Stocks/Endpoints/StockTransactionsEndpoints.cs
@@ -13,7 +13,7 @@ internal class StockTransactionsEndpoints : EndpointGroupBase
 {
     public override string Path => "/stocks/{instrumentId}/transactions";
 
-    public override string[] Tags => ["Transactions"];
+    public override string? Tag => "Transactions";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Tags/Endpoints/Tags.cs
+++ b/src/MooBank.Modules.Tags/Endpoints/Tags.cs
@@ -14,7 +14,7 @@ internal class TagsEndpoints : EndpointGroupBase
 {
     public override string Path => "/tags";
 
-    public override string[] Tags => ["Tags"];
+    public override string? Tag => "Tags";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Tags/Endpoints/Tags.cs
+++ b/src/MooBank.Modules.Tags/Endpoints/Tags.cs
@@ -12,11 +12,9 @@ namespace Asm.MooBank.Modules.Tags.Endpoints;
 
 internal class TagsEndpoints : EndpointGroupBase
 {
-    public override string Name => "Tags";
-
     public override string Path => "/tags";
 
-    public override string Tags => "Tags";
+    public override string[] Tags => ["Tags"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
@@ -13,7 +13,7 @@ internal class TransactionsEndpoints : EndpointGroupBase
 {
     public override string Path => "accounts/{instrumentId}/transactions";
 
-    public override string[] Tags => ["Transactions"];
+    public override string? Tag => "Transactions";
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {

--- a/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
@@ -11,11 +11,9 @@ namespace Asm.MooBank.Modules.Transactions.Endpoints;
 
 internal class TransactionsEndpoints : EndpointGroupBase
 {
-    public override string Name => "Transactions";
-
     public override string Path => "accounts/{instrumentId}/transactions";
 
-    public override string Tags => "Transactions";
+    public override string[] Tags => ["Transactions"];
 
     protected override void MapEndpoints(IEndpointRouteBuilder builder)
     {
@@ -28,14 +26,14 @@ internal class TransactionsEndpoints : EndpointGroupBase
         builder.MapQuery<Search, IEnumerable<Transaction>>("")
             .WithNames("Search Transactions");
 
-        builder.MapCommand<Create, Transaction>("", CommandBinding.Parameters)
+        builder.MapCommand<Create, Transaction>("", binding: CommandBinding.Parameters)
             .WithNames("Create Transaction")
             .Accepts<Models.CreateTransaction>("application/json");
 
-        builder.MapCommand<UpdateBalance, Transaction>("/balance-adjustment", CommandBinding.Parameters)
+        builder.MapCommand<UpdateBalance, Transaction>("/balance-adjustment", binding: CommandBinding.Parameters)
             .WithNames("Set Balance");
 
-        builder.MapPatchCommand<UpdateTransaction, Transaction>("{id}", CommandBinding.None)
+        builder.MapPatchCommand<UpdateTransaction, Transaction>("{id}", binding: CommandBinding.None)
             .WithNames("Update Transaction")
             .Accepts<UpdateTransaction>("application/json");
 

--- a/src/MooBank.Modules.Users/Endpoints/User.cs
+++ b/src/MooBank.Modules.Users/Endpoints/User.cs
@@ -10,11 +10,9 @@ namespace Asm.MooBank.Modules.Users.Endpoints;
 
 public class User : EndpointGroupBase
 {
-    public override string Name => "User";
-
     public override string Path => "/users";
 
-    public override string Tags => "User";
+    public override string[] Tags => ["User"];
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Modules.Users/Endpoints/User.cs
+++ b/src/MooBank.Modules.Users/Endpoints/User.cs
@@ -12,7 +12,7 @@ public class User : EndpointGroupBase
 {
     public override string Path => "/users";
 
-    public override string[] Tags => ["User"];
+    public override string? Tag => "User";
 
 
     protected override void MapEndpoints(IEndpointRouteBuilder routeGroupBuilder)

--- a/src/MooBank.Web.App/src/api/types.gen.ts
+++ b/src/MooBank.Web.App/src/api/types.gen.ts
@@ -3329,7 +3329,9 @@ export type UpdateTagResponse = UpdateTagResponses[keyof UpdateTagResponses];
 
 export type CreateTagByNameData = {
     body: Array<number>;
-    path?: never;
+    path: {
+        name: string;
+    };
     query?: never;
     url: '/tags/{name}';
 };


### PR DESCRIPTION
Uplift the ASM library from `3.8.169` to `4.0.0-beta.0`, migrating the breaking changes from the v4 code audit. Guide: `Asm/docs/migration-v4.md`.

## Changes

- **Packages** — 8 ASM packages → `4.0.0-beta.0`.
- **`EndpointGroupBase` (Batch 9)** ×28 — removed the deleted `Name` override; `Tags` changed `string` → `string[]`.
- **CQRS endpoint mapping (Batch 2)** — body-returning `Map*` commands gained an `int statusCode` at position 2, so the 10 sites passing `CommandBinding` positionally now name it (`binding:`).
- **`Dispatch` → `Execute` (Batch 2)** — for the void `Import` command.
- **Repositories (Batch 3)** — dropped the redundant `ITransactionRepository.AddRange` (now a default member on `IWritableRepository`).
- **`IIdentifiableEqualityComparer` → `IdentifiableEqualityComparer` (Batch 1b)**.
- **ProblemDetails (Batch 5)** — `AddProblemDetailsFactory()` → `AddAsmExceptionHandler()`.
- **Security headers (Batch 7)** — `AddStandardSecurityHeaders` now returns `IServiceCollection`; moved the CSP, permissions policy and COEP removal into the `configure` callback.
- **Variance removal (Batch 2)** — the two Budget breakdown report endpoints mapped a nullable response that only compiled under v3 query covariance; aligned them with the queries' non-nullable contract (the handlers never return `null`).

## Two traps the migration guide didn't flag (caught empirically)

1. **`Asm.OAuth` v4 added `.ValidateOnStart()`** to `AddAzureOAuthOptions`, which the build-time OpenAPI generation trips with no OAuth config (`Audience/ClientId/TenantId is required`). Fixed by supplying the real **public** OAuth identifiers (tenant, audience, client id — already in `publish/appsettings.json` and the SPA) in `appsettings.json`; real environments still override via configuration. A tidier long-term fix would live in ASM.
2. **`MapPostCreate` default binding changed to `Parameters`** — three plain-payload create endpoints (`POST /groups`, `/institutions`, `/bills/accounts`) silently flipped from JSON body to query params. **No compile error** — only the regenerated OpenAPI spec revealed it. Restored with explicit `CommandBinding.Body`. (Decision: keep ASM's `Parameters` default — it mirrors controller `[AsParameters]` binding — and be explicit at the call sites.)

## Spec / frontend

`openapi-v1.json` and the frontend `types.gen.ts` are regenerated. Operation IDs and paths are **unchanged**; the only spec differences are the OIDC discovery URL (now the real tenant) and the newly-documented `/tags/{name}` path parameter.

## Validation

- Backend: **0 warnings / 0 errors**, including build-time OpenAPI generation.
- Tests: **~2,000 unit + 68 Api integration** (exception-handler & auth pipeline) + Institution tests pass.
- Frontend: **tsgo clean, 165 tests pass, lint clean**.

## Note

Pins `4.0.0-beta.0` (the only v4 build published). Hold merge until v4 is GA if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
