### PR TITLE
perf(web): spinner during Breakdown/Top Tags report fetch (no more blank-chart gap)

### DIFF
--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/Breakdown.tsx
@@ -4,6 +4,7 @@ import { useBreakdownReport } from "../../../-hooks/useBreakdownReport";
 
 import type { ChartData } from "chart.js";
 import { Doughnut } from "react-chartjs-2";
+import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
 
 import type { Period } from "models/dateFns";
 import { chartColours } from "utils/chartColours";
@@ -41,6 +42,8 @@ export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, 
     }, [report.data, accountId, period?.startDate, period?.endDate, reportType, tagId]);
 
     return (
+        <>
+        {report.isLoading && <SpinnerContainer />}
         <Doughnut id="bytag" ref={chartRef} data={dataset} options={{
             maintainAspectRatio: false,
             plugins: {
@@ -63,6 +66,7 @@ export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, 
             },
         }}
         />
+        </>
     );
 }
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
@@ -4,6 +4,7 @@ import { useAllTagAverageReport } from "../../../-hooks/useAllTagAverageReport";
 
 import type { ChartData } from "chart.js";
 import { Bar } from "react-chartjs-2";
+import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
 
 import type { Period } from "models/dateFns";
 import { useNavigate } from "@tanstack/react-router";
@@ -35,6 +36,8 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
     }
 
     return (
+        <>
+        {report.isLoading && <SpinnerContainer />}
         <Bar id="alltagaverage" data={dataset} options={{
             plugins: {
                 legend: {
@@ -65,6 +68,7 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
             },
         }}
         />
+        </>
     );
 }
 


### PR DESCRIPTION
## The problem

The Breakdown widget "takes a long time to render". It's not the render (5 slices paints instantly) and it's not literally after loading finished — it's a gap the loading indicator doesn't cover.

Each dashboard widget's spinner is wired differently:

| Widget | Spinner covers | During its report fetch you see |
|---|---|---|
| Budget | its **report** query | spinner → chart |
| In/Out | its **report** query (own `SpinnerContainer`) | spinner → chart |
| **Top Tags** | `useAccounts` (shared, finishes early) | **empty chart** → chart |
| **Breakdown** | `useAccounts` (shared, finishes early) | **empty chart** → chart |

So on Breakdown/Top Tags the accounts spinner clears, then the chart renders with **empty data** while the report query is still fetching — no spinner covers that wait. Breakdown is worst because `GetTransactionTotalsByTag` is the heaviest report proc, so its blank-chart gap is the longest.

## The fix

Render moo-ds `SpinnerContainer` (absolutely positioned — no layout shift) while the report query is loading in the Breakdown and Top Tags components, matching the In/Out pattern. The wait now reads as a spinner, consistent with the other widgets, on the dashboard and the full report pages.

This makes the wait read correctly; it does **not** speed up the query itself. If the Breakdown query still feels slow behind the spinner, the follow-up is to optimise `GetTransactionTotalsByTag` (filter splits by account + date before the tag-ancestor join) — happy to do that next.

## Verification
- `tsc` 7 typecheck + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)