### PR TITLE
fix(web): make RouteError read as a full-page error, not a sprawling widget

### DIFF
--- a/src/MooBank.Web.App/src/css/dashboard.css
+++ b/src/MooBank.Web.App/src/css/dashboard.css
@@ -28,3 +28,23 @@ main.dashboard .section > .section-header {
     max-width: 22ch;
     line-height: 1.3;
 }
+
+/* RouteError (App.tsx defaultErrorComponent) reuses the widget-error layout, but a route-level
+   error needs to read as a full-page message rather than a small widget card. Give it vertical
+   space to centre within, and keep the dev-only error detail (often a long, unbreakable URL) from
+   sprawling the page full-width. */
+.route-error {
+    min-height: 50vh;
+    gap: 1rem;
+}
+
+.route-error-detail {
+    max-width: min(72ch, 100%);
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    text-align: left;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    opacity: 0.7;
+}


### PR DESCRIPTION
## What
The full-page error (`RouteError`, the app's `defaultErrorComponent`) was mis-formatted: a thin strip sprawling full-width across the page bottom, with the raw error message running off the edge.

## Cause
`RouteError` reuses the `.widget-error` (small dashboard-card) layout and renders the dev-only error message in an **unstyled `<pre>`**. A long, unbreakable message — e.g. `Failed to fetch dynamically imported module: https://…/accounts/index.tsx?tsr-split=component` — doesn't wrap, so it forces the container full-width, and the card layout leaves it as a thin strip rather than a centred page.

## Fix (CSS only)
- `.route-error` — `min-height: 50vh` + gap, so a route-level error has space to centre in rather than inheriting the tiny widget-card height.
- `.route-error-detail` — `white-space: pre-wrap; overflow-wrap: anywhere; max-width: min(72ch, 100%)`, so the message wraps and stays constrained instead of sprawling.

## Note on verification
The `<pre>` wrap/constraint is the certain fix for the full-width sprawl. The vertical centring is best-effort — I couldn't inspect the live layout this session (browser was unresponsive), so if the error still sits low/outside the content area after this, that points to the error boundary rendering *below* the app shell (a moo-app Layout concern) rather than CSS, and I'll take a live look. Please eyeball it in your running env.

Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)