### PR TITLE
refactor: log safe work-item context in queue workers (ASM 4.0.25)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,15 +45,15 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="4.0.22" />
-    <PackageVersion Include="Asm.AspNetCore" Version="4.0.22" />
-    <PackageVersion Include="Asm.AspNetCore.Api" Version="4.0.22" />
-    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.22" />
-    <PackageVersion Include="Asm.Domain" Version="4.0.22" />
-    <PackageVersion Include="Asm.Domain.Infrastructure" Version="4.0.22" />
-    <PackageVersion Include="Asm.Hosting" Version="4.0.22" />
-    <PackageVersion Include="Asm.ModelContextProtocol" Version="4.0.22" />
-    <PackageVersion Include="Asm.Testing.Domain" Version="4.0.22" />
+    <PackageVersion Include="Asm" Version="4.0.25" />
+    <PackageVersion Include="Asm.AspNetCore" Version="4.0.25" />
+    <PackageVersion Include="Asm.AspNetCore.Api" Version="4.0.25" />
+    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.25" />
+    <PackageVersion Include="Asm.Domain" Version="4.0.25" />
+    <PackageVersion Include="Asm.Domain.Infrastructure" Version="4.0.25" />
+    <PackageVersion Include="Asm.Hosting" Version="4.0.25" />
+    <PackageVersion Include="Asm.ModelContextProtocol" Version="4.0.25" />
+    <PackageVersion Include="Asm.Testing.Domain" Version="4.0.25" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/src/MooBank/Services/Background/ImportTransactionsService.cs
+++ b/src/MooBank/Services/Background/ImportTransactionsService.cs
@@ -17,4 +17,7 @@ internal class ImportTransactionsBackgroundService(IBackgroundWorkQueue<ImportWo
         var importTransactionsService = services.GetRequiredService<IImportTransactionsService>();
         await importTransactionsService.Import(workItem, cancellationToken);
     }
+
+    // Log only the ids — never User (PII) or FileData (the imported statement).
+    protected override object? DescribeWorkItem(ImportWorkItem workItem) => new { workItem.InstrumentId, workItem.AccountId };
 }

--- a/src/MooBank/Services/Background/ReprocessTransactionsBackgroundService.cs
+++ b/src/MooBank/Services/Background/ReprocessTransactionsBackgroundService.cs
@@ -13,4 +13,6 @@ internal class ReprocessTransactionsBackgroundService(IBackgroundWorkQueue<Repro
         var reprocessTransactionsService = services.GetRequiredService<IReprocessTransactionsService>();
         await reprocessTransactionsService.Reprocess(workItem, cancellationToken);
     }
+
+    protected override object? DescribeWorkItem(ReprocessWorkItem workItem) => new { workItem.InstrumentId, workItem.AccountId };
 }

--- a/src/MooBank/Services/Background/RunRulesBackgroundService.cs
+++ b/src/MooBank/Services/Background/RunRulesBackgroundService.cs
@@ -12,4 +12,6 @@ internal class RunRulesBackgroundService(IBackgroundWorkQueue<Guid> queue, IServ
         var runRulesService = services.GetRequiredService<IRunRulesService>();
         await runRulesService.RunRules(accountId, cancellationToken);
     }
+
+    protected override object? DescribeWorkItem(Guid accountId) => accountId;
 }


### PR DESCRIPTION
Adopts ASM **4.0.25**, which adds `QueuedHostedService<T>.DescribeWorkItem` (ASM AndrewMcLachlan/ASM#430). The base never logs the raw work item; a worker opts in to a **log-safe** descriptor for the per-item error log.

Override it in the three background workers:

- **RunRules** → the account id (a `Guid`).
- **Reprocess** → `{ InstrumentId, AccountId }`.
- **Import** → `{ InstrumentId, AccountId }` **only** — never `ImportWorkItem.User` (PII: email/name/family) or `.FileData` (the imported statement bytes).

This closes the data-protection gap discussed on #897: previously a failing item was logged with just the service name (safe but context-free); now the error log carries the ids needed to diagnose, with the sensitive fields deliberately excluded.

Full solution builds clean (0 warnings/errors); all unit tests pass.
