### PR TITLE
fix(web): stop MSAL silent renewal forcing interactive re-auth

### DIFF
--- a/src/MooBank.Web.App/public/blank.html
+++ b/src/MooBank.Web.App/public/blank.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Authenticating…</title>
+  </head>
+  <!--
+    Dedicated redirect target for MSAL silent token renewal (the hidden iframe used by
+    acquireTokenSilent), wired up via the `silentRedirectUri` prop on <MooApp> in App.tsx.
+    It MUST NOT load the app or MSAL: the SPA re-booting inside the iframe is what triggers
+    BrowserAuthError: block_iframe_reload and forces an interactive sign-in. MSAL reads the
+    auth response straight from this page's URL hash, so no script is needed.
+    This URL must also be registered as a SPA redirect URI on the Entra app registration.
+    See https://learn.microsoft.com/entra/identity-platform/msal-js-avoid-page-reloads
+  -->
+  <body></body>
+</html>

--- a/src/MooBank.Web.App/src/App.tsx
+++ b/src/MooBank.Web.App/src/App.tsx
@@ -29,6 +29,6 @@ export const App = () => {
     })
 
     return (
-        <MooApp client={client.instance} clientId="045f8afa-70f2-4700-ab75-77ac41b306f7" scopes={["api://moobank.mclachlan.family/api.read"]} name="MooBank" version={import.meta.env.VITE_REACT_APP_VERSION} copyrightYear={2013} router={router} queryPersistOptions={queryPersistOptions} />
+        <MooApp client={client.instance} clientId="045f8afa-70f2-4700-ab75-77ac41b306f7" scopes={["api://moobank.mclachlan.family/api.read"]} name="MooBank" version={import.meta.env.VITE_REACT_APP_VERSION} copyrightYear={2013} router={router} queryPersistOptions={queryPersistOptions} silentRedirectUri={`${window.location.origin}/blank.html`} />
     );
 }

--- a/src/MooBank.Web.App/vite.config.ts
+++ b/src/MooBank.Web.App/vite.config.ts
@@ -51,7 +51,10 @@ export default defineConfig({
         manifest: false,
         workbox: {
             globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
-            navigateFallbackDenylist: [/^\/api/, /^\/swagger/, /^\/mcp/],
+            // /blank.html is the MSAL silent-renewal iframe target: it must serve the real blank
+            // page, never the SPA shell (index.html) — booting the app in the iframe re-triggers
+            // BrowserAuthError: block_iframe_reload. See public/blank.html and App.tsx silentRedirectUri.
+            navigateFallbackDenylist: [/^\/api/, /^\/swagger/, /^\/mcp/, /^\/blank\.html$/],
         },
     }),
     visualizer() as any],


### PR DESCRIPTION
## What
Fixes frequent Azure AD password prompts caused by MSAL silent token renewal failing with `BrowserAuthError: block_iframe_reload`.

## Why
MSAL's hidden silent-renewal iframe (`acquireTokenSilent`) loaded the full SPA as its `redirectUri`. MSAL aborts that reload with `block_iframe_reload`, so the moo-app interceptor falls through to a full-page `acquireTokenRedirect` — which prompts for the password whenever the AAD session needs interaction. This is [Microsoft's documented issue](https://learn.microsoft.com/entra/msal/javascript/browser/errors#block_iframe_reload); the sanctioned fix is a scriptless blank redirect page for silent calls, applied **per-request** for apps that also use redirect methods (MooBank does).

## Changes
- `public/blank.html` — scriptless silent-renewal redirect target; must not load the app or MSAL.
- `src/App.tsx` — pass `silentRedirectUri={`${window.location.origin}/blank.html`}` to `<MooApp>` (moo-app ≥ 5.2).
- `vite.config.ts` — add `/blank.html` to the PWA `navigateFallbackDenylist` so the service worker serves the real blank page to the iframe instead of the SPA shell (which would re-trigger `block_iframe_reload`).

## Required follow-up (Entra, not code)
Register `<origin>/blank.html` as a **SPA** redirect URI on the app registration for every origin (`https://localhost:3005/blank.html`, `https://moobank.dev.localhost:<port>/blank.html`, prod). **Until registered, silent renewal fails on a `redirect_uri` mismatch**, so land the Entra change alongside this.

## Not covered
This fixes the `block_iframe_reload` path only. If renewal still prompts and the console shows `login_required` / `AADSTS50058`, that's the separate third-party-cookie problem, not this.

## Validation
typecheck, lint, 172 tests, and production build all pass (on moo-app 5.2.38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)