### PR TITLE
fix(web): render RouteError in the main content panel, not under the sidebar

### DIFF
--- a/src/MooBank.Web.App/src/components/RouteError.tsx
+++ b/src/MooBank.Web.App/src/components/RouteError.tsx
@@ -1,13 +1,28 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Button } from "@andrewmclachlan/moo-ds";
+import { Page } from "@andrewmclachlan/moo-app";
 
 export interface RouteErrorProps {
     error?: Error;
 }
 
+// Wrap in Page so the error occupies the content grid-area (main.container-fluid) —
+// the same wrapper every route and moo-app's own Error page use. A bare div carries
+// no grid-area and gets dropped into an implicit cell (under the sidebar).
 export const RouteError: React.FC<RouteErrorProps> = ({ error }) => (
-    <div className="widget-error route-error">
-        <FontAwesomeIcon icon="triangle-exclamation" className="widget-error-icon" />
-        <div className="widget-error-message">Something went wrong. Try reloading the page.</div>
-        {import.meta.env.DEV && error?.message && <pre className="route-error-detail">{error.message}</pre>}
-    </div>
+    <Page title="Error">
+        <div className="route-error" role="alert">
+            <div className="route-error-content">
+                <span className="route-error-icon" aria-hidden="true">
+                    <FontAwesomeIcon icon="triangle-exclamation" />
+                </span>
+                <h1 className="route-error-title">Something went wrong</h1>
+                <p className="route-error-message">The page didn&rsquo;t load properly. Reloading usually fixes it.</p>
+                <Button variant="primary" onClick={() => window.location.reload()}>Reload page</Button>
+                {import.meta.env.DEV && error?.message && (
+                    <pre className="route-error-detail">{error.message}</pre>
+                )}
+            </div>
+        </div>
+    </Page>
 );

--- a/src/MooBank.Web.App/src/css/dashboard.css
+++ b/src/MooBank.Web.App/src/css/dashboard.css
@@ -29,22 +29,68 @@ main.dashboard .section > .section-header {
     line-height: 1.3;
 }
 
-/* RouteError (App.tsx defaultErrorComponent) reuses the widget-error layout, but a route-level
-   error needs to read as a full-page message rather than a small widget card. Give it vertical
-   space to centre within, and keep the dev-only error detail (often a long, unbreakable URL) from
-   sprawling the page full-width. */
+/* RouteError (App.tsx defaultErrorComponent) is a full-page empty-state, not a widget card.
+   It renders inside <Page> (main.container-fluid, a flex column), so grow to fill the content
+   area and centre within it — this keeps it in the main panel rather than under the sidebar. */
 .route-error {
-    min-height: 50vh;
-    gap: 1rem;
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 24rem;
+    padding: 2rem 1rem;
+    text-align: center;
 }
 
-.route-error-detail {
-    max-width: min(72ch, 100%);
+.route-error-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    width: 100%;
+    max-width: 32rem;
+}
+
+.route-error-icon {
+    display: grid;
+    place-items: center;
+    width: 4rem;
+    height: 4rem;
+    border-radius: 50%;
+    font-size: 1.75rem;
+    color: var(--warning);
+    background: color-mix(in srgb, var(--warning) 16%, transparent);
+}
+
+.route-error-title {
     margin: 0;
+    font-size: 1.5rem;
+    color: var(--body-colour-bold, var(--body-colour));
+}
+
+.route-error-message {
+    margin: 0;
+    max-width: 40ch;
+    line-height: 1.45;
+    color: var(--secondary-colour);
+}
+
+/* Dev-only detail (often a long, unbreakable URL / stack): a contained, scrollable panel that
+   stays secondary and never sprawls the page. */
+.route-error-detail {
+    align-self: stretch;
+    margin: 0.5rem 0 0;
+    padding: 0.75rem 1rem;
+    max-height: 10rem;
+    overflow: auto;
     font-size: 0.8rem;
-    line-height: 1.4;
+    line-height: 1.45;
     text-align: left;
+    color: var(--secondary-colour);
+    background: var(--section-bg);
+    border: 1px solid var(--border-colour);
+    border-radius: var(--border-radius);
     white-space: pre-wrap;
     overflow-wrap: anywhere;
-    opacity: 0.7;
 }


### PR DESCRIPTION
## Problem

The full-page error boundary (`App.tsx` `defaultErrorComponent`) rendered **under the sidebar** instead of in the main content area.

Root cause: the `.app-container` layout is a CSS grid with named areas, and the content cell (`grid-area: main`) is only claimed by `main.container-fluid`. Every route — and moo-app's own error page — renders `<Page>`, which emits that `<main>`. `RouteError` rendered a **bare `<div>`** with no `grid-area`, so the grid dropped it into an implicit cell outside the `main` column.

## Fix

- `RouteError` now renders inside `<Page title="Error">`, so it occupies `grid-area: main` like every other route, and `.route-error` grows to fill and centre within that panel.
- While here, reworked the internals from the reused tiny `widget-error` card styles into a proper full-page empty-state: a tinted warning badge, heading + supporting line, a real **Reload page** button, and the dev-only detail in a contained, scrollable panel.

## Verification
- `tsc` 7 typecheck + vite build clean.
- Frontend tests: 172 passing.
- Placement + styling previewed against the real `.app-container` grid and installed moo-ds tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)