### PR TITLE
Migrate from Asm.Cqrs to Postie

### DIFF
--- a/.claude/rules/backend/cqrs.md
+++ b/.claude/rules/backend/cqrs.md
@@ -104,7 +104,7 @@ public static void MapTransactionEndpoints(this IEndpointRouteBuilder endpoints)
 ```
 
 ### Endpoint Guidelines
-- Use `.MapCommand()` and `.MapQuery()` extensions from `Asm.Cqrs.AspNetCore`
+- Use `.MapCommand()` and `.MapQuery()` extensions from `Postie.AspNetCore`
 - Apply authorization policies using `.RequireAuthorization()`
 - Note: the Transactions module intentionally applies `GetInstrumentViewerPolicy` to its whole
   endpoint group **including writes** (viewers may tag/annotate transactions). This is a settled
@@ -131,6 +131,8 @@ Modules.{Feature}/
 
 ## ASM Library
 
-The CQRS implementation uses the ASM library:
-- `Asm.Cqrs.AspNetCore` - Extensions for mapping endpoints to commands/queries
-- Documentation: https://github.com/AndrewMcLachlan/ASM
+The CQRS implementation uses the ASM and Postie libraries:
+- `Postie.Cqrs` / `Postie.Cqrs.AspNetCore` - CQRS mediator and endpoint dispatcher
+- `Postie.AspNetCore` - Extensions for mapping endpoints to commands/queries
+- `Asm.AspNetCore.Postie` - Paged query endpoint mapping
+- Documentation: https://github.com/AndrewMcLachlan/ASM and https://github.com/AndrewMcLachlan/Postie

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Note: projects live in `MooBank.*` folders but build as `Asm.MooBank.*` assembli
 - **ASM Library** (https://github.com/AndrewMcLachlan/ASM) - Custom NuGet packages:
   - `Asm.AspNetCore.Api` - OpenAPI configuration
   - `Asm.AspNetCore.Modules` - Module registration and endpoint mapping
-  - `Asm.Cqrs.AspNetCore` - CQRS endpoint extensions
+  - `Postie.Cqrs.AspNetCore` / `Postie.AspNetCore` - CQRS endpoint extensions
   - `Asm.Domain` / `Asm.Domain.Infrastructure` - DDD base classes
 - **ReqnRoll** - BDD testing framework
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,15 +45,19 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Asm" Version="4.0.31" />
+    <PackageVersion Include="Asm" Version="4.1.16" />
     <PackageVersion Include="Asm.AspNetCore" Version="4.0.31" />
     <PackageVersion Include="Asm.AspNetCore.Api" Version="4.0.31" />
-    <PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.31" />
+    <PackageVersion Include="Asm.AspNetCore.Postie" Version="4.1.16" />
     <PackageVersion Include="Asm.Domain" Version="4.0.31" />
     <PackageVersion Include="Asm.Domain.Infrastructure" Version="4.0.31" />
     <PackageVersion Include="Asm.Hosting" Version="4.0.31" />
     <PackageVersion Include="Asm.ModelContextProtocol" Version="4.0.31" />
     <PackageVersion Include="Asm.Testing.Domain" Version="4.0.31" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Postie.AspNetCore" Version="1.0.0" />
+    <PackageVersion Include="Postie.Cqrs.AspNetCore" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
@@ -56,8 +56,8 @@
     <PackageVersion Include="Asm.Testing.Domain" Version="4.0.31" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="Postie.AspNetCore" Version="1.0.0" />
-    <PackageVersion Include="Postie.Cqrs.AspNetCore" Version="1.0.0" />
+    <PackageVersion Include="Postie.AspNetCore" Version="1.0.1" />
+    <PackageVersion Include="Postie.Cqrs.AspNetCore" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/docs/superpowers/plans/2026-07-22-postie-migration.md
+++ b/docs/superpowers/plans/2026-07-22-postie-migration.md
@@ -1,0 +1,364 @@
+# Postie Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dogfood Postie 1.0.0: add `Asm.AspNetCore.Postie` (paged-query mapping on Postie), migrate MooBank from Asm.Cqrs to Postie, then remove the Asm.Cqrs projects.
+
+**Architecture:** Three sequenced PRs across two repos. Part A adds an additive Asm package exposing `MapPagedQuery` with Postie's full verb/binding surface, dispatching via the mediator-agnostic `IEndpointDispatcher`. Part B is the MooBank package/namespace/call-site migration with behaviour preservation (explicit `Parameters` binding where Asm's default applied). Part C deletes the two Asm.Cqrs projects as a major version.
+
+**Tech Stack:** .NET 10, Postie 1.0.0 (nuget.org), Asm repo conventions (Reqnroll + Moq tests, `VersionPrefix` versioning), MooBank (xUnit, modules pattern).
+
+**Spec:** `K:\Dev\Apps\MooBank\docs\superpowers\specs\2026-07-22-postie-migration-design.md`
+
+## Global Constraints
+
+- Asm repo (`K:\Dev\Libraries\Asm`): public OSS — no process docs committed; net10.0; `Nullable` enabled; XML docs on all public APIs; Reqnroll (`@Unit`-tagged scenarios) + Moq for tests; version = `VersionPrefix` in `Directory.Build.props` (patch is commit-count, do not hand-set).
+- MooBank repo (`K:\Dev\Apps\MooBank`): docs committed with the branch; central package management (`Directory.Packages.props`); behaviour preservation is the migration rule — no endpoint semantics change beyond the documented deltas.
+- Branches/PRs: Part A `feature/postie-extensions` (Asm), Part B `feature/postie` (MooBank), Part C `feature/remove-cqrs` (Asm). Each part ends at an open PR — the human merges; later parts wait for the earlier merge (Part B needs Part A's package on the GitHub feed).
+- MooBank consumes `ASM.*` from GitHub Packages (see `NuGet.config` source mapping) and `Postie.*` from nuget.org.
+- End every commit message with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- PR bodies end with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+---
+
+## Part A — Asm.AspNetCore.Postie (Asm repo)
+
+### Task A1: Create the package with `MapPagedQuery`
+
+**Files:**
+- Create: `K:\Dev\Libraries\Asm\src\Asm.AspNetCore.Postie\Asm.AspNetCore.Postie.csproj`
+- Create: `K:\Dev\Libraries\Asm\src\Asm.AspNetCore.Postie\AsmPostieEndpointRouteBuilderExtensions.cs`
+- Modify: `K:\Dev\Libraries\Asm\Asm.slnx` (add the project; match existing entry format)
+- Modify: `K:\Dev\Libraries\Asm\Directory.Build.props` (`<VersionPrefix>4.0</VersionPrefix>` → `4.1`)
+- Modify: `K:\Dev\Libraries\Asm\Directory.Packages.props` if Postie needs a central version entry (check whether the repo uses CPM — if no `Directory.Packages.props` exists, put the version on the PackageReference)
+
+**Interfaces:**
+- Consumes: `Asm.PagedResult<T>` (`src/Asm/PagedResult.cs`: `Results` + `Total`), Postie.AspNetCore 1.0.0 public surface (`IEndpointDispatcher.DispatchAsync<T>`, `QueryMethod`, `RequestBinding`).
+- Produces (Part B relies on exactly): `Asm.AspNetCore.AsmPostieEndpointRouteBuilderExtensions.MapPagedQuery<TRequest, TResponse>(this IEndpointRouteBuilder endpoints, string pattern, QueryMethod method = QueryMethod.Get, RequestBinding? binding = null) where TRequest : notnull` returning `RouteHandlerBuilder`.
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd K:/Dev/Libraries/Asm && git checkout -b feature/postie-extensions main
+```
+
+- [ ] **Step 2: Project file**
+
+Create `src/Asm.AspNetCore.Postie/Asm.AspNetCore.Postie.csproj` (mirror a sibling like `src/Asm.Cqrs.AspNetCore/Asm.Cqrs.AspNetCore.csproj` for PropertyGroup conventions — read it first and copy its packaging metadata style):
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Postie endpoint mapping extensions using Asm conventions, starting with paged queries.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Postie.AspNetCore" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Asm\Asm.csproj" />
+  </ItemGroup>
+
+</Project>
+```
+
+(Adjust to match sibling conventions exactly — e.g. if the repo centralises package versions, move `Version` accordingly; if siblings set `IsPackable`/README/icon items explicitly, copy that block.)
+
+- [ ] **Step 3: The extension class**
+
+Create `src/Asm.AspNetCore.Postie/AsmPostieEndpointRouteBuilderExtensions.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
+
+namespace Asm.AspNetCore;
+
+/// <summary>
+/// Maps paged CQRS queries to ASP.NET Core minimal API endpoints, dispatching through Postie's
+/// mediator-agnostic <see cref="IEndpointDispatcher"/>.
+/// </summary>
+public static class AsmPostieEndpointRouteBuilderExtensions
+{
+    private const string QueryHttpMethod = "QUERY";
+
+    /// <summary>
+    /// Maps a query whose response is a <see cref="PagedResult{T}"/> to an endpoint that returns
+    /// the unwrapped page with the total item count in an <c>X-Total-Count</c> response header.
+    /// By default the endpoint is a GET bound from route, query and header values;
+    /// <paramref name="method"/> selects POST or the HTTP QUERY method instead, both of which bind
+    /// the query from the request body by default.
+    /// </summary>
+    /// <typeparam name="TRequest">The type of the query.</typeparam>
+    /// <typeparam name="TResponse">The type of each item in the page.</typeparam>
+    /// <param name="endpoints">The <see cref="IEndpointRouteBuilder"/> to add the route to.</param>
+    /// <param name="pattern">The route pattern.</param>
+    /// <param name="method">The HTTP method to map. Defaults to <see cref="QueryMethod.Get"/>.</param>
+    /// <param name="binding">
+    /// How the query is bound. Defaults to the idiomatic binding for <paramref name="method"/>:
+    /// <see cref="RequestBinding.Parameters"/> for GET, <see cref="RequestBinding.Body"/> for POST
+    /// and QUERY.
+    /// </param>
+    /// <returns>A <see cref="RouteHandlerBuilder"/> that can be used to further customise the endpoint.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="endpoints"/> or <paramref name="pattern"/> is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="method"/> is not a defined <see cref="QueryMethod"/> value, or <paramref name="binding"/> is not a defined <see cref="RequestBinding"/> value.</exception>
+    public static RouteHandlerBuilder MapPagedQuery<TRequest, TResponse>(this IEndpointRouteBuilder endpoints, string pattern, QueryMethod method = QueryMethod.Get, RequestBinding? binding = null) where TRequest : notnull
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        var handler = PagedHandler<TRequest, TResponse>(ResolveBinding(method, binding));
+
+        RouteHandlerBuilder builder = method switch
+        {
+            QueryMethod.Get => endpoints.MapGet(pattern, handler),
+            QueryMethod.Post => endpoints.MapPost(pattern, handler),
+            QueryMethod.Query => endpoints.MapMethods(pattern, [QueryHttpMethod], handler),
+            _ => throw new ArgumentOutOfRangeException(nameof(method), method, $"'{method}' is not a defined {nameof(QueryMethod)} value."),
+        };
+
+        return builder.Produces<IEnumerable<TResponse>>();
+    }
+
+    private static RequestBinding ResolveBinding(QueryMethod method, RequestBinding? binding)
+    {
+        if (binding is { } explicitBinding)
+        {
+            if (explicitBinding is not (RequestBinding.Default or RequestBinding.Body or RequestBinding.Parameters))
+            {
+                throw new ArgumentOutOfRangeException(nameof(binding), explicitBinding, $"'{explicitBinding}' is not a defined {nameof(RequestBinding)} value.");
+            }
+
+            return explicitBinding;
+        }
+
+        return method == QueryMethod.Get ? RequestBinding.Parameters : RequestBinding.Body;
+    }
+
+    // The binding attribute must sit on the delegate's request parameter for minimal API binding to
+    // honour it, so a separate lambda is produced per binding.
+    private static Delegate PagedHandler<TRequest, TResponse>(RequestBinding binding) where TRequest : notnull =>
+        binding switch
+        {
+            RequestBinding.Body => async ([FromBody] TRequest request, HttpContext http, IEndpointDispatcher dispatcher, CancellationToken cancellationToken) =>
+                await DispatchPaged<TRequest, TResponse>(request, http, dispatcher, cancellationToken),
+            RequestBinding.Parameters => async ([AsParameters] TRequest request, HttpContext http, IEndpointDispatcher dispatcher, CancellationToken cancellationToken) =>
+                await DispatchPaged<TRequest, TResponse>(request, http, dispatcher, cancellationToken),
+            _ => async (TRequest request, HttpContext http, IEndpointDispatcher dispatcher, CancellationToken cancellationToken) =>
+                await DispatchPaged<TRequest, TResponse>(request, http, dispatcher, cancellationToken),
+        };
+
+    private static async Task<IResult> DispatchPaged<TRequest, TResponse>(TRequest request, HttpContext http, IEndpointDispatcher dispatcher, CancellationToken cancellationToken) where TRequest : notnull
+    {
+        var result = await dispatcher.DispatchAsync<PagedResult<TResponse>>(request, cancellationToken);
+
+        http.Response.Headers.Append("X-Total-Count", result.Total.ToString());
+        return Results.Ok(result.Results);
+    }
+}
+```
+
+Known, accepted limitations (record in the PR body, not code comments): no Body-binding attribute-conflict guard and no null→404 path — Postie's `GuardBodyBinding`/`EndpointHandlers` are internal. This is dogfooding feedback: consider a future Postie public extension surface for third-party `Map*` authors.
+
+- [ ] **Step 4: Build to verify it compiles**
+
+```bash
+dotnet build src/Asm.AspNetCore.Postie --configuration Release
+```
+
+Expected: success, 0 warnings. (Postie 1.0.0 restores from nuget.org.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Asm.AspNetCore.Postie Asm.slnx Directory.Build.props
+git commit -m "Add Asm.AspNetCore.Postie with MapPagedQuery on Postie's endpoint dispatcher
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Include `Directory.Packages.props` in the add list if it was edited.)
+
+### Task A2: Tests (Reqnroll, TestServer round-trips)
+
+**Files:**
+- Create: `K:\Dev\Libraries\Asm\tests\Asm.AspNetCore.Postie.Tests\Asm.AspNetCore.Postie.Tests.csproj` (mirror `tests/Asm.Cqrs.AspNetCore.Tests/Asm.Cqrs.AspNetCore.Tests.csproj` — read it and copy its Reqnroll/Moq/xunit references and `reqnroll.json` if present)
+- Create: `K:\Dev\Libraries\Asm\tests\Asm.AspNetCore.Postie.Tests\MapPagedQuery.feature`
+- Create: `K:\Dev\Libraries\Asm\tests\Asm.AspNetCore.Postie.Tests\MapPagedQuerySteps.cs`
+- Modify: `K:\Dev\Libraries\Asm\Asm.slnx`
+
+**Interfaces:**
+- Consumes: Task A1's `MapPagedQuery`; Postie's `AddPostie` registration (`Postie.Cqrs.AspNetCore` as a test-only dependency, or mock `IEndpointDispatcher` in DI — use the mock; the package under test must stay mediator-agnostic and the test proves it by never referencing a mediator).
+
+- [ ] **Step 1: Write the feature**
+
+`MapPagedQuery.feature`:
+
+```gherkin
+Feature: MapPagedQuery
+
+@Unit
+Scenario: GET paged query returns the page with a total count header
+    Given a paged endpoint mapped with the default method
+    And the dispatcher returns 2 items with 100 total
+    When I GET the endpoint
+    Then the response status should be 200
+    And the response body should be the unwrapped items
+    And the X-Total-Count header should be '100'
+
+@Unit
+Scenario: POST paged query binds the query from the body
+    Given a paged endpoint mapped with method Post
+    And the dispatcher returns 2 items with 40 total
+    When I POST the criteria to the endpoint
+    Then the response status should be 200
+    And the X-Total-Count header should be '40'
+
+@Unit
+Scenario: QUERY-verb paged query binds the query from the body
+    Given a paged endpoint mapped with method Query
+    And the dispatcher returns 2 items with 7 total
+    When I send a QUERY request with criteria to the endpoint
+    Then the response status should be 200
+    And the X-Total-Count header should be '7'
+
+@Unit
+Scenario: An undefined method value is rejected at map time
+    Given a route builder
+    When I map a paged endpoint with an undefined method value
+    Then an ArgumentOutOfRangeException should be thrown for 'method'
+```
+
+- [ ] **Step 2: Write the steps**
+
+`MapPagedQuerySteps.cs` — TestServer app with a `Mock<IEndpointDispatcher>` registered as singleton; the mock's `DispatchAsync<PagedResult<string>>(It.IsAny<object>(), It.IsAny<CancellationToken>())` returns `new PagedResult<string> { Results = ["item1", "item2"], Total = <per scenario> }`. Map with `app.MapPagedQuery<TestPagedQuery, string>("/paged"[, method])` where `private record TestPagedQuery(string? Term = null);` (no mediator interface — proves mediator-agnosticism). GET scenario calls `client.GetAsync("/paged")`; POST uses `client.PostAsJsonAsync("/paged", new TestPagedQuery("x"))`; QUERY uses `new HttpRequestMessage(new HttpMethod("QUERY"), "/paged") { Content = JsonContent.Create(new TestPagedQuery("x")) }`. Body assertion deserialises `List<string>` and compares to `["item1", "item2"]`. The undefined-method scenario calls `MapPagedQuery<TestPagedQuery, string>("/x", (QueryMethod)42)` inside `Assert.Throws<ArgumentOutOfRangeException>` and asserts `ParamName == "method"`. Follow `HandlersSteps.cs` structure for fixture/step-class layout (constructor-injected scenario context, `[Given]`/`[When]`/`[Then]` attributes with regex bindings matching the feature text verbatim).
+
+- [ ] **Step 3: Run the new tests**
+
+```bash
+dotnet test tests/Asm.AspNetCore.Postie.Tests
+```
+
+Expected: all scenarios pass. (RED first if steps are written before Task A1 is referenced — feature/steps compile against the package, so failure mode here is compile-time; acceptable given A1 precedes.)
+
+- [ ] **Step 4: Full repo build + test, commit**
+
+```bash
+dotnet build Asm.slnx --configuration Release && dotnet test Asm.slnx
+git add tests/Asm.AspNetCore.Postie.Tests Asm.slnx
+git commit -m "Cover MapPagedQuery: verbs, binding, header, guard
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+Expected: 0 warnings, all existing suites still green.
+
+### Task A3: PR
+
+- [ ] Push and open the PR:
+
+```bash
+git push -u origin feature/postie-extensions
+gh pr create --title "Add Asm.AspNetCore.Postie: MapPagedQuery on Postie" --body "<summary per spec: additive package, mediator-agnostic IEndpointDispatcher, full QueryMethod/RequestBinding surface, X-Total-Count contract preserved; version 4.0 -> 4.1; notes the two accepted limitations (no Body-binding guard, no null-to-404 — Postie internals not public) as Postie feedback.>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+**STOP — Part B waits until this PR is merged and CI has published 4.1.x to GitHub Packages.**
+
+---
+
+## Part B — MooBank migration (after A merges)
+
+### Task B1: Package and namespace swap
+
+**Files:**
+- Modify: `K:\Dev\Apps\MooBank\Directory.Packages.props`
+- Modify: all 15 `src\MooBank.Modules.*\MooBank.Modules.*.csproj`
+- Modify: all 15 `src\MooBank.Modules.*\Properties\Global.cs`
+- Commit also: `docs\superpowers\specs\2026-07-22-postie-migration-design.md` and this plan (already on disk, untracked)
+
+- [ ] **Step 1: Branch**
+
+```bash
+cd K:/Dev/Apps/MooBank && git checkout -b feature/postie main
+```
+
+- [ ] **Step 2: Central package versions** — in `Directory.Packages.props`: remove `<PackageVersion Include="Asm.Cqrs.AspNetCore" Version="4.0.31" />`; add (Asm version = the actual 4.1.x CI published — check the GitHub Packages feed):
+
+```xml
+<PackageVersion Include="Asm.AspNetCore.Postie" Version="4.1.X" />
+<PackageVersion Include="Postie.Cqrs.AspNetCore" Version="1.0.0" />
+<PackageVersion Include="Postie.AspNetCore" Version="1.0.0" />
+```
+
+- [ ] **Step 3: Project references** — in each of the 15 module csprojs replace `<PackageReference Include="Asm.Cqrs.AspNetCore" />` with `<PackageReference Include="Postie.Cqrs.AspNetCore" />` and `<PackageReference Include="Postie.AspNetCore" />`; additionally add `<PackageReference Include="Asm.AspNetCore.Postie" />` ONLY in the modules with paged endpoints (find them: `grep -rl "MapPagedQuery" src --include="*.cs"` — expected: Transactions, Stocks and whichever others total 6 call sites across their endpoint files).
+
+- [ ] **Step 4: Global usings** — in each `Properties\Global.cs`: `global using Asm.Cqrs.Commands;` → `global using Postie.Cqrs.Commands;` and `global using Asm.Cqrs.Queries;` → `global using Postie.Cqrs.Queries;`.
+
+- [ ] **Step 5: Registration + dispatcher usings** — `grep -rn "using Asm.Cqrs" src tests --include="*.cs"` and update each remaining explicit using (Module.cs files if any, MCP tool classes, `tests\MooBank.Modules.Budgets.Tests\Support\TestMocks.cs`) to the Postie namespaces. `AddCommandHandlers`/`AddQueryHandlers` calls need no change beyond the using (same names in Postie; they live in `Microsoft.Extensions.DependencyInjection` namespace — verify none of the 15 `Module.cs` files need a new using at all).
+
+- [ ] **Step 6: Verify zero remaining references**
+
+```bash
+grep -rn "Asm\.Cqrs" src tests --include="*.cs" --include="*.csproj" --include="*.props" | grep -v obj
+```
+
+Expected: no output.
+
+### Task B2: Endpoint call-site migration
+
+**Files:** the 44 endpoint files under `src\MooBank.Modules.*\Endpoints\`.
+
+Transformation rules (apply mechanically, verify each with the greps below):
+- [ ] `MapDelete<` → `MapDeleteCommand<` (14 sites; both arities).
+- [ ] `CommandBinding.Body` → `RequestBinding.Body`; `CommandBinding.Parameters` → `RequestBinding.Parameters`; `CommandBinding.None` → `RequestBinding.Default` (add `using Postie.AspNetCore;` where the type is named).
+- [ ] Every `MapCommand`/`MapPutCommand`/`MapPatchCommand`/`MapPostCreate`/`MapPutCreate`/`MapDeleteCommand` call **without** an explicit binding argument gets `binding: RequestBinding.Parameters` appended (behaviour preservation: Asm defaulted all verbs to Parameters, Postie defaults POST/PUT/PATCH to Body). Note: Postie's `MapPostCreate`/`MapPutCreate` parameter order matches Asm's (pattern, routeName, getRouteValues, binding) — spot-check one call against Postie's signature before sweeping.
+- [ ] `MapPagedQuery` call sites (6): unchanged call shape (Task A1 preserved the signature); ensure the file's project has the `Asm.AspNetCore.Postie` reference (Task B1 Step 3).
+- [ ] Verification greps — all must return zero:
+
+```bash
+grep -rn "CommandBinding" src --include="*.cs" | grep -v obj
+grep -rn "MapDelete<" src --include="*.cs" | grep -v obj
+```
+
+And this must return exactly the same count as before migration (69+6+17+17+6+14+9 mapping calls — re-count with the same grep used pre-migration to prove no endpoint was dropped):
+
+```bash
+grep -rno "Map\(Paged\)\?Query<\|MapCommand<\|MapPutCommand<\|MapPatchCommand<\|MapPostCreate<\|MapPutCreate<\|MapDeleteCommand<" src --include="*.cs" | grep -v obj | wc -l
+```
+
+- [ ] Commit: `git add -- src docs && git commit -m "Migrate from Asm.Cqrs to Postie ..."` (explicit paths; include the spec + plan docs).
+
+### Task B3: Build, tests, smoke
+
+- [ ] `dotnet build MooBank.slnx --configuration Release` — 0 errors; triage warnings (new nullable warnings from Postie's annotations are fixable inline if trivial, otherwise report).
+- [ ] `dotnet test MooBank.slnx` — all suites green (expect compile-only churn; the single behavioural test file is `TestMocks.cs`).
+- [ ] Smoke checklist (run the app; requires Andrew's local environment — hand back to him if the app needs infrastructure that isn't running): one endpoint of each shape per the spec's verification gate — GET by id, paged GET (`X-Total-Count` + unwrapped body), POST-create (201 + Location), PATCH, PUT route-bound, DELETE void, 204/202 `MapCommand`, `IFormFile` upload, one MCP tool call, one `WithValidation` 400.
+- [ ] Push, open PR titled "Migrate to Postie" with the deltas table from the spec in the body.
+
+**STOP — Part C waits until the MooBank PR is validated and merged.**
+
+---
+
+## Part C — Asm.Cqrs removal (Asm repo, after B merges)
+
+- [ ] Branch: `git checkout -b feature/remove-cqrs main` (after pulling the merged Part A).
+- [ ] Delete `src/Asm.Cqrs`, `src/Asm.Cqrs.AspNetCore`, `tests/Asm.Cqrs.Tests`, `tests/Asm.Cqrs.AspNetCore.Tests`; remove all four from `Asm.slnx`.
+- [ ] `grep -rn "Asm\.Cqrs" src tests --include="*.cs" --include="*.csproj" | grep -v obj` — expected: no output.
+- [ ] `Directory.Build.props`: `<VersionPrefix>4.1</VersionPrefix>` → `5.0`.
+- [ ] `dotnet build Asm.slnx --configuration Release && dotnet test Asm.slnx` — green, 0 warnings.
+- [ ] Commit, push, PR titled "Remove Asm.Cqrs and Asm.Cqrs.AspNetCore (5.0)" — body: superseded by Postie; MooAuth/MooTrack stay on 4.x until migrated; migration recipe (Global.cs usings, `MapDelete`→`MapDeleteCommand`, `CommandBinding`→`RequestBinding`, explicit `Parameters` bindings, `MapPagedQuery` from `Asm.AspNetCore.Postie`); `CommandQueryController` check flagged for MooAuth/MooTrack.
+
+## Completion
+
+After each part: the PR is the gate — report and stop. No merging without Andrew.

--- a/docs/superpowers/specs/2026-07-22-postie-migration-design.md
+++ b/docs/superpowers/specs/2026-07-22-postie-migration-design.md
@@ -1,0 +1,101 @@
+# MooBank → Postie migration and Asm.Cqrs removal — design
+
+Date: 2026-07-22. Approved scope: MooBank now; MooAuth/MooTrack later; both repos land as branch + PR.
+This spec is committed with the migration branch (in-repo docs are fine for MooBank).
+
+## Goal
+
+Dogfood Postie 1.0.0 by replacing Asm.Cqrs/Asm.Cqrs.AspNetCore in MooBank, then remove the CQRS
+projects from the Asm repo with no functional loss to MooBank.
+
+## Functionality-loss ledger (verified against both codebases)
+
+**Drop-in identical:** `IQuery<T>`, `ICommand<T>`, `ICommand`, `IQueryHandler<,>`,
+`ICommandHandler<,>`/`<>`, `IQueryDispatcher.Dispatch`, `ICommandDispatcher.Dispatch`/`Execute`,
+`AddCommandHandlers(Assembly)`, `AddQueryHandlers(Assembly)` — same names, same ValueTask
+signatures in Postie. MCP tool classes injecting `IQueryDispatcher` need only the namespace change.
+
+**Renames:** `MapDelete` → `MapDeleteCommand` (14 sites); `CommandBinding` → `RequestBinding`
+(`None` → `Default`); namespaces `Asm.Cqrs.*` → `Postie.Cqrs.*`, endpoint extensions
+`Asm.AspNetCore` → `Postie.AspNetCore`.
+
+**Behavioral deltas:**
+1. Command binding default: Asm = `Parameters` for all verbs; Postie = `Body` for POST/PUT/PATCH.
+   Rule: every command mapping that relied on Asm's default gets an explicit
+   `RequestBinding.Parameters`. Behaviour-preserving; revisit per endpoint later if desired.
+2. `MapQuery` null result: Asm = 200 + null body; Postie = 404. Non-issue in MooBank: handlers
+   throw `NotFoundException` (53 files) via `Asm.AspNetCore.Api` middleware, which stays.
+3. Asm's obsolete void `Dispatch(ICommand)` alias does not exist in Postie; MooBank already uses
+   `Execute`.
+
+**Real gap:** `MapPagedQuery<TQuery,TItem>` (6 call sites: writes `X-Total-Count` header, returns
+unwrapped `PagedResult<T>.Results`). `PagedResult<T>` lives in the surviving base `Asm` package.
+Fix: a new Asm package — working name `Asm.AspNetCore.Postie` — that extends Postie's mapping with
+Asm conventions, starting with `MapPagedQuery` (same name, same wire contract: `X-Total-Count` +
+unwrapped `Results`, `Produces` matching today's OpenAPI output). Built on Postie's
+`IEndpointDispatcher` so the extension is mediator-agnostic like Postie's own mapping layer.
+References: `Asm` (PagedResult) + `Postie.AspNetCore` only. Keeps paging reusable for
+MooAuth/MooTrack; still a candidate for promotion into Postie itself if the shape proves general.
+
+**Lost but unused by MooBank:** `CommandQueryController` MVC base class (lives in
+Asm.Cqrs.AspNetCore). Check MooAuth/MooTrack for usage before their migrations.
+
+**Survives unchanged (not part of the removal):** `WithValidation<T>()` (Asm.AspNetCore
+RouteHandlerBuilder extension — chains onto Postie builders), `EndpointGroupBase`, `.WithNames`,
+`.ToMachine()`, `PagedResult<T>`, `NotFoundException` + `AddAsmExceptionHandler`/
+`UseStandardExceptionHandler` (Asm.AspNetCore.Api), FluentValidation registration via
+`AddValidatorsFromAssembly`.
+
+## MooBank migration (branch `feature/postie`, PR)
+
+1. `Directory.Packages.props`: remove `Asm.Cqrs.AspNetCore` 4.0.31; add `Postie.Cqrs.AspNetCore`
+   and `Postie.AspNetCore` 1.0.0. Other Asm packages stay at 4.0.31.
+2. 15 module csprojs: `Asm.Cqrs.AspNetCore` PackageReference → `Postie.Cqrs.AspNetCore` +
+   `Postie.AspNetCore`.
+3. 15 `Properties/Global.cs`: `global using Asm.Cqrs.Commands/Queries` →
+   `Postie.Cqrs.Commands/Queries`. The 137 request/handler files then compile unchanged.
+4. Endpoint files (44): using/namespace adjustments; `MapDelete*` → `MapDeleteCommand*`;
+   `CommandBinding.X` → `RequestBinding.X`; add explicit `binding: RequestBinding.Parameters` to
+   every command mapping that previously relied on Asm's default; `MapPagedQuery` call sites move
+   to the local helper (same call shape).
+5. Add `Asm.AspNetCore.Postie` PackageReference where paged endpoints live; `MapPagedQuery` call
+   sites keep their call shape.
+6. Tests: `MooBank.Modules.Budgets.Tests/Support/TestMocks.cs` re-points its
+   `Mock<ICommandDispatcher>` using to Postie; all other test churn is transitive-compile only.
+7. Verification gate: full solution build zero warnings; all module test suites green; runtime
+   smoke pass comparing pre/post behaviour for one endpoint of each shape — GET by id, paged GET
+   (assert `X-Total-Count` + body shape), POST-create (201 + Location), PATCH, PUT route-bound
+   command, DELETE void, custom-status `MapCommand` (204/202), the `IFormFile` raw-`MapPost`
+   escape hatch, one MCP tool call, one `WithValidation` 400.
+
+## Asm changes (two PRs)
+
+**PR 1 — additive (branch `feature/postie-extensions`, before the MooBank migration):**
+1. New project `src/Asm.AspNetCore.Postie`: `MapPagedQuery<TQuery,TItem>` on
+   `IEndpointRouteBuilder`, dispatching via Postie's `IEndpointDispatcher`, writing
+   `X-Total-Count`, returning `Results.Ok(result.Results)`; XML docs + tests following Asm repo
+   conventions. References `Asm` + `Postie.AspNetCore` (Postie 1.0.0 from nuget.org).
+2. Ship as a minor release (4.1.x) — no breaking change; MooBank's migration consumes it.
+
+**PR 2 — removal (branch `feature/remove-cqrs`, after the MooBank PR is validated):**
+1. Delete `src/Asm.Cqrs` and `src/Asm.Cqrs.AspNetCore` (verified: nothing else in the repo
+   references them — `CommandQueryController` lives inside Asm.Cqrs.AspNetCore; before
+   MooAuth/MooTrack migrate, check whether either uses it and if so re-home it in
+   `Asm.AspNetCore.Postie` on Postie dispatchers).
+2. Remove from solution and from CI build/pack lists.
+3. Major version bump (→ 5.0.0) so MooAuth/MooTrack stay pinned to the last Cqrs-bearing 4.x
+   until their own migrations.
+4. Release notes: removal notice + pointer to Postie, `Asm.AspNetCore.Postie`, and the MooBank
+   migration recipe (renames, binding rule).
+
+## Sequencing
+
+Asm PR 1 (additive extension package, 4.1.x) → MooBank PR (consumes it, smoke-validated, merged)
+→ Asm PR 2 (removal, 5.0.0). The removal ships only after the replacement is proven in real code.
+
+## Out of scope
+
+MooAuth and MooTrack migrations (each gets this document as its template, plus a
+`CommandQueryController` usage check); any Postie feature additions (paging lives in
+`Asm.AspNetCore.Postie` until proven general enough to graduate); changing per-endpoint binding
+semantics beyond behaviour preservation.

--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -44,10 +44,6 @@ void AddServices(WebApplicationBuilder builder)
     ]);
 
     services.AddPostieEndpointDispatcher();
-    // The endpoint dispatcher registers stream support unconditionally; the granular module
-    // registrations never wire IStreamQueryDispatcher, so DI validation needs it registered
-    // even though no endpoint streams yet.
-    services.AddStreamQueryHandlers(typeof(Program).Assembly);
 
     services.AddEndpointsApiExplorer();
     services.AddAzureOAuthOptions("OAuth");

--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Reflection;
 using System.Text.Json.Serialization;
 using Asm.AspNetCore.Api;
@@ -44,6 +44,10 @@ void AddServices(WebApplicationBuilder builder)
     ]);
 
     services.AddPostieEndpointDispatcher();
+    // The endpoint dispatcher registers stream support unconditionally; the granular module
+    // registrations never wire IStreamQueryDispatcher, so DI validation needs it registered
+    // even though no endpoint streams yet.
+    services.AddStreamQueryHandlers(typeof(Program).Assembly);
 
     services.AddEndpointsApiExplorer();
     services.AddAzureOAuthOptions("OAuth");

--- a/src/MooBank.Api/Program.cs
+++ b/src/MooBank.Api/Program.cs
@@ -43,6 +43,8 @@ void AddServices(WebApplicationBuilder builder)
         new Asm.MooBank.Modules.Users.Module(),
     ]);
 
+    services.AddPostieEndpointDispatcher();
+
     services.AddEndpointsApiExplorer();
     services.AddAzureOAuthOptions("OAuth");
 

--- a/src/MooBank.Api/openapi-v1.json
+++ b/src/MooBank.Api/openapi-v1.json
@@ -29,6 +29,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -88,6 +91,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -245,6 +251,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -408,6 +417,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -486,6 +498,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -588,6 +603,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -619,6 +637,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -774,6 +795,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -807,6 +831,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -830,6 +857,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -994,6 +1024,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1125,6 +1158,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1180,6 +1216,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1235,6 +1274,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1290,6 +1332,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1314,6 +1359,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1345,6 +1393,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1385,6 +1436,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -1599,6 +1653,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1639,6 +1696,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1679,6 +1739,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1719,6 +1782,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -1739,6 +1805,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -1814,6 +1883,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -1873,6 +1945,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -1945,6 +2020,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2004,6 +2082,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2167,6 +2248,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2310,6 +2394,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2369,6 +2456,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2451,6 +2541,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2510,6 +2603,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2593,6 +2689,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -2616,6 +2715,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -2734,6 +2836,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -2812,6 +2917,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -3038,6 +3146,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -3117,6 +3228,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -3229,6 +3343,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3278,6 +3395,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3335,6 +3455,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3392,6 +3515,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3457,6 +3583,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3523,6 +3652,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3588,6 +3720,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3654,6 +3789,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3727,6 +3865,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3801,6 +3942,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3850,6 +3994,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3899,6 +4046,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3930,6 +4080,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -3979,6 +4132,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4028,6 +4184,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4077,6 +4236,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4126,6 +4288,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4175,6 +4340,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4206,6 +4374,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -4327,6 +4498,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4376,6 +4550,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4519,6 +4696,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -4567,6 +4747,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4587,6 +4770,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -4618,6 +4804,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -5122,6 +5311,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -5348,6 +5540,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },

--- a/src/MooBank.AppHost/MooBank.AppHost.csproj
+++ b/src/MooBank.AppHost/MooBank.AppHost.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Aspire.AppHost.Sdk/13.4.3">
+﻿<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Accounts.cs
@@ -5,6 +5,7 @@ using Asm.MooBank.Modules.Accounts.Models.Account;
 using Asm.MooBank.Modules.Accounts.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
@@ -23,20 +24,20 @@ internal class Accounts : EndpointGroupBase
             .WithNames("Get Account")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy());
 
-        builder.MapPostCreate<Create, LogicalAccount>("/", "Get Account".ToMachine(), a => new { instrumentId = a.Id }, CommandBinding.Body)
+        builder.MapPostCreate<Create, LogicalAccount>("/", "Get Account".ToMachine(), a => new { instrumentId = a.Id }, RequestBinding.Body)
             .WithNames("Create Account")
             .WithValidation<Create>();
 
-        builder.MapPatchCommand<Update, LogicalAccount>("/{id}")
+        builder.MapPatchCommand<Update, LogicalAccount>("/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Account")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy("id"))
             .WithValidation<Update>();
 
-        builder.MapPutCommand<SetTagPurpose, LogicalAccount>("/{instrumentId}/tag-purposes/{purpose}/{tagId}")
+        builder.MapPutCommand<SetTagPurpose, LogicalAccount>("/{instrumentId}/tag-purposes/{purpose}/{tagId}", binding: RequestBinding.Parameters)
             .WithNames("Set Account Tag Purpose")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy("instrumentId"));
 
-        builder.MapDelete<DeleteTagPurpose, LogicalAccount>("/{instrumentId}/tag-purposes/{purpose}")
+        builder.MapDeleteCommand<DeleteTagPurpose, LogicalAccount>("/{instrumentId}/tag-purposes/{purpose}")
             .WithNames("Delete Account Tag Purpose")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy("instrumentId"));
     }

--- a/src/MooBank.Modules.Accounts/Endpoints/InstitutionAccounts.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/InstitutionAccounts.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Accounts.Commands.InstitutionAccounts;
 using Asm.MooBank.Modules.Accounts.Models.Account;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Accounts.Queries.InstitutionAccounts;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
@@ -21,13 +22,13 @@ internal class InstitutionAccounts : EndpointGroupBase
             .WithNames("Get Institution Account");
 
 
-        builder.MapPostCreate<Create, InstitutionAccount>("/", "Get Institution Account".ToMachine(), a => new { id = a.Id }, CommandBinding.Parameters)
+        builder.MapPostCreate<Create, InstitutionAccount>("/", "Get Institution Account".ToMachine(), a => new { id = a.Id }, RequestBinding.Parameters)
             .WithNames("Create Institution Account");
 
-        builder.MapPatchCommand<Update, InstitutionAccount>("/{id}")
+        builder.MapPatchCommand<Update, InstitutionAccount>("/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Institution Account");
 
-        builder.MapCommand<Close, InstitutionAccount>("/{id}/close")
+        builder.MapCommand<Close, InstitutionAccount>("/{id}/close", binding: RequestBinding.Parameters)
             .WithNames("Close Institution Account");
     }
 }

--- a/src/MooBank.Modules.Accounts/Endpoints/Recurring.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/Recurring.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Accounts.Commands.Recurring;
 using Asm.MooBank.Modules.Accounts.Models.Recurring;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Accounts.Queries.Recurring;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Accounts.Endpoints;
 
@@ -25,18 +26,18 @@ internal class RecurringEndpoints : EndpointGroupBase
             .WithNames("Get Recurring Transaction")
             .Produces<RecurringTransaction>();
 
-        routeGroupBuilder.MapPostCreate<Create, RecurringTransaction>("", "Get Recurring Transaction".ToMachine(), (recurring) => new { recurringTransactionId = recurring.Id }, CommandBinding.None)
+        routeGroupBuilder.MapPostCreate<Create, RecurringTransaction>("", "Get Recurring Transaction".ToMachine(), (recurring) => new { recurringTransactionId = recurring.Id }, RequestBinding.Default)
             .WithNames("Create Recurring Transaction")
             .Accepts<Create>("application/json")
             .Produces<RecurringTransaction>();
 
 
-        routeGroupBuilder.MapPatchCommand<Update, RecurringTransaction>("/{recurringTransactionId}", binding: CommandBinding.None)
+        routeGroupBuilder.MapPatchCommand<Update, RecurringTransaction>("/{recurringTransactionId}", binding: RequestBinding.Default)
             .WithNames("Update Recurring Transaction")
             .Accepts<Update>("application/json")
             .Produces<RecurringTransaction>();
 
-        routeGroupBuilder.MapDelete<Delete>("/{recurringTransactionId}")
+        routeGroupBuilder.MapDeleteCommand<Delete>("/{recurringTransactionId}")
             .WithNames("Delete Recurring Transaction");
     }
 }

--- a/src/MooBank.Modules.Accounts/Endpoints/VirtualRecurring.cs
+++ b/src/MooBank.Modules.Accounts/Endpoints/VirtualRecurring.cs
@@ -1,9 +1,10 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Accounts.Models.Recurring;
 using Asm.MooBank.Modules.Accounts.Queries.Recurring;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Accounts.Endpoints;
 

--- a/src/MooBank.Modules.Accounts/MooBank.Modules.Accounts.csproj
+++ b/src/MooBank.Modules.Accounts/MooBank.Modules.Accounts.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Accounts/Properties/Global.cs
+++ b/src/MooBank.Modules.Accounts/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Assets/Endpoints/Assets.cs
+++ b/src/MooBank.Modules.Assets/Endpoints/Assets.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Assets.Commands;
 using Asm.MooBank.Modules.Assets.Models;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Assets.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Assets.Endpoints;
 
@@ -21,10 +22,10 @@ internal class Assets : EndpointGroupBase
             .WithNames("Get Asset")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy("id"));
 
-        builder.MapPostCreate<Create, Asset>("/", "Get Asset".ToMachine(), a => new { a.Id }, CommandBinding.Body)
+        builder.MapPostCreate<Create, Asset>("/", "Get Asset".ToMachine(), a => new { a.Id }, RequestBinding.Body)
             .WithNames("Create Asset");
 
-        builder.MapPatchCommand<Update, Asset>("/{id}", binding: CommandBinding.None)
+        builder.MapPatchCommand<Update, Asset>("/{id}", binding: RequestBinding.Default)
             .WithNames("Update Asset")
             .Accepts<Update>("application/json")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy("id"));

--- a/src/MooBank.Modules.Assets/MooBank.Modules.Assets.csproj
+++ b/src/MooBank.Modules.Assets/MooBank.Modules.Assets.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Assets/Properties/Global.cs
+++ b/src/MooBank.Modules.Assets/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Bills/Endpoints/BillAccounts.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/BillAccounts.cs
@@ -3,6 +3,7 @@ using Asm.AspNetCore.Routing;
 using Asm.MooBank.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Bills.Endpoints;
 
@@ -23,7 +24,7 @@ internal class BillAccounts : EndpointGroupBase
         builder.MapQuery<Queries.Bills.Get, Models.Bill>("/bills/{id}")
             .WithNames("Get Bill");
 
-        builder.MapPostCreate<Commands.Bills.Create, Models.Bill>("/bills", "Get Bill".ToMachine(), b => b.Id, CommandBinding.Parameters)
+        builder.MapPostCreate<Commands.Bills.Create, Models.Bill>("/bills", "Get Bill".ToMachine(), b => b.Id, RequestBinding.Parameters)
             .WithNames("Create Bill")
             .RequireAuthorization(Policies.GetInstrumentOwnerPolicy());
     }

--- a/src/MooBank.Modules.Bills/Endpoints/BillReports.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/BillReports.cs
@@ -2,6 +2,7 @@ using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Bills.Endpoints;
 

--- a/src/MooBank.Modules.Bills/Endpoints/Bills.cs
+++ b/src/MooBank.Modules.Bills/Endpoints/Bills.cs
@@ -2,6 +2,7 @@ using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Bills.Endpoints;
 
@@ -25,13 +26,13 @@ internal class Bills : EndpointGroupBase
         builder.MapQuery<Queries.Accounts.GetAll, IEnumerable<Models.Account>>("/accounts")
             .WithNames("Get Bill Accounts");
 
-        builder.MapPostCreate<Commands.Accounts.Create, Models.Account>("/accounts", "Get Bill Account".ToMachine(), a => new { InstrumentId = a.Id }, CommandBinding.Body)
+        builder.MapPostCreate<Commands.Accounts.Create, Models.Account>("/accounts", "Get Bill Account".ToMachine(), a => new { InstrumentId = a.Id }, RequestBinding.Body)
             .WithNames("Create Bill Account");
 
         builder.MapPagedQuery<Queries.Bills.GetByUtilityType, Models.Bill>("/types/{utilityType}/bills")
             .WithNames("Get Bills By Utility Type");
 
-        builder.MapCommand<Commands.Bills.Import, Models.ImportResult>("/import", binding: CommandBinding.Body)
+        builder.MapCommand<Commands.Bills.Import, Models.ImportResult>("/import", binding: RequestBinding.Body)
             .WithNames("Import Bills");
     }
 }

--- a/src/MooBank.Modules.Bills/MooBank.Modules.Bills.csproj
+++ b/src/MooBank.Modules.Bills/MooBank.Modules.Bills.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
+    <PackageReference Include="Asm.AspNetCore.Postie" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
@@ -14,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Asm.Cqrs.Commands" />
-    <Using Include="Asm.Cqrs.Queries" />
+    <Using Include="Postie.Cqrs.Commands" />
+    <Using Include="Postie.Cqrs.Queries" />
     <Using Include="Microsoft.EntityFrameworkCore" />
   </ItemGroup>
 

--- a/src/MooBank.Modules.Budgets/Endpoints/Budget.cs
+++ b/src/MooBank.Modules.Budgets/Endpoints/Budget.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Budgets.Commands;
 using Asm.MooBank.Modules.Budgets.Models;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Budgets.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Budgets.Endpoints;
 
@@ -31,18 +32,18 @@ public class Budget : EndpointGroupBase
             .Produces<BudgetLine>()
             .RequireAuthorization(Policies.GetBudgetLinePolicy("id"));
 
-        routeGroupBuilder.MapPostCreate<CreateLine, BudgetLine>("/{year}/lines", "Get Budget Line".ToMachine(), (command, line) => new { year = command.Year, id = line.Id }, CommandBinding.Parameters)
+        routeGroupBuilder.MapPostCreate<CreateLine, BudgetLine>("/{year}/lines", "Get Budget Line".ToMachine(), (command, line) => new { year = command.Year, id = line.Id }, RequestBinding.Parameters)
             .WithNames("Create Budget Line");
 
-        routeGroupBuilder.MapCommand<GenerateBudget, Models.Budget>("/{year}/generate")
+        routeGroupBuilder.MapCommand<GenerateBudget, Models.Budget>("/{year}/generate", binding: RequestBinding.Parameters)
             .WithNames("Generate Budget")
             .Produces<Models.Budget>();
 
-        routeGroupBuilder.MapPatchCommand<UpdateLine, BudgetLine>("/{year}/lines/{id}")
+        routeGroupBuilder.MapPatchCommand<UpdateLine, BudgetLine>("/{year}/lines/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Budget Line")
             .RequireAuthorization(Policies.GetBudgetLinePolicy("id"));
 
-        routeGroupBuilder.MapDelete<DeleteLine>("/{year}/lines/{id}")
+        routeGroupBuilder.MapDeleteCommand<DeleteLine>("/{year}/lines/{id}")
             .WithNames("Delete Budget Line")
             .Produces(StatusCodes.Status204NoContent)
             .RequireAuthorization(Policies.GetBudgetLinePolicy("id"));

--- a/src/MooBank.Modules.Budgets/Endpoints/Reports.cs
+++ b/src/MooBank.Modules.Budgets/Endpoints/Reports.cs
@@ -1,9 +1,10 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Budgets.Models;
 using Asm.MooBank.Modules.Budgets.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Budgets.Endpoints;
 

--- a/src/MooBank.Modules.Budgets/MooBank.Modules.Budgets.csproj
+++ b/src/MooBank.Modules.Budgets/MooBank.Modules.Budgets.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Budgets/Properties/Global.cs
+++ b/src/MooBank.Modules.Budgets/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Families/Endpoints/Families.cs
+++ b/src/MooBank.Modules.Families/Endpoints/Families.cs
@@ -5,6 +5,7 @@ using Asm.MooBank.Modules.Families.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Families.Endpoints;
 
@@ -20,11 +21,11 @@ internal class Families : EndpointGroupBase
             .WithNames("Get My Family")
             .Produces<Models.Family>();
 
-        routeGroupBuilder.MapPatchCommand<UpdateMine, Models.Family>("/")
+        routeGroupBuilder.MapPatchCommand<UpdateMine, Models.Family>("/", binding: RequestBinding.Parameters)
             .WithNames("Update My Family")
             .Produces<Models.Family>();
 
-        routeGroupBuilder.MapDelete<RemoveMember>("/members/{userId}")
+        routeGroupBuilder.MapDeleteCommand<RemoveMember>("/members/{userId}")
             .WithNames("Remove Family Member");
     }
 }

--- a/src/MooBank.Modules.Families/Endpoints/FamiliesAdmin.cs
+++ b/src/MooBank.Modules.Families/Endpoints/FamiliesAdmin.cs
@@ -5,6 +5,7 @@ using Asm.MooBank.Modules.Families.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Families.Endpoints;
 
@@ -24,10 +25,10 @@ internal class FamiliesAdmin : EndpointGroupBase
             .WithNames("Get Family")
             .Produces<Models.Family>();
 
-        routeGroupBuilder.MapPostCreate<Create, Models.Family>("/", "Get Family".ToMachine(), (i) => new { id = i.Id }, CommandBinding.Body)
+        routeGroupBuilder.MapPostCreate<Create, Models.Family>("/", "Get Family".ToMachine(), (i) => new { id = i.Id }, RequestBinding.Body)
             .WithNames("Create Family");
 
-        routeGroupBuilder.MapPatchCommand<Update, Models.Family>("/{id}")
+        routeGroupBuilder.MapPatchCommand<Update, Models.Family>("/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Family");
     }
 }

--- a/src/MooBank.Modules.Families/MooBank.Modules.Families.csproj
+++ b/src/MooBank.Modules.Families/MooBank.Modules.Families.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 

--- a/src/MooBank.Modules.Families/Properties/Global.cs
+++ b/src/MooBank.Modules.Families/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Forecast/Endpoints/ForecastPlans.cs
+++ b/src/MooBank.Modules.Forecast/Endpoints/ForecastPlans.cs
@@ -8,6 +8,7 @@ using Asm.MooBank.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Forecast.Endpoints;
 
@@ -26,22 +27,22 @@ public class ForecastPlans : EndpointGroupBase
             .WithNames("Get Forecast Plan")
             .RequireAuthorization(Policies.GetForecastPlanPolicy());
 
-        routeGroupBuilder.MapPostCreate<CreatePlan, ForecastPlan>("/", "Get Forecast Plan".ToMachine(), (plan) => new { id = plan.Id }, CommandBinding.Parameters)
+        routeGroupBuilder.MapPostCreate<CreatePlan, ForecastPlan>("/", "Get Forecast Plan".ToMachine(), (plan) => new { id = plan.Id }, RequestBinding.Parameters)
             .WithNames("Create Forecast Plan");
 
-        routeGroupBuilder.MapPutCommand<UpdatePlan, ForecastPlan>("/{id}")
+        routeGroupBuilder.MapPutCommand<UpdatePlan, ForecastPlan>("/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Forecast Plan")
             .RequireAuthorization(Policies.GetForecastPlanPolicy());
 
-        routeGroupBuilder.MapDelete<DeletePlan>("/{id}")
+        routeGroupBuilder.MapDeleteCommand<DeletePlan>("/{id}")
             .WithNames("Delete Forecast Plan")
             .RequireAuthorization(Policies.GetForecastPlanPolicy());
 
-        routeGroupBuilder.MapPatchCommand<ArchivePlan, ForecastPlan>("/{id}/archive")
+        routeGroupBuilder.MapPatchCommand<ArchivePlan, ForecastPlan>("/{id}/archive", binding: RequestBinding.Parameters)
             .WithNames("Archive Forecast Plan")
             .RequireAuthorization(Policies.GetForecastPlanPolicy());
 
-        routeGroupBuilder.MapCommand<RunForecast, ForecastResult>("/{planId}/run")
+        routeGroupBuilder.MapCommand<RunForecast, ForecastResult>("/{planId}/run", binding: RequestBinding.Parameters)
             .WithNames("Run Forecast")
             .RequireAuthorization(Policies.GetForecastPlanPolicy("planId"));
     }

--- a/src/MooBank.Modules.Forecast/Endpoints/PlannedItems.cs
+++ b/src/MooBank.Modules.Forecast/Endpoints/PlannedItems.cs
@@ -5,6 +5,7 @@ using Asm.MooBank.Modules.Forecast.Models;
 using Asm.MooBank.Modules.Forecast.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Forecast.Endpoints;
 
@@ -19,13 +20,13 @@ public class PlannedItems : EndpointGroupBase
         routeGroupBuilder.MapQuery<GetPlannedItem, PlannedItem>("/{itemId}")
             .WithNames("Get Planned Item");
 
-        routeGroupBuilder.MapPostCreate<CreatePlannedItem, PlannedItem>("/", "Get Planned Item".ToMachine(), (command, item) => new { planId = command.PlanId, itemId = item.Id }, CommandBinding.Parameters)
+        routeGroupBuilder.MapPostCreate<CreatePlannedItem, PlannedItem>("/", "Get Planned Item".ToMachine(), (command, item) => new { planId = command.PlanId, itemId = item.Id }, RequestBinding.Parameters)
             .WithNames("Create Planned Item");
 
-        routeGroupBuilder.MapPutCommand<UpdatePlannedItem, PlannedItem>("/{itemId}")
+        routeGroupBuilder.MapPutCommand<UpdatePlannedItem, PlannedItem>("/{itemId}", binding: RequestBinding.Parameters)
             .WithNames("Update Planned Item");
 
-        routeGroupBuilder.MapDelete<DeletePlannedItem>("/{itemId}")
+        routeGroupBuilder.MapDeleteCommand<DeletePlannedItem>("/{itemId}")
             .WithNames("Delete Planned Item");
     }
 }

--- a/src/MooBank.Modules.Forecast/MooBank.Modules.Forecast.csproj
+++ b/src/MooBank.Modules.Forecast/MooBank.Modules.Forecast.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
   </ItemGroup>

--- a/src/MooBank.Modules.Forecast/Properties/Global.cs
+++ b/src/MooBank.Modules.Forecast/Properties/Global.cs
@@ -1,5 +1,5 @@
-global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Groups/Endpoints/Groups.cs
+++ b/src/MooBank.Modules.Groups/Endpoints/Groups.cs
@@ -1,10 +1,11 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Groups.Commands;
 using Asm.MooBank.Modules.Groups.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Groups.Endpoints;
 
@@ -24,16 +25,16 @@ public class Groups : EndpointGroupBase
             .WithNames("Get Group")
             .RequireAuthorization(Policies.GetGroupOwnerPolicy("id"));
 
-        routeGroupBuilder.MapPostCreate<Create, Models.Group>("/", "Get Group".ToMachine(), (group) => new { id = group.Id }, CommandBinding.Body)
+        routeGroupBuilder.MapPostCreate<Create, Models.Group>("/", "Get Group".ToMachine(), (group) => new { id = group.Id }, RequestBinding.Body)
             .WithNames("Create Group")
             .WithValidation<Create>();
 
-        routeGroupBuilder.MapPatchCommand<Update, Models.Group>("/{id}")
+        routeGroupBuilder.MapPatchCommand<Update, Models.Group>("/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Group")
             .RequireAuthorization(Policies.GetGroupOwnerPolicy("id"))
             .WithValidation<Update>();
 
-        routeGroupBuilder.MapDelete<Delete>("/{id}")
+        routeGroupBuilder.MapDeleteCommand<Delete>("/{id}")
             .WithNames("Delete Group")
             .RequireAuthorization(Policies.GetGroupOwnerPolicy("id"));
     }

--- a/src/MooBank.Modules.Groups/MooBank.Modules.Groups.csproj
+++ b/src/MooBank.Modules.Groups/MooBank.Modules.Groups.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Groups/Properties/Global.cs
+++ b/src/MooBank.Modules.Groups/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Institutions/Endpoints/Institutions.cs
+++ b/src/MooBank.Modules.Institutions/Endpoints/Institutions.cs
@@ -1,10 +1,11 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Institutions.Commands;
 using Asm.MooBank.Modules.Institutions.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Institutions.Endpoints;
 
@@ -22,12 +23,12 @@ internal class Institutions : EndpointGroupBase
         routeGroupBuilder.MapQuery<Get, Models.Institution>("/{id}")
             .WithNames("Get Institution");
 
-        routeGroupBuilder.MapPostCreate<Create, Models.Institution>("/", "Get Institution".ToMachine(), (i) => new { i.Id }, CommandBinding.Body)
+        routeGroupBuilder.MapPostCreate<Create, Models.Institution>("/", "Get Institution".ToMachine(), (i) => new { i.Id }, RequestBinding.Body)
             .WithNames("Create Institution")
             .RequireAuthorization(Policies.Admin)
             .WithValidation<Create>();
 
-        routeGroupBuilder.MapPatchCommand<Update, Models.Institution>("/{id}")
+        routeGroupBuilder.MapPatchCommand<Update, Models.Institution>("/{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Institution")
             .Accepts<Update>("application/json")
             .RequireAuthorization(Policies.Admin)

--- a/src/MooBank.Modules.Institutions/MooBank.Modules.Institutions.csproj
+++ b/src/MooBank.Modules.Institutions/MooBank.Modules.Institutions.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Institutions/Properties/Global.cs
+++ b/src/MooBank.Modules.Institutions/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Instruments/Endpoints/Import.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Import.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Instruments.Commands.Import;
 using Microsoft.AspNetCore.Antiforgery;
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
@@ -33,7 +34,7 @@ internal class Import : EndpointGroupBase
             .WithMetadata(new RequestSizeLimitAttribute(10 * 1024 * 1024)) // 10MB
             .WithNames("Import");
 
-        builder.MapCommand<Reprocess>("/reprocess", StatusCodes.Status204NoContent, CommandBinding.Parameters)
+        builder.MapCommand<Reprocess>("/reprocess", StatusCodes.Status204NoContent, RequestBinding.Parameters)
             .WithNames("Reprocess")
             .Produces(StatusCodes.Status204NoContent);
 

--- a/src/MooBank.Modules.Instruments/Endpoints/Instruments.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Instruments.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Models;
 using Asm.MooBank.Modules.Instruments.Models.Instruments;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Instruments.Queries.Instruments;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Instruments.Endpoints;
 

--- a/src/MooBank.Modules.Instruments/Endpoints/Rules.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/Rules.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Instruments.Commands.Rules;
 using Asm.MooBank.Modules.Instruments.Models.Rules;
@@ -7,6 +7,7 @@ using Asm.MooBank.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
@@ -27,30 +28,30 @@ public class RulesEndpoints : EndpointGroupBase
             .WithNames("Get Instrument Rule")
             .Produces<Rule>();
 
-        routeGroupBuilder.MapPostCreate<Create, Rule>("", "Get Instrument Rule".ToMachine(), (rule) => new { ruleId = rule.Id }, CommandBinding.None)
+        routeGroupBuilder.MapPostCreate<Create, Rule>("", "Get Instrument Rule".ToMachine(), (rule) => new { ruleId = rule.Id }, RequestBinding.Default)
             .WithNames("Create Instrument Rule")
             .Accepts<Create>("application/json")
             .Produces<Rule>();
 
 
-        routeGroupBuilder.MapPatchCommand<Update, Rule>("/{ruleId}")
+        routeGroupBuilder.MapPatchCommand<Update, Rule>("/{ruleId}", binding: RequestBinding.Parameters)
             .WithNames("Update Instrument Rule")
             .Produces<Rule>();
 
-        routeGroupBuilder.MapDelete<Delete>("/{ruleId}")
+        routeGroupBuilder.MapDeleteCommand<Delete>("/{ruleId}")
             .WithNames("Delete Instrument Rule");
 
 
-        routeGroupBuilder.MapPutCommand<AddTag, Rule>("/{ruleId}/tag/{tagId}")
+        routeGroupBuilder.MapPutCommand<AddTag, Rule>("/{ruleId}/tag/{tagId}", binding: RequestBinding.Parameters)
             .WithNames("Add Tag to Instrument Rule")
             .Produces<Rule>()
             .RequireAuthorization(Policies.GetTagFamilyPolicy("tagId"));
 
-        routeGroupBuilder.MapDelete<RemoveTag>("/{ruleId}/tag/{tagId}")
+        routeGroupBuilder.MapDeleteCommand<RemoveTag>("/{ruleId}/tag/{tagId}")
             .WithNames("Remove Tag from Instrument Rule")
             .RequireAuthorization(Policies.GetTagFamilyPolicy("tagId"));
 
-        routeGroupBuilder.MapCommand<Run>("run", StatusCodes.Status202Accepted, CommandBinding.Parameters)
+        routeGroupBuilder.MapCommand<Run>("run", StatusCodes.Status202Accepted, RequestBinding.Parameters)
             .WithNames("Run rules");
     }
 }

--- a/src/MooBank.Modules.Instruments/Endpoints/VirtualInstruments.cs
+++ b/src/MooBank.Modules.Instruments/Endpoints/VirtualInstruments.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Models;
 using Asm.MooBank.Modules.Instruments.Commands.VirtualInstruments;
@@ -7,6 +7,7 @@ using Asm.MooBank.Modules.Instruments.Queries.VirtualAccounts;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Instruments.Endpoints;
 
@@ -24,18 +25,18 @@ internal class VirtualInstruments : EndpointGroupBase
         builder.MapQuery<Get, VirtualInstrument>("/{virtualInstrumentId}")
             .WithNames("Get Virtual Instrument");
 
-        builder.MapPostCreate<Create, VirtualInstrument>("/", "Get Virtual Instrument".ToMachine(), a => new { VirtualInstrumentId = a.Id }, CommandBinding.Parameters)
+        builder.MapPostCreate<Create, VirtualInstrument>("/", "Get Virtual Instrument".ToMachine(), a => new { VirtualInstrumentId = a.Id }, RequestBinding.Parameters)
             .WithNames("Create Virtual Instrument");
 
-        builder.MapPatchCommand<Update, VirtualInstrument>("/{virtualInstrumentId}", binding: CommandBinding.None)
+        builder.MapPatchCommand<Update, VirtualInstrument>("/{virtualInstrumentId}", binding: RequestBinding.Default)
             .WithNames("Update Virtual Instrument")
             .Accepts<Update>("application/json");
 
-        builder.MapPatchCommand<UpdateBalance, VirtualInstrument>("/{virtualInstrumentId}/balance", binding: CommandBinding.None)
+        builder.MapPatchCommand<UpdateBalance, VirtualInstrument>("/{virtualInstrumentId}/balance", binding: RequestBinding.Default)
             .WithNames("Update Virtual Instrument Balance")
             .Accepts<UpdateBalance>("application/json");
 
-        builder.MapDelete<Delete>("/{virtualInstrumentId}")
+        builder.MapDeleteCommand<Delete>("/{virtualInstrumentId}")
             .WithNames("Delete Virtual Instrument");
     }
 }

--- a/src/MooBank.Modules.Instruments/MooBank.Modules.Instruments.csproj
+++ b/src/MooBank.Modules.Instruments/MooBank.Modules.Instruments.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>

--- a/src/MooBank.Modules.Instruments/Properties/Global.cs
+++ b/src/MooBank.Modules.Instruments/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.ReferenceData/Endpoints/ReferenceData.cs
+++ b/src/MooBank.Modules.ReferenceData/Endpoints/ReferenceData.cs
@@ -1,9 +1,10 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.ReferenceData.Models;
 using Asm.MooBank.Modules.ReferenceData.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.ReferenceData.Endpoints;
 

--- a/src/MooBank.Modules.ReferenceData/MooBank.Modules.ReferenceData.csproj
+++ b/src/MooBank.Modules.ReferenceData/MooBank.Modules.ReferenceData.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 

--- a/src/MooBank.Modules.ReferenceData/Queries/GetImporterTypes.cs
+++ b/src/MooBank.Modules.ReferenceData/Queries/GetImporterTypes.cs
@@ -1,4 +1,4 @@
-﻿using Asm.Cqrs.Queries;
+﻿using Postie.Cqrs.Queries;
 using Asm.MooBank.Models;
 using Asm.MooBank.Modules.ReferenceData.Models;
 using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Reports/Endpoints/GroupReports.cs
+++ b/src/MooBank.Modules.Reports/Endpoints/GroupReports.cs
@@ -4,6 +4,7 @@ using Asm.MooBank.Modules.Reports.Models;
 using Asm.MooBank.Modules.Reports.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Reports.Endpoints;
 

--- a/src/MooBank.Modules.Reports/Endpoints/Reports.cs
+++ b/src/MooBank.Modules.Reports/Endpoints/Reports.cs
@@ -1,10 +1,11 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Reports.Models;
 using Asm.MooBank.Modules.Reports.Queries;
 using Asm.MooBank.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Reports.Endpoints;
 

--- a/src/MooBank.Modules.Reports/MooBank.Modules.Reports.csproj
+++ b/src/MooBank.Modules.Reports/MooBank.Modules.Reports.csproj
@@ -4,7 +4,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>

--- a/src/MooBank.Modules.Reports/Properties/Global.cs
+++ b/src/MooBank.Modules.Reports/Properties/Global.cs
@@ -1,4 +1,4 @@
-﻿global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Stocks/Endpoints/StockHoldings.cs
+++ b/src/MooBank.Modules.Stocks/Endpoints/StockHoldings.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Stocks.Commands;
 using Asm.MooBank.Modules.Stocks.Models;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Stocks.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Stocks.Endpoints;
 
@@ -25,10 +26,10 @@ internal class StockHoldings : EndpointGroupBase
             .WithNames("Get Stock Holding CPI adjusted gain/loss")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy());
 
-        builder.MapPostCreate<Create, StockHolding>("/", "Get Stock Holding".ToMachine(), a => new { InstrumentId = a.Id }, CommandBinding.Body)
+        builder.MapPostCreate<Create, StockHolding>("/", "Get Stock Holding".ToMachine(), a => new { InstrumentId = a.Id }, RequestBinding.Body)
             .WithNames("Create Stock Holding");
 
-        builder.MapPatchCommand<Update, StockHolding>("/{instrumentId}", binding: CommandBinding.None)
+        builder.MapPatchCommand<Update, StockHolding>("/{instrumentId}", binding: RequestBinding.Default)
             .WithNames("Update Stock Holding")
             .Accepts<Update>("application/json")
             .RequireAuthorization(Policies.GetInstrumentViewerPolicy());

--- a/src/MooBank.Modules.Stocks/Endpoints/StockTransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Stocks/Endpoints/StockTransactionsEndpoints.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Stocks.Commands.Transactions;
 using Asm.MooBank.Modules.Stocks.Models;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Stocks.Queries.StockTransactions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Stocks.Endpoints;
 
@@ -20,7 +21,7 @@ internal class StockTransactionsEndpoints : EndpointGroupBase
         builder.MapPagedQuery<Get, StockTransaction>("{pageSize}/{pageNumber}")
             .WithNames("Get Stock Transactions");
 
-        builder.MapCommand<Create, StockTransaction>("/", binding: CommandBinding.None)
+        builder.MapCommand<Create, StockTransaction>("/", binding: RequestBinding.Default)
             .WithNames("Create Stock Transaction")
             .Accepts<Create>("application/json");
     }

--- a/src/MooBank.Modules.Stocks/MooBank.Modules.Stocks.csproj
+++ b/src/MooBank.Modules.Stocks/MooBank.Modules.Stocks.csproj
@@ -4,7 +4,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
+    <PackageReference Include="Asm.AspNetCore.Postie" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Stocks/Properties/Global.cs
+++ b/src/MooBank.Modules.Stocks/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Tags/Endpoints/Tags.cs
+++ b/src/MooBank.Modules.Tags/Endpoints/Tags.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Tags.Commands;
 using Asm.MooBank.Modules.Tags.Models;
@@ -7,6 +7,7 @@ using Asm.MooBank.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Tags.Endpoints;
 
@@ -31,30 +32,30 @@ internal class TagsEndpoints : EndpointGroupBase
             .WithNames("Get Tag")
             .RequireAuthorization(Policies.GetTagFamilyPolicy());
 
-        builder.MapPostCreate<Create, MooBank.Models.Tag>("", "get-tag", t => new { t.Id }, CommandBinding.Body)
+        builder.MapPostCreate<Create, MooBank.Models.Tag>("", "get-tag", t => new { t.Id }, RequestBinding.Body)
             .WithNames("Create Tag")
             .WithValidation<Create>();
 
-        builder.MapPutCreate<CreateByName, MooBank.Models.Tag>("{name}", "get-tag", t => new { t.Id })
+        builder.MapPutCreate<CreateByName, MooBank.Models.Tag>("{name}", "get-tag", t => new { t.Id }, RequestBinding.Parameters)
             .WithNames("Create Tag by Name")
             .Accepts<IEnumerable<int>>("application/json")
             .WithSummary("Create a tag by name");
 
-        builder.MapPatchCommand<Update, MooBank.Models.Tag>("{id}")
+        builder.MapPatchCommand<Update, MooBank.Models.Tag>("{id}", binding: RequestBinding.Parameters)
             .WithNames("Update Tag")
             .WithValidation<Update>()
             .RequireAuthorization(Policies.GetTagFamilyPolicy());
 
-        builder.MapDelete<Delete>("{id}")
+        builder.MapDeleteCommand<Delete>("{id}")
             .WithNames("Delete Tag")
             .RequireAuthorization(Policies.GetTagFamilyPolicy());
 
-        builder.MapPutCommand<AddSubTag, MooBank.Models.Tag>("{id}/tags/{subTagId}")
+        builder.MapPutCommand<AddSubTag, MooBank.Models.Tag>("{id}/tags/{subTagId}", binding: RequestBinding.Parameters)
             .WithNames("Add Sub Tag")
             .RequireAuthorization(Policies.GetTagFamilyPolicy())
             .RequireAuthorization(Policies.GetTagFamilyPolicy("subTagId"));
 
-        builder.MapDelete<RemoveSubTag>("{id}/tags/{subTagId}")
+        builder.MapDeleteCommand<RemoveSubTag>("{id}/tags/{subTagId}")
             .WithNames("Remove Sub Tag")
             .RequireAuthorization(Policies.GetTagFamilyPolicy())
             .RequireAuthorization(Policies.GetTagFamilyPolicy("subTagId"));

--- a/src/MooBank.Modules.Tags/MooBank.Modules.Tags.csproj
+++ b/src/MooBank.Modules.Tags/MooBank.Modules.Tags.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Tags/Properties/Global.cs
+++ b/src/MooBank.Modules.Tags/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
+++ b/src/MooBank.Modules.Transactions/Endpoints/TransactionsEndpoints.cs
@@ -1,4 +1,4 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Models;
 using Asm.MooBank.Modules.Transactions.Commands;
@@ -6,6 +6,7 @@ using Asm.MooBank.Modules.Transactions.Queries.Transactions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Transactions.Endpoints;
 
@@ -26,21 +27,21 @@ internal class TransactionsEndpoints : EndpointGroupBase
         builder.MapQuery<Search, IEnumerable<Transaction>>("")
             .WithNames("Search Transactions");
 
-        builder.MapCommand<Create, Transaction>("", binding: CommandBinding.Parameters)
+        builder.MapCommand<Create, Transaction>("", binding: RequestBinding.Parameters)
             .WithNames("Create Transaction")
             .Accepts<Models.CreateTransaction>("application/json");
 
-        builder.MapCommand<UpdateBalance, Transaction>("/balance-adjustment", binding: CommandBinding.Parameters)
+        builder.MapCommand<UpdateBalance, Transaction>("/balance-adjustment", binding: RequestBinding.Parameters)
             .WithNames("Set Balance");
 
-        builder.MapPatchCommand<UpdateTransaction, Transaction>("{id}", binding: CommandBinding.None)
+        builder.MapPatchCommand<UpdateTransaction, Transaction>("{id}", binding: RequestBinding.Default)
             .WithNames("Update Transaction")
             .Accepts<UpdateTransaction>("application/json");
 
-        builder.MapPutCommand<AddTag, Transaction>("{id}/tag/{tagId}")
+        builder.MapPutCommand<AddTag, Transaction>("{id}/tag/{tagId}", binding: RequestBinding.Parameters)
             .WithNames("Add Tag");
 
-        builder.MapDelete<RemoveTag, Transaction>("{id}/tag/{tagId}")
+        builder.MapDeleteCommand<RemoveTag, Transaction>("{id}/tag/{tagId}")
             .WithNames("Remove Tag");
     }
 }

--- a/src/MooBank.Modules.Transactions/MooBank.Modules.Transactions.csproj
+++ b/src/MooBank.Modules.Transactions/MooBank.Modules.Transactions.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
+    <PackageReference Include="Asm.AspNetCore.Postie" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>

--- a/src/MooBank.Modules.Transactions/Properties/Global.cs
+++ b/src/MooBank.Modules.Transactions/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Modules.Users/Endpoints/User.cs
+++ b/src/MooBank.Modules.Users/Endpoints/User.cs
@@ -1,10 +1,11 @@
-﻿using Asm.AspNetCore;
+using Asm.AspNetCore;
 using Asm.AspNetCore.Routing;
 using Asm.MooBank.Modules.Users.Commands;
 using Asm.MooBank.Modules.Users.Queries;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Postie.AspNetCore;
 
 namespace Asm.MooBank.Modules.Users.Endpoints;
 
@@ -33,12 +34,12 @@ public class User : EndpointGroupBase
             .WithNames("Get User")
             .Produces<Models.User>();
 
-        routeGroupBuilder.MapPatchCommand<Update, Models.User>("/me")
+        routeGroupBuilder.MapPatchCommand<Update, Models.User>("/me", binding: RequestBinding.Parameters)
             .WithNames("Update User")
             .WithValidation<Update>()
             .Produces<Models.User>();
 
-        //routeGroupBuilder.MapDelete<Delete>("/{id}")
+        //routeGroupBuilder.MapDeleteCommand<Delete>("/{id}")
         //.WithName("Delete User");
     }
 }

--- a/src/MooBank.Modules.Users/MooBank.Modules.Users.csproj
+++ b/src/MooBank.Modules.Users/MooBank.Modules.Users.csproj
@@ -4,7 +4,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Asm.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.Cqrs.AspNetCore" />
+    <PackageReference Include="Postie.AspNetCore" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />

--- a/src/MooBank.Modules.Users/Properties/Global.cs
+++ b/src/MooBank.Modules.Users/Properties/Global.cs
@@ -1,5 +1,5 @@
-﻿global using Asm.Cqrs.Commands;
-global using Asm.Cqrs.Queries;
+﻿global using Postie.Cqrs.Commands;
+global using Postie.Cqrs.Queries;
 global using Asm.Domain;
 global using Asm.MooBank.Security;
 global using Microsoft.EntityFrameworkCore;

--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9549,7 +9549,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"

--- a/src/MooBank.Web.App/src/components/AccountList/VirtualAccountRow.tsx
+++ b/src/MooBank.Web.App/src/components/AccountList/VirtualAccountRow.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { numberClassName } from "utils/classNameHelpers";
 import { amountStep } from "utils/currency";
-import { EditColumn, emptyGuid, useClickAway } from "@andrewmclachlan/moo-ds";
+import { emptyGuid, useClickAway } from "@andrewmclachlan/moo-ds";
 
 import type { VirtualInstrument } from "api/types.gen";
 import { useUpdateVirtualInstrumentBalance } from "routes/accounts/-hooks/useUpdateVirtualInstrumentBalance";

--- a/src/MooBank.Web.App/src/components/AccountSummary.tsx
+++ b/src/MooBank.Web.App/src/components/AccountSummary.tsx
@@ -2,10 +2,7 @@ import React from "react";
 
 import { Section } from "@andrewmclachlan/moo-ds";
 import classNames from "classnames";
-import { format } from "date-fns/format";
-import { parseISO } from "date-fns/parseISO";
 import type { LogicalAccount } from "api/types.gen";
-import { useInstitutions } from "hooks/useInstitutions";
 import { useAccount } from "./AccountProvider";
 import { Amount } from "./Amount";
 import { AccountTypeBadge } from "./AccountTypeBadge";
@@ -15,7 +12,6 @@ import { formatDisplayDate } from "utils/dateFns";
 export const AccountSummary: React.FC<AccountSummaryProps> = ({ className, ...props }) => {
 
     const account = useAccount();
-    const { data: institutions } = useInstitutions();
 
     if (!account) return null;
 

--- a/src/MooBank.Web.App/src/components/MiniPeriodSelector.tsx
+++ b/src/MooBank.Web.App/src/components/MiniPeriodSelector.tsx
@@ -2,7 +2,7 @@ import { format } from "date-fns/format";
 
 import { usePeriodSelector } from ".";
 import type { PeriodSelectorProps } from ".";
-import { Button, Form, Input } from "@andrewmclachlan/moo-ds";
+import { Button, Input } from "@andrewmclachlan/moo-ds";
 import { periodOptions } from "models/periodOptions";
 
 export const MiniPeriodSelector: React.FC<PeriodSelectorProps> = ({ instant = false, cacheKey = "period-id", ...props }) => {

--- a/src/MooBank.Web.App/src/components/ReportTypeSelector.tsx
+++ b/src/MooBank.Web.App/src/components/ReportTypeSelector.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { HTMLAttributes } from "react";
-import { Button, ButtonGroup, Col, Row } from "@andrewmclachlan/moo-ds";
+import { Button, ButtonGroup } from "@andrewmclachlan/moo-ds";
 import type { transactionTypeFilter } from "models/transactions";
 
 export const ReportTypeSelector: React.FC<ReportTypeSelectorProps> = ({ value, onChange, ...rest }) => {

--- a/src/MooBank.Web.App/src/routes/accounts/$id/manage/-components/InstitutionAccountEdit.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/manage/-components/InstitutionAccountEdit.tsx
@@ -5,7 +5,7 @@ import { Button, Modal } from "@andrewmclachlan/moo-ds";
 import { useForm } from "react-hook-form";
 import { useUpdateInstitutionAccount } from "../../../-hooks/useUpdateInstitutionAccount";
 
-export const InstitutionAccountEdit: React.FC<InstitutionAccountEditProps> = ({ institutionAccount, show, onHide, onSave }) => {
+export const InstitutionAccountEdit: React.FC<InstitutionAccountEditProps> = ({ institutionAccount, show, onHide }) => {
 
     const account = useAccount() as LogicalAccount;
     const updateInstitutionAccount = useUpdateInstitutionAccount();

--- a/src/MooBank.Web.App/src/routes/accounts/$id/manage/-components/InstitutionAccountRow.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/manage/-components/InstitutionAccountRow.tsx
@@ -1,4 +1,4 @@
-import { DeleteIcon, Icon } from "@andrewmclachlan/moo-ds";
+import { Icon } from "@andrewmclachlan/moo-ds";
 import { useAccount } from "components";
 import { formatDisplayDate } from "utils/dateFns";
 import type { InstitutionAccount, LogicalAccount } from "api/types.gen";

--- a/src/MooBank.Web.App/src/routes/accounts/$id/manage/-components/ReprocessModal.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/manage/-components/ReprocessModal.tsx
@@ -35,7 +35,7 @@ export const ReprocessModal: React.FC<ReprocessModalProps> = ({ instrumentId, on
                         {openAccounts.map(ia => {
                             return (
                                 <div key={ia.id} className={`import-type-option ${institutionAccountId === ia.id ? 'selected' : ''}`} onClick={() => setInstitutionAccountId(ia.id)}>
-                                    <input type="radio" id={ia.id} name="institutionAccountId" value={ia.id} className="form-check-input" checked={institutionAccountId === ia.id} onChange={(e) => { setInstitutionAccountId(ia.id); }} />
+                                    <input type="radio" id={ia.id} name="institutionAccountId" value={ia.id} className="form-check-input" checked={institutionAccountId === ia.id} onChange={() => { setInstitutionAccountId(ia.id); }} />
                                     <label htmlFor={ia.id} className="form-label">{ia.name ?? ia.institutionId}</label>
                                 </div>
                             );

--- a/src/MooBank.Web.App/src/routes/accounts/$id/manage/bank.create.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/manage/bank.create.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { SectionForm, Form } from "@andrewmclachlan/moo-ds";
 
-import type { CreateInstitutionAccount as Create, InstitutionAccount, LogicalAccount } from "api/types.gen";
+import type { CreateInstitutionAccount as Create, LogicalAccount } from "api/types.gen";
 import { useCreateInstitutionAccount } from "../../-hooks/useCreateInstitutionAccount";
 import { AccountPage, InstitutionSelector, useAccount } from "components";
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/manage/index.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/manage/index.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useIdParams } from "@andrewmclachlan/moo-app";
-import { DeleteIcon, EditColumn, Icon, IconButton, SectionTable } from "@andrewmclachlan/moo-ds";
+import { Icon, IconButton, SectionTable } from "@andrewmclachlan/moo-ds";
 
 import { AccountPage, useAccount } from "components";
 import type { Controller, InstitutionAccount, LogicalAccount } from "api/types.gen";

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TagTrend.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TagTrend.tsx
@@ -2,11 +2,9 @@ import { Section } from "@andrewmclachlan/moo-ds";
 import type { ChartData } from "chart.js";
 import React, { useEffect, useState } from "react";
 import { Line } from "react-chartjs-2";
-import { Form, Row } from "@andrewmclachlan/moo-ds";
 import { useNavigate, useParams } from "@tanstack/react-router";
 
 import { TagSelector } from "components";
-import { PeriodSelector } from "components/PeriodSelector";
 import { ReportTypeSelector } from "components/ReportTypeSelector";
 import type { Period } from "models/dateFns";
 import type { TagSettings } from "api/types.gen";

--- a/src/MooBank.Web.App/src/routes/accounts/-components/AccountForm.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-components/AccountForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, InputGroup } from "@andrewmclachlan/moo-ds";
+import { Button } from "@andrewmclachlan/moo-ds";
 import { useForm } from "react-hook-form";
 import { useNavigate } from "@tanstack/react-router";
 
@@ -14,7 +14,7 @@ import { useCreateAccount } from "../-hooks/useCreateAccount";
 import { useUpdateAccount } from "../-hooks/useUpdateAccount";
 import { useUser } from "hooks/useUser";
 import { CurrencyInput } from "components/CurrencyInput";
-import { formatDate, formatISO } from "date-fns";
+import { formatDate } from "date-fns";
 
 export const AccountForm: React.FC<{ account?: LogicalAccount }> = ({ account = null }) => {
 

--- a/src/MooBank.Web.App/src/routes/accounts/-components/ManageVirtualAccount.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-components/ManageVirtualAccount.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Button, InputGroup } from "@andrewmclachlan/moo-ds";
+import { Button } from "@andrewmclachlan/moo-ds";
 import { useMatchRoute, useNavigate, useParams } from "@tanstack/react-router";
-import { Form, Section, SectionForm } from "@andrewmclachlan/moo-ds";
+import { Form, SectionForm } from "@andrewmclachlan/moo-ds";
 import type { VirtualInstrument } from "api/types.gen";
 import { useUpdateVirtualInstrument } from "routes/accounts/-hooks/useUpdateVirtualInstrument";
 import { useVirtualInstrument } from "routes/accounts/-hooks/useVirtualInstrument";

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/components/Import.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/components/Import.tsx
@@ -47,7 +47,7 @@ export const Import: React.FC<ImportProps> = ({ show, accountId, onClose }) => {
                         {openAccounts.map(ia => {
                             return (
                                 <div key={ia.id} className={`import-type-option ${institutionAccountId === ia.id ? 'selected' : ''}`} onClick={() => setInstitutionAccountId(ia.id)}>
-                                    <input type="radio" id={ia.id} name="institutionAccountId" value={ia.id} className="form-check-input" checked={institutionAccountId === ia.id} onChange={(e) => { setInstitutionAccountId(ia.id); }} />
+                                    <input type="radio" id={ia.id} name="institutionAccountId" value={ia.id} className="form-check-input" checked={institutionAccountId === ia.id} onChange={() => { setInstitutionAccountId(ia.id); }} />
                                     <label htmlFor={ia.id} className="form-label">{ia.name ?? ia.institutionId}</label>
                                 </div>
                             );

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/components/MiniFilterPanel.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/components/MiniFilterPanel.tsx
@@ -1,6 +1,6 @@
 import { Section } from "@andrewmclachlan/moo-ds";
 import React from "react";
-import { Form, Input } from "@andrewmclachlan/moo-ds";
+import { Input } from "@andrewmclachlan/moo-ds";
 
 import { TagSelector } from "components";
 

--- a/src/MooBank.Web.App/src/routes/accounts/-transactions/details/TransactionSplit.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/-transactions/details/TransactionSplit.tsx
@@ -56,7 +56,7 @@ export const TransactionSplit: React.FC<TransactionSplitProps> = ({ transaction,
             <section className="offsets" hidden={isCredit(transaction.transactionType)}>
                 <Form.Label>Corresponding rebate / refund</Form.Label>
 
-                {offsetBy?.map((to, index) =>
+                {offsetBy?.map((to) =>
                     <Row key={to.transaction.id}>
                         <Col sm={9}>
                             <TransactionSearch value={to.transaction} onChange={(v) => v ? offsetChanged({ ...to, transaction: v }, to.transaction) : removeOffset(to.transaction.id)} transaction={transaction} excludedTransactions={offsetBy.map(ob => ob.transaction.id)} />

--- a/src/MooBank.Web.App/src/routes/assets/$id/manage.tsx
+++ b/src/MooBank.Web.App/src/routes/assets/$id/manage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, InputGroup } from "@andrewmclachlan/moo-ds";
+import { Button } from "@andrewmclachlan/moo-ds";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
 import { Form, SectionForm } from "@andrewmclachlan/moo-ds";

--- a/src/MooBank.Web.App/src/routes/assets/$id/route.tsx
+++ b/src/MooBank.Web.App/src/routes/assets/$id/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { AssetProvider } from "../-components/AssetProvider";
 import { useAsset } from "../-hooks/useAsset";
 

--- a/src/MooBank.Web.App/src/routes/assets/create.tsx
+++ b/src/MooBank.Web.App/src/routes/assets/create.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { Button, InputGroup } from "@andrewmclachlan/moo-ds";
+import { Button } from "@andrewmclachlan/moo-ds";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import type { CreateAsset as NewAsset } from "api/types.gen";
-import { emptyAsset } from "models/assets";
 
 import { Page } from "@andrewmclachlan/moo-app";
 import { Form, SectionForm } from "@andrewmclachlan/moo-ds";

--- a/src/MooBank.Web.App/src/routes/bills/$id.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/$id.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import type { PropsWithChildren } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
-import type { AccountTypeSummary, Account } from "api/types.gen";
+import type { Account } from "api/types.gen";
 import { useBillAccountsByType } from "./-hooks/useBillAccountsByType";
 
 import { Page, useIdParams } from "@andrewmclachlan/moo-app";

--- a/src/MooBank.Web.App/src/routes/bills/-components/AddBill.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/-components/AddBill.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Button, Input, Modal } from "@andrewmclachlan/moo-ds";
+import { Button, Modal } from "@andrewmclachlan/moo-ds";
 import { useFieldArray, useForm } from "react-hook-form";
 import { format } from "date-fns";
 

--- a/src/MooBank.Web.App/src/routes/bills/-components/BillsChart.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/-components/BillsChart.tsx
@@ -4,7 +4,7 @@ import type { AnnotationOptions } from "chartjs-plugin-annotation";
 import { Line } from "react-chartjs-2";
 import { Section } from "@andrewmclachlan/moo-ds";
 
-import type { BillFilter, CostDataPoint } from "../-hooks/types";
+import type { BillFilter } from "../-hooks/types";
 import { useCostPerUnitReport } from "../-hooks/useCostPerUnitReport";
 import { useServiceChargeReport } from "../-hooks/useServiceChargeReport";
 import { chartColours, useChartColours } from "utils/chartColours";

--- a/src/MooBank.Web.App/src/routes/bills/-components/UtilityTypeBillsTab.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/-components/UtilityTypeBillsTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Table } from "@andrewmclachlan/moo-ds";
-import { format, parseISO, subYears } from "date-fns";
+import { format, subYears } from "date-fns";
 import { getNumberOfPages, Pagination, useLocalStorage } from "@andrewmclachlan/moo-ds";
 
 import type { Bill, UtilityType, Account } from "api/types.gen";

--- a/src/MooBank.Web.App/src/routes/bills/accounts/$id.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/accounts/$id.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import type { PropsWithChildren } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { Page, useIdParams } from "@andrewmclachlan/moo-app";
@@ -8,7 +7,7 @@ import type { Bill } from "api/types.gen";
 import { useBillAccount } from "../-hooks/useBillAccount";
 import { useBills } from "../-hooks/useBills";
 
-import { Button, Table } from "@andrewmclachlan/moo-ds";
+import { Table } from "@andrewmclachlan/moo-ds";
 import { AddBill } from "../-components/AddBill";
 import { BillDetails } from "../-components/BillDetails";
 import { BillRow } from "../-components/BillRow";

--- a/src/MooBank.Web.App/src/routes/bills/index.tsx
+++ b/src/MooBank.Web.App/src/routes/bills/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { Nav, Tab, Tabs } from "@andrewmclachlan/moo-ds";
+import { Tab, Tabs } from "@andrewmclachlan/moo-ds";
 import { useNavigate } from "@tanstack/react-router";
 
 import { IconButton, Section } from "@andrewmclachlan/moo-ds";

--- a/src/MooBank.Web.App/src/routes/forecast/index.tsx
+++ b/src/MooBank.Web.App/src/routes/forecast/index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { Section, SpinnerContainer } from "@andrewmclachlan/moo-ds";
+import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
 import { useEffect, useState } from "react";
-import { Spinner } from "@andrewmclachlan/moo-ds";
 import { useForecastPlans } from "./-hooks/useForecastPlans";
 import { useForecastPlan } from "./-hooks/useForecastPlan";
 import { useForecastResult } from "./-hooks/useForecastResult";
@@ -32,7 +31,7 @@ function Forecast() {
         }
     }, [plans, planId]);
 
-    const { data: plan, isLoading: planLoading } = useForecastPlan(planId);
+    const { data: plan } = useForecastPlan(planId);
     const { data: result, isFetching: resultLoading } = useForecastResult(planId);
 
     // The forecast is denominated in the plan's currency, falling back to the user's preferred currency.

--- a/src/MooBank.Web.App/src/routes/groups/-components/GroupRow.tsx
+++ b/src/MooBank.Web.App/src/routes/groups/-components/GroupRow.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import type { Group } from "api/types.gen";
-import { Icon } from "@andrewmclachlan/moo-ds";
 
 export const GroupRow: React.FC<GroupRowProps> = (props) => {
 

--- a/src/MooBank.Web.App/src/routes/settings/families/add.tsx
+++ b/src/MooBank.Web.App/src/routes/settings/families/add.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { useForm } from "react-hook-form";
 import { useNavigate } from "@tanstack/react-router";
 
 import { Page } from "@andrewmclachlan/moo-app";
 
 import type { Family } from "api/types.gen";
-import { emptyFamily } from "models/families";
 import { useCreateFamily } from "./-hooks/useCreateFamily";
 import { FamilyForm } from "./-components/FamilyForm";
 
@@ -26,8 +24,6 @@ function CreateFamily() {
 
         navigate({ to: "/settings/families" });
     }
-
-    const form = useForm<Family>({ defaultValues: emptyFamily });
 
     return (
         <Page title="Create Family" breadcrumbs={[{ text: "Families", route: "/settings/families" }, { text: "Create Family", route: "/settings/families/add" }]}>

--- a/src/MooBank.Web.App/src/routes/settings/institutions/index.tsx
+++ b/src/MooBank.Web.App/src/routes/settings/institutions/index.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { changeSortDirection, IconLinkButton, Input, MiniPagination, PageSize, Pagination, PaginationControls, SortablePaginationTh, Section, SectionTable, SortableTh, useLocalStorage, Badge } from "@andrewmclachlan/moo-ds";
+import { changeSortDirection, IconLinkButton, PageSize, Pagination, PaginationControls, SortablePaginationTh, Section, SectionTable, SortableTh, useLocalStorage, Badge } from "@andrewmclachlan/moo-ds";
 import type { BadgeHue, SortDirection } from "@andrewmclachlan/moo-ds";
 import { institutionTypeOptions } from "models/institutions";
 import { useNavigate } from "@tanstack/react-router";
 import { useInstitutions } from "hooks/useInstitutions";
 import { SettingsPage } from "../-components/SettingsPage";
-import { use, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 export const Route = createFileRoute("/settings/institutions/")({
     component: Institutions,

--- a/src/MooBank.Web.App/src/routes/settings/route.tsx
+++ b/src/MooBank.Web.App/src/routes/settings/route.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/settings")({
     component: () => <Outlet />,

--- a/src/MooBank.Web.App/src/routes/shares/$id/manage.tsx
+++ b/src/MooBank.Web.App/src/routes/shares/$id/manage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { Button, InputGroup } from "@andrewmclachlan/moo-ds";
+import { Button } from "@andrewmclachlan/moo-ds";
 import { useNavigate } from "@tanstack/react-router";
 import type { StockHolding } from "api/types.gen";
 import { StockHoldingPage } from "../-components/StockHoldingPage";

--- a/src/MooBank.Web.App/src/routes/tags/index.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/index.tsx
@@ -80,10 +80,6 @@ function TransactionTags() {
         setNewTag(blankTag);
     }
 
-    const createSubTag = (name: string) => {
-        createTransactionTag.mutate({ name });
-    }
-
     const nameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setNewTag({ ...newTag, name: e.currentTarget.value });
     }

--- a/src/MooBank.Web.App/src/routes/tags/visualiser.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/visualiser.tsx
@@ -45,7 +45,6 @@ function Visualiser() {
 
     const handleFocus = useCallback((id: number) => {
         state.setFocusId(id);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         navigate({ search: { focus: id } as any, replace: true });
     }, [navigate, state]);
 

--- a/tests/MooBank.Modules.Budgets.Tests/Support/TestMocks.cs
+++ b/tests/MooBank.Modules.Budgets.Tests/Support/TestMocks.cs
@@ -1,4 +1,4 @@
-using Asm.Cqrs.Commands;
+using Postie.Cqrs.Commands;
 using Asm.Domain;
 using Asm.MooBank.Audit;
 using Asm.MooBank.Domain.Entities.Budget;


### PR DESCRIPTION
## Summary

Dogfoods Postie 1.0.0 as the CQRS + endpoint-mapping engine, replacing Asm.Cqrs / Asm.Cqrs.AspNetCore. Two commits: the package/namespace swap, then the endpoint call-site migration. Behaviour preservation was the rule throughout — verified by review against the pinned Asm 4.0.31 source.

- Packages: `Asm.Cqrs.AspNetCore` → `Postie.Cqrs.AspNetCore` + `Postie.AspNetCore` (1.0.0); `Asm.AspNetCore.Postie` 4.1.16 added where the 6 `MapPagedQuery` endpoints live; base `Asm` bumped 4.0.31 → 4.1.16 (dependency floor of the new package — all other Asm.* stay 4.0.31).
- The 137 request/handler files compile unchanged (global-using swap only). MCP tools keep injecting `IQueryDispatcher` — namespace change only.
- Endpoints: `MapDelete` → `MapDeleteCommand`; `CommandBinding` → `RequestBinding` (`None`→`Default`); every command mapping that relied on Asm's default binding now passes `binding: RequestBinding.Parameters` explicitly (Postie defaults POST/PUT/PATCH to Body — this pins the old behaviour). Mapping-call count 139 = 139 pre/post.
- `services.AddPostieEndpointDispatcher()` added in `Program.cs`: the modules' granular `AddCommandHandlers`/`AddQueryHandlers` registration never registers Postie's endpoint dispatcher (only `AddPostie()` does). Caught by build-time OpenAPI generation.
- Convention docs (`CLAUDE.md`, `.claude/rules/backend/cqrs.md`) updated to the Postie APIs.
- Chucked a bunch of ESLint fixes in for the ride

## Verification

Release build 0 warnings / 0 errors; full suite green (21 test projects, ~2,050 tests, 0 failures). Reviews: per-task + an adversarial pass over binding preservation on every command-mapping site.

## Smoke checklist (needs your local environment)

One of each shape against the running app: GET by id · paged GET (assert `X-Total-Count` + unwrapped body) · POST-create (201 + Location) · PATCH · route-bound PUT · DELETE (204) · `MapCommand` 204/202 · `IFormFile` import upload · one MCP tool call · one `WithValidation` 400.

## Flagged, not fixed

- **Pre-existing latent issue** (unchanged by this PR): `Tags.CreateByName` defines a `BindAsync` reading sub-tag ids from the body (and the endpoint declares `.Accepts<IEnumerable<int>>`), but the site has been `[AsParameters]`-bound since Asm 4.0.31, which bypasses `BindAsync` — `Tags` binds from the query string, the body is never read. Possibly vestigial (a dedicated Add Sub Tag endpoint exists). Worth confirming whether create-by-name-with-sub-tags is used.
- Your uncommitted `src/MooBank.Web.App/` edits were left untouched and are not in any commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)