### PR TITLE
perf(web): warm per-account report queries on hover

### DIFF
--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-utils/warmReport.ts
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-utils/warmReport.ts
@@ -1,0 +1,31 @@
+import { getPeriod } from "hooks/period";
+import { formatISODate } from "utils/dateFns";
+import { getRouterQueryClient } from "utils/routerQueryClient";
+
+type ReportRange = { accountId: string; start: string; end: string };
+
+// Warms a report query into the cache during route resolution. The report nav links hover-preload
+// (defaultPreload: "intent"), so this runs before the click and the chart is ready on mount.
+// Reports default their period from getPeriod() and format dates with formatISODate, so the warmed
+// key matches what the page requests. buildOptions returns the same generated query options the
+// report hook uses (accountId-only reports simply ignore start/end). No-op until the root route has
+// captured the QueryClient (see utils/routerQueryClient) — i.e. on cold direct loads.
+export const warmReport = (
+    accountId: string,
+    buildOptions: (range: ReportRange) => unknown,
+): void => {
+    const queryClient = getRouterQueryClient();
+    if (!queryClient) return;
+
+    const { startDate, endDate } = getPeriod();
+    if (!startDate || !endDate) return;
+
+    // Each caller builds a fully-typed generated *Options object (path/query params are checked at
+    // the call site); the strict queryKey tuple typing just doesn't unify through this generic
+    // boundary, so cast at the ensureQueryData edge.
+    void queryClient.ensureQueryData(buildOptions({
+        accountId,
+        start: formatISODate(startDate),
+        end: formatISODate(endDate),
+    }) as any);
+};

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/all-tag-average.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/all-tag-average.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { allTagAverageReportOptions } from "api/@tanstack/react-query.gen";
+import { warmReport } from "./-utils/warmReport";
 
 import { ReportsPage } from "./-components/ReportsPage";
 
@@ -18,6 +20,8 @@ import { differenceInMonths } from "date-fns";
 
 
 export const Route = createFileRoute("/accounts/$id/reports/all-tag-average")({
+    // Matches the page defaults: reportType "Debit", top 20, monthly.
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => allTagAverageReportOptions({ path: { accountId, start, end, reportType: "debit" as any }, query: { Top: 20, Interval: "Monthly" } })),
     component: AllTagAverage,
 });
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/by-tag.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/by-tag.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { byTagReportOptions } from "api/@tanstack/react-query.gen";
+import { warmReport } from "./-utils/warmReport";
 
 import { ReportsPage } from "./-components/ReportsPage";
 import { useByTagReport } from "../../-hooks/useByTagReport";
@@ -18,6 +20,8 @@ import { getPeriod } from "hooks";
 
 
 export const Route = createFileRoute("/accounts/$id/reports/by-tag")({
+    // Matches the page default reportType "Debit".
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => byTagReportOptions({ path: { accountId, start, end, reportType: "debit" as any } })),
     component: ByTag,
 });
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/in-out.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/in-out.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { inOutReportOptions } from "api/@tanstack/react-query.gen";
+import { warmReport } from "./-utils/warmReport";
 
 import { ReportsPage } from "./-components/ReportsPage";
 import "./-components/Reports.css";
@@ -21,6 +23,7 @@ import { getPeriod } from "hooks";
 
 
 export const Route = createFileRoute("/accounts/$id/reports/in-out")({
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => inOutReportOptions({ path: { accountId, start, end } })),
     component: InOutPage,
 });
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/monthly-balances.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/monthly-balances.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { monthlyBalancesReportForPeriodOptions } from "api/@tanstack/react-query.gen";
 import { MonthlyBalances } from "./-components/MonthlyBalances";
+import { warmReport } from "./-utils/warmReport";
 
 export const Route = createFileRoute("/accounts/$id/reports/monthly-balances")({
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => monthlyBalancesReportForPeriodOptions({ path: { accountId, start, end } })),
     component: MonthlyBalances,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/principal-vs-interest.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/principal-vs-interest.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { principalVsInterestReportOptions } from "api/@tanstack/react-query.gen";
 import { PrincipalVsInterest } from "./-components/PrincipalVsInterest";
+import { warmReport } from "./-utils/warmReport";
 
 export const Route = createFileRoute("/accounts/$id/reports/principal-vs-interest")({
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => principalVsInterestReportOptions({ path: { accountId, start, end } })),
     component: PrincipalVsInterest,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/savings-interest.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/savings-interest.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { savingsInterestReportOptions } from "api/@tanstack/react-query.gen";
 import { SavingsInterest } from "./-components/SavingsInterest";
+import { warmReport } from "./-utils/warmReport";
 
 export const Route = createFileRoute("/accounts/$id/reports/savings-interest")({
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => savingsInterestReportOptions({ path: { accountId, start, end } })),
     component: SavingsInterest,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/super-contributions.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/super-contributions.tsx
@@ -1,6 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { superContributionsReportOptions } from "api/@tanstack/react-query.gen";
 import { SuperContributions } from "./-components/SuperContributions";
+import { warmReport } from "./-utils/warmReport";
 
 export const Route = createFileRoute("/accounts/$id/reports/super-contributions")({
+    loader: ({ params }) => warmReport(params.id, ({ accountId, start, end }) => superContributionsReportOptions({ path: { accountId, start, end } })),
     component: SuperContributions,
 });

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/super-returns.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/super-returns.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { superReturnsReportOptions } from "api/@tanstack/react-query.gen";
 import { SuperReturns } from "./-components/SuperReturns";
+import { warmReport } from "./-utils/warmReport";
 
 export const Route = createFileRoute("/accounts/$id/reports/super-returns")({
+    // SuperReturns keys on the account only (no date range); the range from warmReport is ignored.
+    loader: ({ params }) => warmReport(params.id, ({ accountId }) => superReturnsReportOptions({ path: { accountId } })),
     component: SuperReturns,
 });


### PR DESCRIPTION
## What
Extends the preemptive-loading pattern (merged in #902) to the account **report** tabs, so browsing an account's reports feels instant rather than blank-then-fetch.

## How
Each report route gets a fire-and-forget `loader` that warms its primary query into the cache during route resolution. The report nav links already hover-preload (`defaultPreload: "intent"`), so the chart is fetched before the tab is clicked. A shared `warmReport` helper resolves the default period from the existing `getPeriod()` — matching what each report requests on mount — and warms the generated query options (so the key can't drift; each caller builds a fully-typed `*Options`).

Depends on the `routerQueryClient` bridge from #902 (now in main).

## Coverage
`in-out`, `monthly-balances`, `savings-interest`, `super-contributions`, `super-returns`, `principal-vs-interest`, `all-tag-average` (Top Tags), `by-tag` (All Tags).

**Deferred** (noted for follow-up): `breakdown` (nested optional-tag route whose index renders null) and `tag-trend` (requires a tag id) — both need more than a period default.

## Notes
- Warms each report's **primary** query only; multi-panel reports (e.g. in-out's same-period-last-year / trend) still fetch their secondary queries on mount.
- A mismatched key would just be a harmless cache miss (the component fetches as normal), so this degrades gracefully.

## Validation
typecheck, lint (0 errors), 172 tests, build all pass. Live snappiness not stopwatch-verified (browser extension unavailable this session), but the warmed keys match the hooks' keys by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)