### PR TITLE
feat(web): skeleton loading for the accounts list

### DIFF
--- a/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
@@ -4,7 +4,6 @@ using Asm.MooBank.Modules.Accounts.Commands;
 using Asm.MooBank.Modules.Accounts.Models.Account;
 using Asm.MooBank.Modules.Accounts.Queries;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
 namespace Asm.MooBank.Modules.Accounts.Endpoints;

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2025.4.0",
       "license": "MIT",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.38",
-        "@andrewmclachlan/moo-ds": "^5.2.38",
-        "@andrewmclachlan/moo-icons": "^5.2.38",
+        "@andrewmclachlan/moo-app": "^5.2.48",
+        "@andrewmclachlan/moo-ds": "^5.2.48",
+        "@andrewmclachlan/moo-icons": "^5.2.48",
         "@azure/msal-react": "^5.5.1",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
@@ -91,9 +91,9 @@
       "license": "MIT"
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.38",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.38/00131a106f4fac1b6a0d6cc4274816ff250c15ab",
-      "integrity": "sha512-S+sYEvAVRVq5n1tc91fqdNgY/OycB42qT0iutvv3bzFCGWXA7SFHccdB9Ffkel++q+mG0GnQtShkHhmJJt5USw==",
+      "version": "5.2.48",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.48/32c46b4f73445d5739cacb6aeac1a57b87e16c91",
+      "integrity": "sha512-wtMxRe/AULhFHhxvdeVLgY6HEAhSZYvL5X9M7c+7nSDnDzJShrOlfc3GRQDMv0G2w0PK55rfVoCXy4toMWnSUw==",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.0",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.38",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.38/9e131aacf2f9096112189961e4284d30cbf0abbf",
-      "integrity": "sha512-G7Kk1deYRjEs7KP/oDCDLGZB3iReiBk75Fe6EZvBcRLE9to1LfsTXxYaY252LQpSOEVH589ip7aXHrb+EknQig==",
+      "version": "5.2.48",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.48/ace2139e718a0d0dabb5dd60b54fd8dc2bf5abc2",
+      "integrity": "sha512-7h40ZOStHXBEgdRKkMwWt9tv2xuov+rA5sM2L23BVyoKh4KrXKBFlsnPf0ZCJiVZq/t0Snj0hI1vxfnF7uFYJA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.38",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.38/ed0deb0f742b3899621054b201d4c1a1cd355d96",
-      "integrity": "sha512-cM2Hehco5nGAKf49If1hWyTMhNqgo5D8dLwzLQE9BhRSN49GCnfaGUgePoIhtPLu3qc+RnK54/3WLVECcrXiyA==",
+      "version": "5.2.48",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.48/b4129cd0785cd0b9a4f1cd64ecbcfafd03673a9c",
+      "integrity": "sha512-bJHwtCxEIbRWNo9gtOp2w/2BooSmmhCGMIEpLRaldqjLsdihsQrIguJzquPS+0h/lZr8Tgb4ZLBV17VuDtIDPQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2025.4.0",
       "license": "MIT",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.48",
-        "@andrewmclachlan/moo-ds": "^5.2.48",
-        "@andrewmclachlan/moo-icons": "^5.2.48",
+        "@andrewmclachlan/moo-app": "^5.2.56",
+        "@andrewmclachlan/moo-ds": "^5.2.56",
+        "@andrewmclachlan/moo-icons": "^5.2.56",
         "@azure/msal-react": "^5.5.1",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
@@ -91,9 +91,9 @@
       "license": "MIT"
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.48",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.48/32c46b4f73445d5739cacb6aeac1a57b87e16c91",
-      "integrity": "sha512-wtMxRe/AULhFHhxvdeVLgY6HEAhSZYvL5X9M7c+7nSDnDzJShrOlfc3GRQDMv0G2w0PK55rfVoCXy4toMWnSUw==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.56/baef7891a9bd8b3e38f52028cb722feff522b003",
+      "integrity": "sha512-sI5ZyiRe8pip9RDRuYOdP4cWef1NMxiOgT1ZcfCYFc0yvP7ZNJ2gPQ4YU4bTpp3kQ3IjRR1Sl4/izgX49yj9cw==",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.0",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.48",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.48/ace2139e718a0d0dabb5dd60b54fd8dc2bf5abc2",
-      "integrity": "sha512-7h40ZOStHXBEgdRKkMwWt9tv2xuov+rA5sM2L23BVyoKh4KrXKBFlsnPf0ZCJiVZq/t0Snj0hI1vxfnF7uFYJA==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.56/25699e7ff2f3f4b6d79a1ff1fa5381ff8ac45d0e",
+      "integrity": "sha512-0Kan5HZCgd2E3/d9JPU6Op1ZfdWXPMZJxORFWl5cWUh1AjCUnGGCl5+qPCpHMPKiteLb2U8J2MM2M5yB2ityrQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.48",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.48/b4129cd0785cd0b9a4f1cd64ecbcfafd03673a9c",
-      "integrity": "sha512-bJHwtCxEIbRWNo9gtOp2w/2BooSmmhCGMIEpLRaldqjLsdihsQrIguJzquPS+0h/lZr8Tgb4ZLBV17VuDtIDPQ==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.56/7c637eb03718f17a0f9bcc44baebc05d5f7a4ee2",
+      "integrity": "sha512-mCq0wfSNel2RKrVneKplwYEE7RW3QkQTa0vtFOM1zYJTrc3V/nn6caOURPCgndLFOQGMADd2Zin+FZBUgPEl7w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -14,9 +14,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.38",
-    "@andrewmclachlan/moo-ds": "^5.2.38",
-    "@andrewmclachlan/moo-icons": "^5.2.38",
+    "@andrewmclachlan/moo-app": "^5.2.48",
+    "@andrewmclachlan/moo-ds": "^5.2.48",
+    "@andrewmclachlan/moo-icons": "^5.2.48",
     "@azure/msal-react": "^5.5.1",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -14,9 +14,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.48",
-    "@andrewmclachlan/moo-ds": "^5.2.48",
-    "@andrewmclachlan/moo-icons": "^5.2.48",
+    "@andrewmclachlan/moo-app": "^5.2.56",
+    "@andrewmclachlan/moo-ds": "^5.2.56",
+    "@andrewmclachlan/moo-icons": "^5.2.56",
     "@azure/msal-react": "^5.5.1",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",

--- a/src/MooBank.Web.App/src/components/AccountList/AccountList.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/AccountList.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { useFormattedAccounts } from "hooks/useFormattedAccounts";
 import { AccountListGroup } from "./AccountListGroup";
+import { AccountListSkeleton } from "./AccountListSkeleton";
 
 export const AccountList: React.FC = () => {
 
     const { data, isLoading } = useFormattedAccounts();
+
+    if (isLoading) return <AccountListSkeleton />;
 
     return (
         <>

--- a/src/MooBank.Web.App/src/components/AccountList/AccountList.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/AccountList.tsx
@@ -7,7 +7,10 @@ export const AccountList: React.FC = () => {
 
     const { data, isLoading } = useFormattedAccounts();
 
-    if (isLoading) return <AccountListSkeleton />;
+    // Gate on "no data yet" rather than isLoading: a persisted query rehydrating from IndexedDB is
+    // pending-but-paused (isLoading === false) while data is still undefined, so isLoading would skip
+    // the skeleton on a normal refresh.
+    if (!data) return <AccountListSkeleton />;
 
     return (
         <>

--- a/src/MooBank.Web.App/src/components/AccountList/AccountListSkeleton.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/AccountListSkeleton.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { SectionTable, Skeleton } from "@andrewmclachlan/moo-ds";
+
+// Loading placeholder for the account list. The formatted-accounts query is usually already warm
+// from the dashboard, so this mainly covers a cold/direct visit to /accounts. It mirrors
+// AccountListGroup's table (same columns and responsive classes) so nothing shifts when data
+// arrives. Each table carries aria-busy; the Skeleton shapes are aria-hidden, so the loading region
+// owns the single busy announcement. Cell widths auto-vary via moo-ds's tr-scoped skeleton CSS.
+const SkeletonGroup: React.FC<{ rows: number }> = ({ rows }) => (
+    <SectionTable
+        className="accounts"
+        hover
+        aria-busy="true"
+        aria-label="Loading accounts"
+        header={<header><h3><Skeleton.Text style={{ width: "12rem" }} /></h3></header>}
+        headerSize={2}
+    >
+        <thead>
+            <tr>
+                <th className="expander d-none d-sm-table-cell"></th>
+                <th>Name</th>
+                <th className="d-none d-sm-table-cell">Type</th>
+                <th className="number">Balance</th>
+            </tr>
+        </thead>
+        <tbody>
+            {Array.from({ length: rows }, (_, i) => (
+                <tr key={i}>
+                    <td className="expander d-none d-sm-table-cell"></td>
+                    <td><Skeleton.Text /></td>
+                    <td className="d-none d-sm-table-cell"><Skeleton.Text /></td>
+                    <td className="number"><Skeleton.Text /></td>
+                </tr>
+            ))}
+        </tbody>
+    </SectionTable>
+);
+
+export const AccountListSkeleton: React.FC = () => (
+    <>
+        <SkeletonGroup rows={3} />
+        <SkeletonGroup rows={5} />
+    </>
+);
+
+AccountListSkeleton.displayName = "AccountListSkeleton";

--- a/src/MooBank.Web.App/src/routes/accounts/$id/rules.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/rules.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import React, { useEffect, useState } from "react";
-import { Table } from "@andrewmclachlan/moo-ds";
+import { LoadingTableRows, Table } from "@andrewmclachlan/moo-ds";
 
 import { IconButton, PageSize, Pagination, PaginationControls, PaginationTh, SearchBox, Section, SortableTh, changeSortDirection, getNumberOfPages, useLocalStorage } from "@andrewmclachlan/moo-ds";
 import type { SortDirection } from "@andrewmclachlan/moo-ds";
@@ -82,7 +82,8 @@ function Rules() {
                 </thead>
                 <tbody>
                     <NewRule />
-                    {pagedRules.map((r) => <RuleRow key={r.id} accountId={account.id} rule={r} />)}
+                    {!rules && <LoadingTableRows rows={pageSize} cols={4} />}
+                    {rules && pagedRules.map((r) => <RuleRow key={r.id} accountId={account.id} rule={r} />)}
                 </tbody>
                 <tfoot>
                     <tr>

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/components/TransactionList.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/components/TransactionList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import { getNumberOfPages, Pagination, PaginationControls, PageSize, SectionTable, MiniPagination } from "@andrewmclachlan/moo-ds";
+import { getNumberOfPages, Pagination, PaginationControls, PageSize, SectionTable, MiniPagination, LoadingTableRows } from "@andrewmclachlan/moo-ds";
 
 import { useAccount } from "components";
 import type { Transaction } from "api/types.gen";
@@ -43,7 +43,7 @@ export const TransactionList: React.FC<TransactionListProps> = ({compact = false
                     {transactions?.map((t, index) =>
                         <TransactionRow compact={compact} key={t.id} transaction={t} onClick={rowClick} previousDate={index > 0 ? parseISO(transactions[index - 1].transactionTime) : undefined} />
                     )}
-                    {!transactions && Array.from({ length: pageSize }, (_value, index) => index).map((i) => <tr key={i}><td colSpan={6}>&nbsp;</td></tr>)}
+                    {!transactions && <LoadingTableRows rows={pageSize} cols={compact ? 2 : 6} />}
                 </tbody>
                 <tfoot>
                     <tr>

--- a/src/MooBank.Web.App/src/routes/groups/index.tsx
+++ b/src/MooBank.Web.App/src/routes/groups/index.tsx
@@ -20,7 +20,7 @@ function ManageGroups() {
 
     const { data } = groupsQuery;
 
-    const groupRows: React.ReactNode[] = data?.map(a => <GroupRow key={a.id} group={a} />) ?? [<LoadingTableRows key={1} rows={2} cols={3} />];
+    const groupRows: React.ReactNode[] = data?.map(a => <GroupRow key={a.id} group={a} />) ?? [<LoadingTableRows key={1} rows={5} cols={3} />];
 
     return (
         <Page title="Groups" breadcrumbs={[{ text: "Groups", route: "/groups" }]} actions={[<IconButton badge key="add" onClick={() => navigate({ to: "/groups/create" })} icon="plus">Create Group</IconButton>]}>

--- a/src/MooBank.Web.App/src/routes/tags/-components/TagRow.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/-components/TagRow.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import type { Tag } from "api/types.gen";
-import { EditColumn, Icon, useUpdatingState } from "@andrewmclachlan/moo-ds";
+import { EditColumn, Icon, LoadingTableRow, useUpdatingState } from "@andrewmclachlan/moo-ds";
 import { useDeleteTag } from "../-hooks/useDeleteTag";
 import { useUpdateTag } from "../-hooks/useUpdateTag";
 import { TransactionTagTransactionTagPanel } from "./TagTagPanel";
@@ -12,9 +12,7 @@ export const TransactionTagRow: React.FC<TransactionTagRowProps> = (props) => {
 
     const { tag, ...tagRow } = useTagRowEvents(props);
 
-    if (!tag) return (
-        <tr className="empty-row"><td colSpan={3}>&nbsp;</td></tr>
-    );
+    if (!tag) return <LoadingTableRow cols={3} />;
 
     return (
         <tr>

--- a/src/MooBank.Web.App/src/routes/tags/index.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/index.tsx
@@ -60,7 +60,9 @@ function TransactionTags() {
     }, [JSON.stringify(allTags), search]);
 
     useEffect(() => {
-        if (isLoading) {
+        // Gate on "no data yet" rather than isLoading: while a persisted query rehydrates from
+        // IndexedDB it is pending-but-paused, so isLoading is false even though allTags is undefined.
+        if (!allTags) {
             // @ts-ignore: placeholder rows of undefined are rendered as loading skeletons
             setPagedTags(Array.from({ length: pageSize }).map((): any => undefined));
             return;


### PR DESCRIPTION
## What
The accounts list (`/accounts`) showed **nothing** while the formatted-accounts query loaded — `data` was undefined, so `data?.groups.map(...)` produced no output. This adds a shimmering skeleton placeholder instead.
Also did groups, rules and tags.

## How
- Bumps moo-* **5.2.38 → 5.2.56** for the new moo-ds `Skeleton` component and improved combo-box.
- New `AccountListSkeleton` mirrors `AccountListGroup`'s `SectionTable` — same columns and responsive classes — so there's **no layout shift** when data arrives. Two skeleton groups (3 and 5 rows). Cell widths auto-vary via moo-ds's `tr`-scoped skeleton CSS, so it reads as tabular data.
- `AccountList` short-circuits to the skeleton when `isLoading`.
- Accessibility: the tables carry `aria-busy`; `Skeleton` shapes are `aria-hidden`, so the loading region owns the single busy announcement (per the component's contract).

## Note
`isLoading` (React Query v5) is only true on a cold load with no cached data. The formatted-accounts query is usually already warm from the dashboard, so in practice the skeleton shows mainly on a **direct/first visit** to `/accounts` — exactly where the blank was.

## Validation
typecheck, lint, 172 tests, build all pass. The lock change is only the three moo-* packages (no unrelated churn). Not verified visually this session (dev server was down for the dep bump) — worth a cold load of `/accounts` (hard refresh) to eyeball it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)