### PR TITLE
perf(web): preempt and warm the transaction list on account navigation

### DIFF
--- a/src/MooBank.Web.App/src/components/AccountList/AccountRow.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/AccountRow.tsx
@@ -2,7 +2,7 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import React, { useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 
 import { numberClassName } from "utils/classNameHelpers";
 
@@ -14,7 +14,7 @@ import { AccountTypeBadge } from "components/AccountTypeBadge";
 
 export const AccountRow: React.FC<AccountRowProps> = (props) => {
 
-    const { onRowClick } = useAccountRowCommonState(props);
+    const { onRowClick, onRowMouseEnter } = useAccountRowCommonState(props);
 
     const [showVirtualAccounts, setShowVirtualAccounts] = useState<boolean>(localStorage.getItem(`account|${MD5(props.instrument.id)}`) === "true");
 
@@ -28,7 +28,7 @@ export const AccountRow: React.FC<AccountRowProps> = (props) => {
 
     return (
         <>
-            <tr onClick={onRowClick} className="clickable">
+            <tr onClick={onRowClick} onMouseEnter={onRowMouseEnter} className="clickable">
                 <td className="d-none d-sm-table-cell" onClick={showVirtualAccountsClick}>{props.instrument.virtualInstruments && props.instrument.virtualInstruments.length > 0 && <FontAwesomeIcon icon={showVirtualAccounts ? "chevron-down" : "chevron-right"} />}</td>
                 <td>{props.instrument.name}</td>
                 <td className="d-none d-sm-table-cell"><AccountTypeBadge type={props.instrument.instrumentType} /></td>
@@ -59,6 +59,7 @@ export interface AccountRowProps {
 export const useAccountRowCommonState = (props: AccountRowProps) => {
 
     const navigate = useNavigate();
+    const router = useRouter();
 
     const onRowClick = () => {
 
@@ -70,12 +71,20 @@ export const useAccountRowCommonState = (props: AccountRowProps) => {
                 navigate({ to: `/shares/${props.instrument.id}` });
                 break;
             default:
-                navigate({ to: `/accounts/${props.instrument.id}` });
+                navigate({ to: `/accounts/${props.instrument.id}/transactions` });
                 break;
         }
     };
 
+    // Hover-prefetch the transactions route (runs its warming loader) so the list is ready by the
+    // time the row is clicked. Only accounts have the optimised route; assets/shares are unchanged.
+    const onRowMouseEnter = () => {
+        if (props.instrument.instrumentType === "Asset" || props.instrument.instrumentType === "Shares") return;
+        void router.preloadRoute({ to: "/accounts/$id/transactions", params: { id: props.instrument.id } } as any);
+    };
+
     return {
         onRowClick,
+        onRowMouseEnter,
     };
 }

--- a/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/-dashboard/Breakdown.tsx
@@ -23,8 +23,8 @@ export const BreakdownWidget: React.FC = () => {
         // period=1 (Last Month) scopes the target page to the dashboard's period.
         if (!clickedTag.hasChildren) {
             const url = !clickedTag.tagId
-                ? `/accounts/${account!.id}?untagged=true&period=1`
-                : `/accounts/${account!.id}?tag=${clickedTag.tagId}&type=${reportType}&period=1`;
+                ? `/accounts/${account!.id}/transactions?untagged=true&period=1`
+                : `/accounts/${account!.id}/transactions?tag=${clickedTag.tagId}&type=${reportType}&period=1`;
             navigate({ to: url });
             return;
         }

--- a/src/MooBank.Web.App/src/routes/__root.tsx
+++ b/src/MooBank.Web.App/src/routes/__root.tsx
@@ -3,11 +3,16 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 
 import { getTagsOptions, importerTypesOptions } from "api/@tanstack/react-query.gen";
+import { setRouterQueryClient } from "utils/routerQueryClient";
 import Layout from "../Layout";
 
 const Root = () => {
 
     const queryClient = useQueryClient();
+
+    // PROTOTYPE: expose the live QueryClient to the /accounts/$id route loader,
+    // which runs outside React and can't reach it via context. See routerQueryClient.ts.
+    setRouterQueryClient(queryClient);
 
     // The root route only renders once login has completed, so this warms
     // caches the user will need shortly (tag panels, import page) while they

--- a/src/MooBank.Web.App/src/routes/accounts/$id/index.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/index.tsx
@@ -1,5 +1,9 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
+// Fallback for direct hits on the bare /accounts/$id URL (bookmarks, refresh): redirect to the
+// default tab, forwarding any search params. In-app navigation must target /accounts/$id/transactions
+// (or another concrete tab) DIRECTLY, never the bare route — a client-side navigation through this
+// beforeLoad redirect deadlocks the router if the /accounts/$id layout route ever gains a loader.
 export const Route = createFileRoute("/accounts/$id/")({
     beforeLoad: ({ params, location }) => {
         throw redirect({

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/BreakdownPage.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/BreakdownPage.tsx
@@ -32,8 +32,8 @@ export const BreakdownPage = () => {
     const selectedTagChanged = (clickedTag: TagValue) => {
         if (!clickedTag.hasChildren || clickedTag.tagId === tagId) {
             const url = !clickedTag.tagId
-                ? `/accounts/${accountId}?untagged=true`
-                : `/accounts/${accountId}?tag=${clickedTag.tagId}&type=${reportType}`;
+                ? `/accounts/${accountId}/transactions?untagged=true`
+                : `/accounts/${accountId}/transactions?tag=${clickedTag.tagId}&type=${reportType}`;
             navigate({ to: url });
             return;
         }

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
@@ -60,7 +60,7 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
                 if (elements.length !== 1) return;
                 const tag = report.data!.tags[elements[0].index];
                 const periodQuery = periodId ? `&period=${periodId}` : "";
-                const url = !tag.tagId ? `/accounts/${accountId}?untagged=true${periodQuery}` : `/accounts/${accountId}?tag=${tag.tagId}&type=${reportType}${periodQuery}`;
+                const url = !tag.tagId ? `/accounts/${accountId}/transactions?untagged=true${periodQuery}` : `/accounts/${accountId}/transactions?tag=${tag.tagId}&type=${reportType}${periodQuery}`;
                 navigate({ to: url });
             },
         }}

--- a/src/MooBank.Web.App/src/routes/accounts/$id/transactions.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/transactions.tsx
@@ -1,8 +1,35 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Transactions } from "../-transactions/Transactions";
-import { validateTransactionSearch } from "../-transactions/transactionSearch";
+import {
+    defaultSortDirection,
+    defaultSortField,
+    getStoredPageSize,
+    resolveTransactionSearch,
+    searchToFilter,
+    validateTransactionSearch,
+} from "../-transactions/transactionSearch";
+import { warmTransactions } from "../-hooks/useTransactions";
+import { getRouterQueryClient } from "utils/routerQueryClient";
 
 export const Route = createFileRoute("/accounts/$id/transactions")({
     validateSearch: validateTransactionSearch,
+    loaderDeps: ({ search }) => search,
+    // Warm the transaction list into the cache during route resolution. With defaultPreload:"intent"
+    // and the account rows' hover-preload, this starts the fetch before the click, so the list is
+    // ready (or in flight) by the time the component mounts. Fire-and-forget: never block navigation.
+    loader: ({ params, deps }) => {
+        const queryClient = getRouterQueryClient();
+        if (!queryClient) return;
+        const resolved = resolveTransactionSearch(deps as Record<string, unknown>);
+        void warmTransactions(
+            queryClient,
+            params.id,
+            searchToFilter(resolved),
+            getStoredPageSize(),
+            resolved.page ?? 1,
+            resolved.sortField ?? defaultSortField,
+            resolved.sortDirection ?? defaultSortDirection,
+        );
+    },
     component: Transactions,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/-hooks/useTransactions.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-hooks/useTransactions.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import type { PagedResult, SortDirection } from "@andrewmclachlan/moo-ds";
 import type { Transaction, TransactionFilterType, SortDirection as GenSortDirection } from "api/types.gen";
 import type { TransactionsFilter } from "models/transactions";
@@ -8,9 +9,14 @@ import {
 } from "api/@tanstack/react-query.gen";
 import { getTransactions, getUntaggedTransactions } from "api/sdk.gen";
 
-export const useTransactions = (accountId: string, filter: TransactionsFilter, pageSize: number, pageNumber: number, sortField: string, sortDirection: SortDirection) => {
+// Single source of the query key + fetch for the transaction list, so the component hook and the
+// route loader (which warms the cache) always agree on the key. `tagged` selects the untagged
+// endpoint. `enabled` mirrors the guard that a date range must be present.
+export const transactionsQueryConfig = (accountId: string, filter: TransactionsFilter, pageSize: number, pageNumber: number, sortField: string, sortDirection: SortDirection) => {
 
-    const queryParams = {
+    const path = { instrumentId: accountId, pageSize, pageNumber };
+
+    const query = {
         Filter: filter.description || undefined,
         Start: filter.start || undefined,
         End: filter.end || undefined,
@@ -21,41 +27,44 @@ export const useTransactions = (accountId: string, filter: TransactionsFilter, p
         ExcludeNetZero: filter.filterNetZero || undefined,
     };
 
-    const tagged = filter.filterTagged;
+    const enabled = !!accountId && !!filter?.start && !!filter?.end;
 
-    const untaggedResult = useQuery({
-        queryKey: getUntaggedTransactionsQueryKey({
-            path: { instrumentId: accountId, pageSize, pageNumber },
-            query: queryParams,
-        }),
-        queryFn: async ({ signal }) => {
-            const { data, headers } = await getUntaggedTransactions({
-                path: { instrumentId: accountId, pageSize, pageNumber },
-                query: queryParams,
-                signal,
-                throwOnError: true,
-            });
+    if (filter.filterTagged) {
+        return {
+            enabled,
+            queryKey: getUntaggedTransactionsQueryKey({ path, query }),
+            queryFn: async ({ signal }: { signal: AbortSignal }) => {
+                const { data, headers } = await getUntaggedTransactions({ path, query, signal, throwOnError: true });
+                return { results: data, total: Number(headers['x-total-count'] ?? 0) } as PagedResult<Transaction>;
+            },
+        };
+    }
+
+    return {
+        enabled,
+        queryKey: getTransactionsQueryKey({ path, query }),
+        queryFn: async ({ signal }: { signal: AbortSignal }) => {
+            const { data, headers } = await getTransactions({ path, query, signal, throwOnError: true });
             return { results: data, total: Number(headers['x-total-count'] ?? 0) } as PagedResult<Transaction>;
         },
-        enabled: !!accountId && !!filter?.start && !!filter?.end && tagged,
-    });
+    };
+};
 
-    const regularResult = useQuery({
-        queryKey: getTransactionsQueryKey({
-            path: { instrumentId: accountId, pageSize, pageNumber },
-            query: queryParams,
-        }),
-        queryFn: async ({ signal }) => {
-            const { data, headers } = await getTransactions({
-                path: { instrumentId: accountId, pageSize, pageNumber },
-                query: queryParams,
-                signal,
-                throwOnError: true,
-            });
-            return { results: data, total: Number(headers['x-total-count'] ?? 0) } as PagedResult<Transaction>;
-        },
-        enabled: !!accountId && !!filter?.start && !!filter?.end && !tagged,
-    });
+export const useTransactions = (accountId: string, filter: TransactionsFilter, pageSize: number, pageNumber: number, sortField: string, sortDirection: SortDirection) => {
 
-    return tagged ? untaggedResult : regularResult;
-}
+    const { enabled, queryKey, queryFn } = transactionsQueryConfig(accountId, filter, pageSize, pageNumber, sortField, sortDirection);
+
+    return useQuery({ queryKey, queryFn, enabled });
+};
+
+// Warms the active transactions query into the cache. Used by the transactions route loader so a
+// hover-preload (or the click) fetches the list ahead of the component mounting. No-op if the
+// filter has no date range (the query would be disabled anyway).
+export const warmTransactions = (queryClient: QueryClient, accountId: string, filter: TransactionsFilter, pageSize: number, pageNumber: number, sortField: string, sortDirection: SortDirection) => {
+
+    const { enabled, queryKey, queryFn } = transactionsQueryConfig(accountId, filter, pageSize, pageNumber, sortField, sortDirection);
+
+    if (!enabled) return Promise.resolve(undefined);
+
+    return queryClient.ensureQueryData({ queryKey, queryFn });
+};

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/hooks/useTransactionSearch.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/hooks/useTransactionSearch.ts
@@ -7,6 +7,7 @@ import type { SortDirection } from "@andrewmclachlan/moo-ds";
 import {
     defaultSortDirection,
     defaultSortField,
+    resolveTransactionSearch,
     searchToFilter,
     type TransactionSearch,
 } from "../transactionSearch";
@@ -22,9 +23,13 @@ export const useTransactionSearch = () => {
     const page = search.page ?? 1;
     const sortField = search.sortField ?? defaultSortField;
     const sortDirection = search.sortDirection ?? defaultSortDirection;
+    // Resolve defaults (persisted filters + default period) so the filter carries a date range from
+    // the first render — the query is then enabled immediately (and hits the loader-warmed cache)
+    // instead of waiting for the filter panel's post-mount effect to write params to the URL. `search`
+    // stays raw for the panel, which distinguishes explicit URL/widget params from these defaults.
     // Memoise so the debounced filter has a stable reference to track (searchToFilter builds a
     // fresh object each render); debounce the whole filter at the query, as the former slice did.
-    const filter = useMemo(() => searchToFilter(search), [search]);
+    const filter = useMemo(() => searchToFilter(resolveTransactionSearch(search as Record<string, unknown>)), [search]);
     const [debouncedFilter] = useDebounce(filter, 250);
 
     const patch = (values: Partial<TransactionSearch>) =>

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/transactionSearch.test.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/transactionSearch.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { last12Months, lastMonth } from "utils/dateFns";
+import { resolveTransactionSearch } from "./transactionSearch";
+
+const store = (key: string, value: unknown) => localStorage.setItem(key, JSON.stringify(value));
+const setUrl = (query: string) => window.history.pushState({}, "", query ? `?${query}` : "?");
+
+beforeEach(() => {
+    localStorage.clear();
+    setUrl("");
+    vi.useFakeTimers();
+    // Mid-month so "last month" and "last 12 months" are unambiguous.
+    vi.setSystemTime(new Date("2026-07-17T02:00:00Z"));
+});
+
+afterEach(() => {
+    localStorage.clear();
+    setUrl("");
+    vi.useRealTimers();
+});
+
+describe("resolveTransactionSearch", () => {
+    it("defaults an empty search to the last-month period and no filters", () => {
+        const result = resolveTransactionSearch({});
+
+        expect(result.tags).toBeUndefined();
+        expect(result.tagged).toBeUndefined();
+        expect(result.netZero).toBeUndefined();
+        expect(result.type).toBeUndefined();
+        expect(result.description).toBeUndefined();
+        expect(result.start).toBe(lastMonth().startDate.toISOString());
+        expect(result.end).toBe(lastMonth().endDate.toISOString());
+    });
+
+    it("uses the stored period-id for the date range", () => {
+        store("period-id", "5"); // Last 12 months
+
+        const result = resolveTransactionSearch({});
+
+        expect(result.start).toBe(last12Months().startDate.toISOString());
+        expect(result.end).toBe(last12Months().endDate.toISOString());
+    });
+
+    it("applies persisted localStorage filters when the URL is silent", () => {
+        store("filter-tag", [5, 9]);
+        store("filter-tagged", true);
+        store("filter-netzero", true);
+        store("filter-type", "Debit");
+        store("filter-description", "coffee");
+
+        const result = resolveTransactionSearch({});
+
+        expect(result.tags).toEqual([5, 9]);
+        expect(result.tagged).toBe(true);
+        expect(result.netZero).toBe(true);
+        expect(result.type).toBe("Debit");
+        expect(result.description).toBe("coffee");
+    });
+
+    it("lets explicit URL/widget params win over stored filters", () => {
+        store("filter-tag", [5]);
+        store("filter-type", "Debit");
+
+        const result = resolveTransactionSearch({ tag: "7", type: "Credit" });
+
+        expect(result.tags).toEqual([7]);
+        expect(result.type).toBe("Credit");
+    });
+
+    it("suppresses stored tagged and description defaults when a widget tag filter is present", () => {
+        store("filter-tag", [5]);
+        store("filter-tagged", true);
+        store("filter-description", "coffee");
+
+        const result = resolveTransactionSearch({ tag: "7" });
+
+        expect(result.tags).toEqual([7]);
+        expect(result.tagged).toBeUndefined();
+        expect(result.description).toBeUndefined();
+    });
+
+    it("keeps an explicit start/end from the URL instead of the default period", () => {
+        const result = resolveTransactionSearch({
+            start: "2025-01-01T00:00:00.000Z",
+            end: "2025-01-31T00:00:00.000Z",
+        });
+
+        expect(result.start).toBe("2025-01-01T00:00:00.000Z");
+        expect(result.end).toBe("2025-01-31T00:00:00.000Z");
+    });
+
+    it("omits an empty stored tag list", () => {
+        store("filter-tag", []);
+
+        const result = resolveTransactionSearch({});
+
+        expect(result.tags).toBeUndefined();
+    });
+});

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/transactionSearch.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/transactionSearch.ts
@@ -1,6 +1,7 @@
 import type { SortDirection } from "@andrewmclachlan/moo-ds";
 
 import type { TransactionsFilter, transactionTypeFilter } from "models/transactions";
+import { getPeriod } from "hooks/period";
 
 // Typed, URL-driven state for the transaction list. Replaces the former Redux slice: filter,
 // sort and page live in the route search params so the view is shareable/bookmarkable. pageSize
@@ -64,6 +65,56 @@ export const validateTransactionSearch = (search: Record<string, unknown>): Tran
     if (search.sortDirection === "Ascending" || search.sortDirection === "Descending") result.sortDirection = search.sortDirection;
 
     return result;
+};
+
+// Reads a JSON-encoded localStorage value (the shape moo-ds `useLocalStorage` writes), returning
+// the fallback when the key is absent or unparseable.
+const readStored = <T>(key: string, fallback: T): T => {
+    try {
+        const raw = localStorage.getItem(key);
+        return raw === null ? fallback : (JSON.parse(raw) as T);
+    } catch {
+        return fallback;
+    }
+};
+
+// The persisted page-size preference (localStorage), matching useTransactionSearch's default.
+export const getStoredPageSize = (): number => readStored<number>("transactions-page-size", 50);
+
+// Fills a validated search with the same defaults the filter panel seeds from — persisted
+// localStorage filters, and the default period (getPeriod: URL ?period → stored period-id →
+// last month). This lets the transaction query be built synchronously (with a date range, so it
+// is enabled) on the first render and warmed by the route loader, instead of only after the
+// panel's post-mount effect writes the params to the URL. It mirrors useFilterPanel's
+// URL-first-then-localStorage merge, including the widget-filter special-casing (an incoming
+// tag/type/tagged param suppresses the stored "tagged" and description defaults).
+export const resolveTransactionSearch = (rawSearch: Record<string, unknown>): TransactionSearch => {
+    const search = validateTransactionSearch(rawSearch);
+    const hasWidgetFilter = !!(search.tags?.length || search.type || search.tagged);
+
+    const storedTags = readStored<number[]>("filter-tag", []);
+    const tags = search.tags ?? (storedTags.length ? storedTags : undefined);
+
+    const tagged = search.tags?.length
+        ? undefined // widget tag filters always show tagged transactions
+        : (search.tagged ?? (hasWidgetFilter ? undefined : readStored("filter-tagged", false) || undefined));
+
+    const netZero = search.netZero ?? (readStored("filter-netzero", false) || undefined);
+    const type = search.type ?? (readStored<transactionTypeFilter>("filter-type", "") || undefined);
+    const description = hasWidgetFilter ? undefined : (readStored("filter-description", "") || undefined);
+
+    const period = getPeriod();
+
+    return {
+        ...search,
+        tags,
+        tagged,
+        netZero,
+        type,
+        description,
+        start: search.start ?? period.startDate.toISOString(),
+        end: search.end ?? period.endDate.toISOString(),
+    };
 };
 
 // Projects the URL search state onto the filter shape consumed by the transaction query hooks.

--- a/src/MooBank.Web.App/src/utils/routerQueryClient.ts
+++ b/src/MooBank.Web.App/src/utils/routerQueryClient.ts
@@ -1,0 +1,20 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+// PROTOTYPE bridge for the /accounts/$id route loader.
+//
+// A TanStack Router `loader` runs outside React, so it cannot call
+// `useQueryClient()`. MooApp creates the QueryClient internally and only exposes
+// it through React context — unreachable from a loader — so the root route
+// captures it here for the loader to warm the account cache.
+//
+// PRODUCTION shape: MooApp should inject its QueryClient into the router context
+// (`<RouterProvider router={router} context={{ queryClient }} />`) and the root
+// route use `createRootRouteWithContext<{ queryClient: QueryClient }>()`. The
+// loader would then read `context.queryClient` and this module would go away.
+let routerQueryClient: QueryClient | undefined;
+
+export const setRouterQueryClient = (client: QueryClient): void => {
+    routerQueryClient = client;
+};
+
+export const getRouterQueryClient = (): QueryClient | undefined => routerQueryClient;


### PR DESCRIPTION
## What
Navigating into an account now shows its transactions immediately, instead of a ~1s blank-then-populate.

## Two parts

### 1. Route rework (also fixes a latent deadlock)
A route `loader` on the `/accounts/$id` **layout** froze the renderer when reached via **client-side** navigation, because account rows navigated to the bare `/accounts/$id`, which goes through the child `index.tsx` `beforeLoad` `throw redirect()`. That SPA-nav-through-redirect + parent-loader combination deadlocks the router (direct URL loads are fine). Fix: all in-app navigation targets `/accounts/$id/transactions` **directly** — account rows (`AccountRow`), and the dashboard/report tag drill-downs (`Breakdown`, `BreakdownPage`, `TopTags`), which carry their `?tag=/untagged=/type=` filters straight to the transactions route (`validateTransactionSearch` already accepts those keys). The bare-route `index.tsx` redirect stays as the direct-URL/bookmark fallback, with a comment warning against in-app use.

### 2. Warming + synchronous seed
- `resolveTransactionSearch` (new, unit-tested) fills the default filter from persisted localStorage filters + the existing `getPeriod()`, so the transactions query is enabled on the **first render** rather than after the filter panel's post-mount effect → URL round-trip → 250ms debounce.
- `transactionsQueryConfig` (extracted) is the single source of the query key, shared by `useTransactions` and a fire-and-forget route `loader` (`transactions.tsx`) that warms the list into the cache.
- Account rows `router.preloadRoute` on **hover**, so with `defaultPreload: "intent"` the fetch starts before the click.

## Note for review
`src/utils/routerQueryClient.ts` is a bridge that hands the live `QueryClient` to the loader (which runs outside React and can't call `useQueryClient`). It's prototype scaffolding: the productionised form is for MooApp to inject its `QueryClient` into the router context (`<RouterProvider context={{ queryClient }} />`) so the loader reads `context.queryClient` and the bridge is deleted. Fine to merge as-is; flagged for the follow-up.

## Validation
typecheck, lint, 172 tests (7 new for the resolver), and production build all pass (on moo-app 5.2.38). Live snappiness was not stopwatch-verified — the browser extension was unresponsive during the session — but the query now fires on first render and warms on hover by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)