### PR TITLE
fix(web): keep dashboard widget titles pinned to the top while loading

### DIFF
--- a/src/MooBank.Web.App/src/css/dashboard.css
+++ b/src/MooBank.Web.App/src/css/dashboard.css
@@ -1,3 +1,10 @@
+/* The dashboard section is a CSS grid with `align-items: center` (moo-ds). During load the header
+   is the only in-flow item (the chart's spinner is absolutely positioned), so centring drifts the
+   title downward — it isn't pinned to the top. Top-align the header so it stays put in both states. */
+main.dashboard .section > .section-header {
+    align-self: start;
+}
+
 .widget-error {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## What
Dashboard widget titles drifted downward during loading instead of staying at the top.

## Cause
The dashboard `.section` is a CSS grid with `align-items: center` (moo-ds). When loaded, its rows are filled (header, value, chart) so the header sits in the top row. During load the chart's spinner is `position: absolute` (out of flow), leaving the header as the only in-flow grid item — so `align-items: center` drifts it down. Measured in the running app: header offset 16px loaded → 55px loading.

## Fix
```css
main.dashboard .section > .section-header { align-self: start; }
```
Top-anchors just the header, leaving the grid's `align-items: center` intact for the chart's own cell alignment. Verified live by simulating the loading state — header returns to 16px in both states. Fixes every dashboard widget, not only the chart ones.

## Note
This is really a moo-ds dashboard-grid issue (its section headers are centred); shipping as a local override for now, to be ported into moo-ds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)