### PR TITLE
fix(web): bump moo-app to 5.2.66 (auth-window query race fix)

### DIFF
--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2025.4.0",
       "license": "MIT",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.58",
-        "@andrewmclachlan/moo-ds": "^5.2.58",
-        "@andrewmclachlan/moo-icons": "^5.2.58",
+        "@andrewmclachlan/moo-app": "^5.2.66",
+        "@andrewmclachlan/moo-ds": "^5.2.66",
+        "@andrewmclachlan/moo-icons": "^5.2.66",
         "@azure/msal-react": "^5.5.1",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
@@ -91,12 +91,12 @@
       "license": "MIT"
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.58",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.58/ac1e092452db947fc2bafa5e8b34802663683fae",
-      "integrity": "sha512-UQheCAktNveXUNY+cdJ0lOscurD1qXGIHCZ+T+zKtWW4/6GkAN/50IojM9gVSzFL+t2tfxTc/yHdNs9lb7jpEQ==",
+      "version": "5.2.66",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.66/bd3102c563ab7767eb998975535f9bb7460a5726",
+      "integrity": "sha512-0qVAfDPNjhWnf9o4jRgR2AJAXX6uvX5MrYZFLoBsW75gnIwYdmOMZ/qepN46eJ3DlxzzNE/6Wq6K9tM3onytQQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^5.17.0",
+        "@azure/msal-browser": "^5.17.1",
         "axios": "^1.18.1",
         "classnames": "^2.5.1",
         "date-fns": "^4.4.0",
@@ -106,23 +106,23 @@
       },
       "peerDependencies": {
         "@andrewmclachlan/moo-ds": ">=4.0.0",
-        "@azure/msal-react": "^5.5.2",
-        "@fortawesome/fontawesome-svg-core": "^7.3.0",
-        "@fortawesome/free-regular-svg-icons": "^7.3.0",
-        "@fortawesome/free-solid-svg-icons": "^7.3.0",
+        "@azure/msal-react": "^5.5.3",
+        "@fortawesome/fontawesome-svg-core": "^7.3.1",
+        "@fortawesome/free-regular-svg-icons": "^7.3.1",
+        "@fortawesome/free-solid-svg-icons": "^7.3.1",
         "@fortawesome/react-fontawesome": "^3.4.0",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-persist-client": "^5.101.2",
         "@tanstack/react-router": "^1.170.16",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-hook-form": "^7.81.0"
+        "react-hook-form": "^7.82.0"
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.58",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.58/72a12e168502c0fd1c9992ad944777ff7d536db8",
-      "integrity": "sha512-Er9F5Tdx4s1daLyVQvyj1pwWR30FKwR9/TnqvJqFU56HOPtA4y5Khv9I/znsTsoyB0hiEjju4I2HUihgcPbfLQ==",
+      "version": "5.2.66",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.66/f7098584bc221365cc06b89f9ba1e447f6c57b81",
+      "integrity": "sha512-FI7j/0LFETYzPrCRH59r+lyraCZfxo1KFc/XrFdgt629u68/tjoDXyTBDDZfbG42SpeLRKm3t7eYN5nCb61z+g==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -133,19 +133,19 @@
         "use-debounce": "^10.1.1"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "^7.3.0",
-        "@fortawesome/free-regular-svg-icons": "^7.3.0",
-        "@fortawesome/free-solid-svg-icons": "^7.3.0",
+        "@fortawesome/fontawesome-svg-core": "^7.3.1",
+        "@fortawesome/free-regular-svg-icons": "^7.3.1",
+        "@fortawesome/free-solid-svg-icons": "^7.3.1",
         "@fortawesome/react-fontawesome": "^3.4.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
-        "react-hook-form": "^7.81.0"
+        "react-hook-form": "^7.82.0"
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.58",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.58/4c00caad9f2516c3fe7ba95f4d5c41f5eb5e6e85",
-      "integrity": "sha512-rFXn4907XrUpdVZK80ouGN2uHbFvSuULnVXN+gmsBbNkMKhjsV7J3ukvh27N6IkSmpDb0pl/L6ereFtCBOK+mA==",
+      "version": "5.2.66",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.66/d9f1cd8cd4d3cc0f367792e743278bbb1ef5cbe8",
+      "integrity": "sha512-sVmPSfsKcSn9MFx3umTuTrOmV1pVjl74nADHlXr7I1Sy9fEs+J+EWuvIR4uU3GFfpwIP7EJKkgrHcGQ7SRGlZQ==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",
@@ -225,36 +225,36 @@
       "license": "MIT"
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.0.tgz",
-      "integrity": "sha512-/yTnW2TCk9Mh+2b/NOaHAN+MryUNxzRTaJD/YtrqOA9bpBWfTXn/iyReRbaLrK/btBo3stEzLyEvuWp2NZ5DuA==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
+      "integrity": "sha512-zBhRGzABKSI7hfWh5EaZmril5ybZ7imBN1qEZl5sDTaelr+l8SnPjZO50Q4dnKnm347YPIlBMSnXKZyh3Yu5DQ==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.11.1"
+        "@azure/msal-common": "16.11.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.11.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.1.tgz",
-      "integrity": "sha512-yPohvMwWLv1XnaWnIUyKUh8CvcVChCGqG/VluGwfGmaAfrZTNt5yQ+sIs462Sgw6+e2K83KGmMJ860p73ZSCrw==",
+      "version": "16.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.2.tgz",
+      "integrity": "sha512-yDhtBOGDCdK9ipQ9g3+wmlMEPnZx2pXaDicDd9jYyR1L+7lEbvEohTDmF5qejZDutZY3m9pWPxeYxzNC701A2w==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-react": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.2.tgz",
-      "integrity": "sha512-gqLSay+1NfOjDUNL/A64myLhbPck/ne8Gw6O4Yb14Y/U/7AntnJs1Fzwyxt5AxOMnBkfzl9loDpBas2fugkwXw==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.3.tgz",
+      "integrity": "sha512-wPSCQuKFilQNSn/1M2FabKDanRc6Any9RTAXOp9uJGe6OYCEphetF9BTu68aIHsE+I2GFkXVqjx359VMRs+/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@azure/msal-browser": "^5.17.0",
+        "@azure/msal-browser": "^5.17.1",
         "react": "^16.8.0 || ^17 || ^18 || ^19.2.1"
       }
     },
@@ -3569,46 +3569,46 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
-      "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.1.tgz",
+      "integrity": "sha512-k0C0sdHmZtAo6dRDtd1Z/qcpyHbL0CKsjV8seMY/21xGhY5Wsv0XRmiI/xEEH4y2c9b1+jvgNs/3EqhV27yUEA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
-      "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.1.tgz",
+      "integrity": "sha512-BoxVN3PKnMbgStHhjoaky/oWdxHomDqmBVA24IA3KEmssFGeI7u9YT/BJceOjIum/t6TpPa/vcMKaVYQeIQ/3Q==",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.0"
+        "@fortawesome/fontawesome-common-types": "7.3.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-regular-svg-icons": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.0.tgz",
-      "integrity": "sha512-4675NiHzJJs0dLStFpp5G1JNfMYxqFSxZ2iCaiMfHptjlc8McLG9oqcd5pFEiPiqfiV2YG25cJ9EYWIEhUvp+A==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.3.1.tgz",
+      "integrity": "sha512-q1EsmL7Q8DDnkRBUjSvrxbq7c9oVwwVjCn/xa5apKmdp65YSgzUg2y0Ltnd5aDbT6GdAQQdXql5Ha90ArqIReQ==",
       "license": "(CC-BY-4.0 AND MIT)",
       "peer": true,
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.0"
+        "@fortawesome/fontawesome-common-types": "7.3.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
-      "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.1.tgz",
+      "integrity": "sha512-v0BLa0eqg7ubvVWeNSHVBs8fWH/GJicERZoJaxJ3FE/lj67VSqzoMg9pzfZVOfLMX10y0pGwQAuxoRVVH2patg==",
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.0"
+        "@fortawesome/fontawesome-common-types": "7.3.1"
       },
       "engines": {
         "node": ">=6"
@@ -12385,9 +12385,9 @@
       "license": "MIT"
     },
     "node_modules/react-hook-form": {
-      "version": "7.81.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.81.0.tgz",
-      "integrity": "sha512-ocbmr2p5KBMoAfj4WCUvped33lVi1Kd5DuDUvQDnB6VEAacOjPI/jMbtDdbhco4y9ct4xUuCmMY0b/C9L0QHjw==",
+      "version": "7.82.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.82.0.tgz",
+      "integrity": "sha512-Zw/uFZ2dO+02GHlBn7JFGn8kZJ7LdM33B/0BXOovzFay+CMhf94JMw5BVu+F1tVkUKjNvBuaE3fz5BJhga10Tg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -14,9 +14,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.58",
-    "@andrewmclachlan/moo-ds": "^5.2.58",
-    "@andrewmclachlan/moo-icons": "^5.2.58",
+    "@andrewmclachlan/moo-app": "^5.2.66",
+    "@andrewmclachlan/moo-ds": "^5.2.66",
+    "@andrewmclachlan/moo-icons": "^5.2.66",
     "@azure/msal-react": "^5.5.1",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",


### PR DESCRIPTION
Bumps `@andrewmclachlan/moo-app`, `moo-ds`, and `moo-icons` to **5.2.66**, picking up [MooApp #644](https://github.com/AndrewMcLachlan/MooApp/pull/644).

## What it fixes
On a first load after a while (token expired, account still cached), the app went through the MSAL redirect flow, reloaded, and dashboard widgets showed **"Unable to load this widget"** with **no `/api` calls** — because `Login` rendered data-fetching children while MSAL was still mid-flight, the token interceptor cancelled the request, and `retry: false` made the error permanent (recovery only fired for interactive, not silent, token success).

MooApp 5.2.66 fixes it two ways:
- `Login` now also waits for `inProgress === InteractionStatus.None`.
- Auth recovery fires on silent `ACQUIRE_TOKEN_SUCCESS` too, invalidating only errored queries.

## Verification
- Confirmed both fixes present in the installed dist.
- `tsc` 7.0.2 typecheck + vite build clean.
- Frontend tests: 172 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)