### PR TITLE
fix: accept 4 decimal places in amount inputs

### DIFF
--- a/src/MooBank.Web.App/src/components/AccountList/VirtualAccountRow.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/VirtualAccountRow.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import React, { useEffect, useRef, useState } from "react";
 
 import { numberClassName } from "utils/classNameHelpers";
+import { amountStep } from "utils/currency";
 import { EditColumn, emptyGuid, useClickAway } from "@andrewmclachlan/moo-ds";
 
 import type { VirtualInstrument } from "api/types.gen";
@@ -23,7 +24,7 @@ export const VirtualAccountRow: React.FC<VirtualAccountRowProps> = (props) => {
             <td className="d-none d-sm-table-cell"><AccountTypeBadge type={props.account.controller === "Virtual" ? "Virtual" : "Reserved Sum"} /></td>
             <td className={classNames("number", numberClassName(balance))} onClick={canEditBalance ? balanceClick : undefined}>
                 {!editingBalance && <Amount amount={balance} negativeColour minus />}
-                {editingBalance && <input autoFocus type="number" className="form-control" value={balance} onChange={balanceChange} onKeyUp={keyPress} ref={balanceRef} />}
+                {editingBalance && <input autoFocus type="number" step={amountStep} className="form-control" value={balance} onChange={balanceChange} onKeyUp={keyPress} ref={balanceRef} />}
             </td>
         </tr>
     );

--- a/src/MooBank.Web.App/src/components/CurrencyInput.test.tsx
+++ b/src/MooBank.Web.App/src/components/CurrencyInput.test.tsx
@@ -41,4 +41,22 @@ describe("CurrencyInput", () => {
         const input = document.querySelector<HTMLInputElement>("#amount")!;
         expect(input).toHaveAttribute("type", "number");
     });
+
+    // Amounts persist as decimal(12, 4). A coarser step makes the browser reject finer values
+    // with a stepMismatch on submit, which previously capped every amount field at 2dp.
+    it("accepts 4 decimal places", () => {
+        renderCurrencyInput({ currency: "AUD" });
+        const input = document.querySelector<HTMLInputElement>("#amount")!;
+
+        expect(input).toHaveAttribute("step", "0.0001");
+
+        input.value = "12.3456";
+        expect(input.validity.stepMismatch).toBe(false);
+    });
+
+    it("lets a caller override the step", () => {
+        renderCurrencyInput({ currency: "AUD", step: 1 });
+        const input = document.querySelector<HTMLInputElement>("#amount")!;
+        expect(input).toHaveAttribute("step", "1");
+    });
 });

--- a/src/MooBank.Web.App/src/components/CurrencyInput.tsx
+++ b/src/MooBank.Web.App/src/components/CurrencyInput.tsx
@@ -1,7 +1,7 @@
 import { Form } from "@andrewmclachlan/moo-ds";
 import type { InputProps } from "@andrewmclachlan/moo-ds";
 import { InputGroup } from "@andrewmclachlan/moo-ds";
-import { currencySymbols } from "utils/currency";
+import { amountStep, currencySymbols } from "utils/currency";
 
 export interface CurrencyInputProps extends Omit<InputProps, "type"> {
     /** ISO currency code (e.g. "AUD", "USD"). Drives the input-group symbol; falls back to "$". */
@@ -12,6 +12,6 @@ export const CurrencyInput: React.FC<CurrencyInputProps> = ({ currency, ...props
 
     <InputGroup>
         <InputGroup.Text>{(currency && currencySymbols[currency.toUpperCase()]) || "$"}</InputGroup.Text>
-        <Form.Input type="number" className="form-control" placeholder="0.00" maxLength={10} step={0.01} {...props} />
+        <Form.Input type="number" className="form-control" placeholder="0.00" maxLength={10} step={amountStep} {...props} />
     </InputGroup>
 )

--- a/src/MooBank.Web.App/src/routes/accounts/-components/RecurringTransactions.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-components/RecurringTransactions.tsx
@@ -11,6 +11,7 @@ import { useGetRecurringTransactions } from "routes/accounts/-hooks/useGetRecurr
 import { useCreateRecurringTransaction } from "routes/accounts/-hooks/useCreateRecurringTransaction";
 import { useUpdateRecurringTransaction } from "routes/accounts/-hooks/useUpdateRecurringTransaction";
 import { useDeleteRecurringTransaction } from "routes/accounts/-hooks/useDeleteRecurringTransaction";
+import { amountStep } from "utils/currency";
 
 export const RecurringTransactions: React.FC<RecurringTransactionsProps> = ({ account }) => {
 
@@ -51,7 +52,7 @@ export const RecurringTransactions: React.FC<RecurringTransactionsProps> = ({ ac
             <tbody>
                 <tr>
                     <td><input type="text" className="form-control" placeholder="Description" value={newRT.description} onChange={e => setNewRT({ ...newRT, description: e.currentTarget.value })} /></td>
-                    <td><input type="number" className="form-control" placeholder="Amount" value={newRT.amount} onChange={e => setNewRT({ ...newRT, amount: e.currentTarget.valueAsNumber })} /></td>
+                    <td><input type="number" step={amountStep} className="form-control" placeholder="Amount" value={newRT.amount} onChange={e => setNewRT({ ...newRT, amount: e.currentTarget.valueAsNumber })} /></td>
                     <td>
                         <select className="form-control" value={newRT.schedule} onChange={e => setNewRT({ ...newRT, schedule: e.currentTarget.value as ScheduleFrequency })}>
                             {Schedules.map(s => <option key={s}>{s}</option>)}

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/details/NewTransactionSplit.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/details/NewTransactionSplit.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import { SaveIcon } from "@andrewmclachlan/moo-ds";
 import { valueAsNumber } from "utils/valueAsNumber";
+import { amountStep } from "utils/currency";
 import type { Transaction, TransactionSplit } from "api/types.gen";
 import { newTransactionSplit } from "models/transactions";
 import { Col, Input, Row } from "@andrewmclachlan/moo-ds";
@@ -27,7 +28,7 @@ export const NewTransactionSplit: React.FC<NewTransactionSplitProps> = ({ transa
                 <TransactionSplitTagPanel as="div" onChange={(s) => splitChanged({ ...split, tags: s.tags })} alwaysShowEditPanel transactionSplit={split} />
             </Col>
             <Col sm={3} className="split-controls">
-                <Input type="number" value={split.amount} required min={0} max={transaction.amount} onChange={(s) => splitChanged({ ...split, amount: valueAsNumber(s.currentTarget) })} />
+                <Input type="number" step={amountStep} value={split.amount} required min={0} max={transaction.amount} onChange={(s) => splitChanged({ ...split, amount: valueAsNumber(s.currentTarget) })} />
                 {/*<Input.Feedback type="invalid">Please enter an amount</Input.Feedback>*/}
                 <SaveIcon onClick={saveClick} />
             </Col>

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/details/TransactionSplit.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/details/TransactionSplit.tsx
@@ -1,6 +1,7 @@
 import { TransactionSearch } from "components";
 import { DeleteIcon } from "@andrewmclachlan/moo-ds";
 import { valueAsNumber } from "utils/valueAsNumber";
+import { amountStep } from "utils/currency";
 import type { Transaction, TransactionSplit as TransactionSplitModel, TransactionOffsetFor } from "api/types.gen";
 import { isCredit } from "utils/transactions";
 import React, { useState } from "react";
@@ -46,7 +47,7 @@ export const TransactionSplit: React.FC<TransactionSplitProps> = ({ transaction,
                 <Col sm={3}>
                     <Form.Label>Amount</Form.Label>
                     <div className="split-controls">
-                        <Input type="number" value={split.amount} required max={transaction.amount} onChange={(e) => splitChanged({ ...split, amount: valueAsNumber(e.currentTarget) })} />
+                        <Input type="number" step={amountStep} value={split.amount} required max={transaction.amount} onChange={(e) => splitChanged({ ...split, amount: valueAsNumber(e.currentTarget) })} />
                         {/*<Input.Feedback type="invalid">Please enter an amount</Input.Feedback>*/}
                         <DeleteIcon onClick={() => removeSplit(split.id)} />
                     </div>
@@ -61,7 +62,7 @@ export const TransactionSplit: React.FC<TransactionSplitProps> = ({ transaction,
                             <TransactionSearch value={to.transaction} onChange={(v) => v ? offsetChanged({ ...to, transaction: v }, to.transaction) : removeOffset(to.transaction.id)} transaction={transaction} excludedTransactions={offsetBy.map(ob => ob.transaction.id)} />
                         </Col>
                         <Col sm={3} className="offset-controls">
-                            <Input type="number" value={to.amount} required max={to.transaction.amount} onChange={e => offsetChanged({ ...to, amount: valueAsNumber(e.currentTarget) })} />
+                            <Input type="number" step={amountStep} value={to.amount} required max={to.transaction.amount} onChange={e => offsetChanged({ ...to, amount: valueAsNumber(e.currentTarget) })} />
                             {/* <Input.Feedback type="invalid">Please enter an amount</Input.Feedback> */}
                             <DeleteIcon onClick={() => removeOffset(to.transaction.id)} />
                         </Col>

--- a/src/MooBank.Web.App/src/routes/bills/-components/AddBill.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/-components/AddBill.tsx
@@ -8,6 +8,7 @@ import { Form, Section, SectionForm } from "@andrewmclachlan/moo-ds";
 import type { CreateBill } from "models/bills";
 import { useCreateBill } from "../-hooks/useCreateBill";
 import { useBillAccounts } from "../-hooks/useBillAccounts";
+import { amountStep } from "utils/currency";
 
 export interface AddBillProps {
     accountId?: string;
@@ -183,7 +184,7 @@ export const AddBill: React.FC<AddBillProps> = ({ accountId, show, onHide }) => 
                                     </Form.Group>
                                     <Form.Group groupId={`discounts.${index}.discountAmount`}>
                                         <Form.Label>Discount Amount</Form.Label>
-                                        <Form.Input type="number" step="0.01" />
+                                        <Form.Input type="number" step={amountStep} />
                                     </Form.Group>
                                     <Form.Group groupId={`discounts.${index}.reason`}>
                                         <Form.Label>Reason</Form.Label>

--- a/src/MooBank.Web.App/src/routes/budget/-components/NewBudgetLine.tsx
+++ b/src/MooBank.Web.App/src/routes/budget/-components/NewBudgetLine.tsx
@@ -8,6 +8,7 @@ import { Input } from "@andrewmclachlan/moo-ds";
 import { useTags } from "hooks/useTags";
 import { useCreateBudgetLine } from "../-hooks/useCreateBudgetLine";
 import { useGetTagValue } from "../-hooks/useGetTagValue";
+import { amountStep } from "utils/currency";
 
 export const NewBudgetLine: React.FC<NewBudgetLineProps> = (props) => {
 
@@ -38,7 +39,7 @@ export const NewBudgetLine: React.FC<NewBudgetLineProps> = (props) => {
         <tr>
             <td><ComboBox<Tag> selectedItems={[tag]} onChange={(t: Tag[]) => setTag(t[0])} items={allTags.data ?? []} labelField={(t) => t?.name} valueField={(t) => t.id?.toString()} /></td>
             <td><Input value={notes} onChange={(e) => setNotes(e.currentTarget.value)} /></td>
-            <td><Input type="number" min={0} value={amount} onChange={(e) => setAmount((e.currentTarget as any).valueAsNumber)} /></td>
+            <td><Input type="number" step={amountStep} min={0} value={amount} onChange={(e) => setAmount((e.currentTarget as any).valueAsNumber)} /></td>
             <td><MonthSelector value={month} onChange={setMonth} /></td>
             <td className="row-action"><SaveIcon onClick={add} /></td>
         </tr>

--- a/src/MooBank.Web.App/src/routes/shares/$id/transactions/add.tsx
+++ b/src/MooBank.Web.App/src/routes/shares/$id/transactions/add.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Button, Form, SectionForm } from "@andrewmclachlan/moo-ds";
+import { CurrencyInput } from "components";
 import { type CreateStockTransaction, emptyStockTransaction } from "models/stocks";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "@tanstack/react-router";
@@ -39,11 +40,11 @@ function AddStockTransaction() {
                 </Form.Group>
                 <Form.Group groupId="price">
                     <Form.Label>Price</Form.Label>
-                    <Form.Input type="number" required maxLength={10} />
+                    <CurrencyInput required />
                 </Form.Group>
                 <Form.Group groupId="fees">
                     <Form.Label>Fees</Form.Label>
-                    <Form.Input type="number" required maxLength={10} />
+                    <CurrencyInput required />
                 </Form.Group>
                 <Form.Group groupId="date">
                     <Form.Label>Date</Form.Label>

--- a/src/MooBank.Web.App/src/utils/currency.ts
+++ b/src/MooBank.Web.App/src/utils/currency.ts
@@ -14,6 +14,13 @@ export const currencySymbols: Record<string, string> = {
     CHF: "CHF ",
 };
 
+/**
+ * Step for monetary inputs. Amounts are persisted as decimal(12, 4), so inputs must accept
+ * 4 decimal places — a coarser step makes the browser reject finer values on form submit
+ * (stepMismatch), which is what blocked 4dp share prices.
+ */
+export const amountStep = 0.0001;
+
 export const getCurrencySymbol = (code: string | null | undefined): string => {
     if (!code) return "";
     const upper = code.toUpperCase();


### PR DESCRIPTION
## Problem

Amounts persist as `decimal(12,4)` throughout the backend (`Transaction.Amount`, `TransactionSplit.Amount`, `StockTransaction.Price`/`.Fees`, budget lines, …), but the UI capped them well below that.

The reported bug was on the add-shares transaction form. `step` on `<input type="number">` doesn't stop you *typing* a value — it drives **constraint validation on submit**, and both share forms submit through `SectionForm`:

- `shares/$id/transactions/add.tsx` had Quantity, Price and Fees as bare `<Form.Input type="number">` with **no `step` at all** → HTML defaults to `step="1"` → any decimal was a `stepMismatch` and the form refused to submit. Price was effectively **integer-only**, not 2dp.
- Everything routed through `CurrencyInput` hardcoded `step={0.01}` → capped at 2dp.

The backend was never the constraint. This is a frontend-only fix.

## Changes

- `utils/currency.ts` — new `amountStep = 0.0001`, commented with the `decimal(12,4)` justification.
- `CurrencyInput.tsx` — `step={0.01}` → `step={amountStep}`. Covers AddTransaction, shares create, assets create/manage and AccountForm in one place. `{...props}` still spreads after `step`, so callers can override.
- `shares/$id/transactions/add.tsx` — Price and Fees now use `CurrencyInput`, matching the pattern already in `shares/create.tsx`. **This is the reported bug.**
- Five raw money inputs given `step={amountStep}`: transaction splits (×2), new split, new budget line, virtual account balance, recurring transaction amount.
- `AddBill.tsx` — `discountAmount` only.

## Deliberately unchanged

- **Share Quantity** — `int` end to end (SQL `INT`, C# `int`, 6 places). Fractional shares would be a schema change; out of scope.
- **`AddBill` Total and Cost** — these are **computed columns** (`Total AS (CurrentReading - PreviousReading) PERSISTED`, `Cost AS utilities.TotalCost(Id)`), so a finer step wouldn't correspond to editable 4dp storage. Meter readings, discount %, and the utility rate fields (already `0.00001`/`0.001`) also left as-is.
- **Forecast** stays at `[Precision(18, 2)]` — projections are estimates.
- **Display** is still 2dp (`Amount.tsx` defaults `decimalPlaces = 2`). A price entered as `12.3456` saves correctly but renders as `$12.35`. Worth a follow-up for share prices specifically.

## Known gap — moo-ds `EditColumn`

`EditColumn` destructures `{children, className, type, ...props}` but only forwards `className/type/value/onChange/onBlur/onKeyUp/ref/autoFocus` to its input — **`...props` never reaches the DOM**, so `step` is unsettable. Affects the inline-edit amounts in `RecurringTransactions.tsx:67` and `BudgetLine.tsx:31`.

No live bug (those inputs aren't inside a submitting form, so `stepMismatch` never blocks anything), but 4dp entry there will show wrong spinner increments. Being fixed in MooApp separately.

## Verification

- `npm test` — **174 passed** / 25 files (was 172; +2 new)
- `npm run build` — clean, `tsc` 7.0.2
- `npm run lint` — 0 errors, 151 warnings (pre-existing baseline)

Two cases added to the existing `CurrencyInput.test.tsx`, and **confirmed they can fail** — reverting `amountStep` to `0.01` turns the suite red. jsdom was separately probed to confirm it genuinely implements `validity.stepMismatch` (reports `true` for `12.3456` at `step="0.01"`), so the `stepMismatch === false` assertion isn't vacuously passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
