### PR TITLE
Uplift moo-app 5.2.87: 401 auth recovery + login spinner

### DIFF
--- a/src/MooBank.Web.App/package-lock.json
+++ b/src/MooBank.Web.App/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2025.4.0",
       "license": "MIT",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.66",
-        "@andrewmclachlan/moo-ds": "^5.2.66",
-        "@andrewmclachlan/moo-icons": "^5.2.66",
+        "@andrewmclachlan/moo-app": "^5.2.87",
+        "@andrewmclachlan/moo-ds": "^5.2.87",
+        "@andrewmclachlan/moo-icons": "^5.2.87",
         "@azure/msal-react": "^5.5.1",
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
@@ -91,9 +91,9 @@
       "license": "MIT"
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.66",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.66/bd3102c563ab7767eb998975535f9bb7460a5726",
-      "integrity": "sha512-0qVAfDPNjhWnf9o4jRgR2AJAXX6uvX5MrYZFLoBsW75gnIwYdmOMZ/qepN46eJ3DlxzzNE/6Wq6K9tM3onytQQ==",
+      "version": "5.2.87",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.87/ad34bad7836c446064f903d4aca325578e0be9ad",
+      "integrity": "sha512-+IGhXNKjea9XI9vjarBYNvJNLBlsP0z5TAJ9Ro7fnMQ8fDXvCcPsbPxYsUbTY8bV6C6aD2dEUvkv1xpkiiqk6w==",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.1",
@@ -120,9 +120,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.66",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.66/f7098584bc221365cc06b89f9ba1e447f6c57b81",
-      "integrity": "sha512-FI7j/0LFETYzPrCRH59r+lyraCZfxo1KFc/XrFdgt629u68/tjoDXyTBDDZfbG42SpeLRKm3t7eYN5nCb61z+g==",
+      "version": "5.2.87",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.87/e2207a3a710014fd594b3cd657f971cd303a084f",
+      "integrity": "sha512-7hy8KdKGP0DFw1cFu7E/YDNSFKPhWoLw8FU1ycc3BDj/RsQi/0ZlPujk1NWPLi+Ho8tM58r0L5Z0fMFSwa//OQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.66",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.66/d9f1cd8cd4d3cc0f367792e743278bbb1ef5cbe8",
-      "integrity": "sha512-sVmPSfsKcSn9MFx3umTuTrOmV1pVjl74nADHlXr7I1Sy9fEs+J+EWuvIR4uU3GFfpwIP7EJKkgrHcGQ7SRGlZQ==",
+      "version": "5.2.87",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.87/4874de336ab243c267dd021746b47fc6458b86de",
+      "integrity": "sha512-euTaLpcljfsmRl2rybxqpsWtgtB8jNsfU7B+K8oTaNfH5v/kfc0PwfxRZmfrxaWUJF0lsp+NTak+N2P/uK5/1A==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",
@@ -9549,7 +9549,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"

--- a/src/MooBank.Web.App/package.json
+++ b/src/MooBank.Web.App/package.json
@@ -14,9 +14,9 @@
   },
   "type": "module",
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.66",
-    "@andrewmclachlan/moo-ds": "^5.2.66",
-    "@andrewmclachlan/moo-icons": "^5.2.66",
+    "@andrewmclachlan/moo-app": "^5.2.87",
+    "@andrewmclachlan/moo-ds": "^5.2.87",
+    "@andrewmclachlan/moo-icons": "^5.2.87",
     "@azure/msal-react": "^5.5.1",
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",

--- a/src/MooBank.Web.App/src/App.tsx
+++ b/src/MooBank.Web.App/src/App.tsx
@@ -3,7 +3,7 @@ import "utils/chartSetup";
 
 import { MooApp } from "@andrewmclachlan/moo-app";
 import { createRouter } from "@tanstack/react-router";
-import { Spinner } from "@andrewmclachlan/moo-ds";
+import { Spinner, SpinnerContainer } from "@andrewmclachlan/moo-ds";
 import { RouteError } from "components";
 import { routeTree } from "./routeTree.gen.ts";
 import { client } from "./api/client.gen";
@@ -29,6 +29,6 @@ export const App = () => {
     })
 
     return (
-        <MooApp client={client.instance} clientId="045f8afa-70f2-4700-ab75-77ac41b306f7" scopes={["api://moobank.mclachlan.family/api.read"]} name="MooBank" version={import.meta.env.VITE_REACT_APP_VERSION} copyrightYear={2013} router={router} queryPersistOptions={queryPersistOptions} silentRedirectUri={`${window.location.origin}/blank.html`} />
+        <MooApp client={client.instance} clientId="045f8afa-70f2-4700-ab75-77ac41b306f7" scopes={["api://moobank.mclachlan.family/api.read"]} name="MooBank" version={import.meta.env.VITE_REACT_APP_VERSION} copyrightYear={2013} router={router} queryPersistOptions={queryPersistOptions} silentRedirectUri={`${window.location.origin}/blank.html`} authFallback={<SpinnerContainer />} />
     );
 }


### PR DESCRIPTION
Consumes [MooApp #650](https://github.com/AndrewMcLachlan/MooApp/pull/650) to fix the logged-out dashboard auth cycle reported in production.

## Problem

When logged out, dashboard widgets spun, briefly showed load errors, then re-errored on a refresh — **F5 did not clear it**; only navigating to Accounts and back rendered. Root cause: MSAL judges token validity by local expiry alone, so a token the API rejects (signing-key rollover, Conditional Access sign-in frequency, clock skew) 401s every request, and with `retry: false` the app was stuck in a permanent error state.

## What this brings in (moo-app 5.2.87)

- **401 → force-refresh → retry once**, with loop safety designed in (per-request retry cap, single-flight refresh, failed refresh falls into the existing guarded redirect). Kills the F5-sticky failure class.
- **No error flash**: auth-cancelled queries stay pending across the login redirect (bounded 5 × 500 ms) instead of showing "Unable to load"; one recovery refetches every errored query via `AUTH_RECOVERED_EVENT`.

## MooBank-side change

- Bump `moo-app`/`moo-ds`/`moo-icons` 5.2.66 → 5.2.87
- `authFallback={<SpinnerContainer />}` — the login/redirect window now shows a spinner rather than a blank screen

## Verification

- `tsc --noEmit` clean (TS 7.0.2)
- Lint: 0 errors, 104 warnings (unchanged)
- Build + PWA generation succeed
- All 174 Vitest tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)