### PR TITLE
feat(mcp): add bill entry tools so an LLM can record bills from PDFs

### DIFF
--- a/src/MooBank.Modules.Bills/Commands/Bills/Import.cs
+++ b/src/MooBank.Modules.Bills/Commands/Bills/Import.cs
@@ -9,6 +9,8 @@ internal class ImportHandler(
     IUnitOfWork unitOfWork,
     Domain.Entities.Utility.IAccountRepository accountRepository) : ICommandHandler<Import, ImportResult>
 {
+    private const int InvoiceNumberMaxLength = 15;
+
     public async ValueTask<ImportResult> Handle(Import command, CancellationToken cancellationToken)
     {
         var userAccounts = (await accountRepository.Get(cancellationToken)).ToList();
@@ -24,6 +26,14 @@ internal class ImportHandler(
             if (account == null)
             {
                 errors.Add($"Account '{bill.AccountName}' not found for bill dated {bill.IssueDate}");
+                continue;
+            }
+
+            // The column is VARCHAR(15); without this the insert fails with a truncation error
+            // that takes the whole batch down rather than just the offending bill.
+            if (bill.InvoiceNumber?.Length > InvoiceNumberMaxLength)
+            {
+                errors.Add($"Invoice number '{bill.InvoiceNumber}' exceeds {InvoiceNumberMaxLength} characters for account '{account.Name}'");
                 continue;
             }
 

--- a/src/MooBank.Modules.Bills/McpTools/BillTools.cs
+++ b/src/MooBank.Modules.Bills/McpTools/BillTools.cs
@@ -17,7 +17,7 @@ public class BillTools(IQueryDispatcher queryDispatcher, ICommandDispatcher comm
         "Records one or more utility bills, typically read from a supplier's invoice. " +
         "Bills whose invoice number or issue date already exists on the account are rejected rather than duplicated, so re-reading the same invoice is safe. " +
         "Each bill is accepted or rejected on its own; the result reports how many of each and why. " +
-        "Do not supply the bill's total cost or total usage — MooBank calculates both from the periods, readings and discounts.")]
+        "Do not supply the bill's total cost or overall usage total (the computed Total) — MooBank calculates those from the readings, periods and discounts.")]
     public ValueTask<ImportResult> ImportBills(
         [Description("The bills to record.")] IEnumerable<BillEntry> bills,
         CancellationToken cancellationToken = default) =>

--- a/src/MooBank.Modules.Bills/McpTools/BillTools.cs
+++ b/src/MooBank.Modules.Bills/McpTools/BillTools.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using Asm.MooBank.Modules.Bills.Models;
+using ModelContextProtocol.Server;
+
+namespace Asm.MooBank.Modules.Bills.McpTools;
+
+[McpServerToolType]
+public class BillTools(IQueryDispatcher queryDispatcher, ICommandDispatcher commandDispatcher)
+{
+    [McpServerTool(Destructive = false, Idempotent = true, Name = "get-bill-accounts", ReadOnly = true, Title = "Get Bill Accounts")]
+    [Description("Retrieves the utility accounts (electricity, gas, water etc.) that bills can be recorded against, along with the date range already covered by recorded bills. Call this first: import-bills identifies accounts by name and only the names returned here will match.")]
+    public ValueTask<IEnumerable<Models.Account>> GetBillAccounts(CancellationToken cancellationToken = default) =>
+        queryDispatcher.Dispatch(new Queries.Accounts.GetAll(), cancellationToken);
+
+    [McpServerTool(Destructive = false, Idempotent = false, Name = "import-bills", ReadOnly = false, Title = "Import Bills")]
+    [Description(
+        "Records one or more utility bills, typically read from a supplier's invoice. " +
+        "Bills whose invoice number or issue date already exists on the account are rejected rather than duplicated, so re-reading the same invoice is safe. " +
+        "Each bill is accepted or rejected on its own; the result reports how many of each and why. " +
+        "Do not supply the bill's total cost or total usage — MooBank calculates both from the periods, readings and discounts.")]
+    public ValueTask<ImportResult> ImportBills(
+        [Description("The bills to record.")] IEnumerable<BillEntry> bills,
+        CancellationToken cancellationToken = default) =>
+        commandDispatcher.Dispatch(new Commands.Bills.Import(bills.ToImportBill()), cancellationToken);
+}

--- a/src/MooBank.Modules.Bills/Models/BillEntry.cs
+++ b/src/MooBank.Modules.Bills/Models/BillEntry.cs
@@ -19,7 +19,7 @@ public record BillEntry
     public string? InvoiceNumber { get; set; }
 
     [Description("The date the bill was issued.")]
-    public DateOnly IssueDate { get; set; }
+    public required DateOnly IssueDate { get; set; }
 
     [Description("The meter reading at the end of the billing period, where the bill shows one.")]
     public int? CurrentReading { get; set; }

--- a/src/MooBank.Modules.Bills/Models/BillEntry.cs
+++ b/src/MooBank.Modules.Bills/Models/BillEntry.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+
+namespace Asm.MooBank.Modules.Bills.Models;
+
+/// <summary>
+/// A bill as read off a supplier's invoice.
+/// </summary>
+/// <remarks>
+/// Deliberately does not derive from <see cref="BillBase"/>. Cost and Total are computed columns,
+/// so any value supplied for them is dropped on insert. Leaving them off this contract stops a
+/// caller supplying the figures printed on the invoice and believing they were stored.
+/// </remarks>
+public record BillEntry
+{
+    [Description("The name of the utility account the bill belongs to, exactly as returned by get-bill-accounts.")]
+    public required string AccountName { get; set; }
+
+    [Description("The invoice number printed on the bill. Must be 15 characters or fewer.")]
+    public string? InvoiceNumber { get; set; }
+
+    [Description("The date the bill was issued.")]
+    public DateOnly IssueDate { get; set; }
+
+    [Description("The meter reading at the end of the billing period, where the bill shows one.")]
+    public int? CurrentReading { get; set; }
+
+    [Description("The meter reading at the start of the billing period, where the bill shows one.")]
+    public int? PreviousReading { get; set; }
+
+    [Description("Whether the charges on the bill are inclusive of GST.")]
+    public bool? CostsIncludeGST { get; set; }
+
+    [Description("The billing periods covered. A bill with a tariff change part-way through covers more than one period.")]
+    public IEnumerable<BillEntryPeriod> Periods { get; set; } = [];
+
+    [Description("Any discounts applied to the bill.")]
+    public IEnumerable<Discount> Discounts { get; set; } = [];
+}
+
+/// <summary>
+/// A single billing period within a <see cref="BillEntry"/>.
+/// </summary>
+/// <remarks>
+/// Carries only the fields that are actually persisted; Days, DaysInclusive and Cost are all
+/// derived by the database from the values below.
+/// </remarks>
+public record BillEntryPeriod
+{
+    [Description("The first day of the billing period.")]
+    public DateOnly PeriodStart { get; set; }
+
+    [Description("The last day of the billing period.")]
+    public DateOnly PeriodEnd { get; set; }
+
+    [Description("The price charged per unit of usage.")]
+    public decimal PricePerUnit { get; set; }
+
+    [Description("The total units consumed during the period.")]
+    public decimal TotalUsage { get; set; }
+
+    [Description("The daily supply or service charge.")]
+    public decimal ChargePerDay { get; set; }
+}
+
+public static class BillEntryExtensions
+{
+    /// <summary>
+    /// Convert to the shape the import command consumes.
+    /// </summary>
+    public static ImportBill ToImportBill(this BillEntry entry) =>
+        new()
+        {
+            AccountName = entry.AccountName,
+            InvoiceNumber = entry.InvoiceNumber,
+            IssueDate = entry.IssueDate,
+            CurrentReading = entry.CurrentReading,
+            PreviousReading = entry.PreviousReading,
+            CostsIncludeGST = entry.CostsIncludeGST,
+            Periods = entry.Periods.Select(p => new Period
+            {
+                PeriodStart = p.PeriodStart.ToDateTime(TimeOnly.MinValue),
+                PeriodEnd = p.PeriodEnd.ToDateTime(TimeOnly.MinValue),
+                PricePerUnit = p.PricePerUnit,
+                TotalUsage = p.TotalUsage,
+                ChargePerDay = p.ChargePerDay,
+            }).ToList(),
+            Discounts = entry.Discounts.ToList(),
+        };
+
+    public static IEnumerable<ImportBill> ToImportBill(this IEnumerable<BillEntry> entries) =>
+        entries.Select(e => e.ToImportBill());
+}

--- a/src/MooBank.Modules.Bills/MooBank.Modules.Bills.csproj
+++ b/src/MooBank.Modules.Bills/MooBank.Modules.Bills.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="ModelContextProtocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MooBank.Api.Tests/Mcp/McpToolDiscoveryTests.cs
+++ b/tests/MooBank.Api.Tests/Mcp/McpToolDiscoveryTests.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using Asm.MooBank.Api.Tests.Authorization;
+using Asm.MooBank.Api.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+
+namespace Asm.MooBank.Api.Tests.Mcp;
+
+/// <summary>
+/// Tests that MCP tools are discovered from the module assemblies.
+/// </summary>
+/// <remarks>
+/// Tools are registered by convention — <c>WithToolsFromAssemblies("Asm.MooBank.Modules")</c> scans
+/// by assembly name prefix — so nothing in the compiler or a grep will tell you that a module's
+/// tools failed to register. This asserts the composed host actually sees them.
+///
+/// Shares the authorization collection's factory rather than standing up its own: two
+/// WebApplicationFactory instances starting concurrently race in HostFactoryResolver, and one of
+/// them fails with "The entry point exited without ever building an IHost".
+/// </remarks>
+[Trait("Category", "Integration")]
+[Collection(AuthorizationTestCollection.Name)]
+public class McpToolDiscoveryTests(MooBankWebApplicationFactory factory)
+{
+    /// <summary>
+    /// Given the composed application
+    /// When the registered MCP tools are resolved
+    /// Then every module's tools should be present
+    /// </summary>
+    [Theory]
+    [InlineData("get-instruments")]
+    [InlineData("get-transactions")]
+    [InlineData("get-tags")]
+    [InlineData("get-me")]
+    [InlineData("get-bill-accounts")]
+    [InlineData("import-bills")]
+    public void RegisteredTools_IncludeEveryModulesTools(string toolName)
+    {
+        // Arrange / Act
+        var toolNames = factory.Services.GetServices<McpServerTool>().Select(t => t.ProtocolTool.Name).ToList();
+
+        // Assert
+        Assert.Contains(toolName, toolNames);
+    }
+
+    /// <summary>
+    /// Given the registered MCP tools
+    /// When the bill import tool is inspected
+    /// Then it should be advertised as a write operation
+    /// </summary>
+    /// <remarks>
+    /// import-bills is the only tool that writes. Clients surface the read-only hint to the user,
+    /// so getting it wrong understates what the tool does.
+    /// </remarks>
+    [Fact]
+    public void ImportBillsTool_IsNotAdvertisedAsReadOnly()
+    {
+        // Arrange
+        var tools = factory.Services.GetServices<McpServerTool>();
+
+        // Act
+        var importBills = Assert.Single(tools, t => t.ProtocolTool.Name == "import-bills");
+
+        // Assert
+        Assert.NotEqual(true, importBills.ProtocolTool.Annotations?.ReadOnlyHint);
+    }
+}

--- a/tests/MooBank.Modules.Bills.Tests/Commands/Bills/ImportTests.cs
+++ b/tests/MooBank.Modules.Bills.Tests/Commands/Bills/ImportTests.cs
@@ -301,6 +301,45 @@ public class ImportTests
         Assert.Single(account.Bills);
     }
 
+    /// <summary>
+    /// Given a bill whose invoice number is longer than the column allows
+    /// When the bills are imported
+    /// Then that bill should be rejected with an error and the others still imported
+    /// </summary>
+    /// <remarks>
+    /// utilities.Bill.InvoiceNumber is VARCHAR(15). Without the guard the insert fails with a
+    /// truncation error that takes the whole batch down instead of the one offending bill.
+    /// </remarks>
+    [Fact]
+    public async Task Handle_InvoiceNumberTooLong_RejectsOnlyThatBill()
+    {
+        // Arrange
+        var account = TestEntities.CreateAccount(name: "Test Account");
+        _mocks.AccountRepositoryMock
+            .Setup(r => r.Get(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([account]);
+
+        var handler = new ImportHandler(
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.AccountRepositoryMock.Object);
+
+        var bills = new[]
+        {
+            TestEntities.CreateImportBill(accountName: "Test Account", issueDate: new DateOnly(2024, 1, 15), invoiceNumber: "1234567890123456"),
+            TestEntities.CreateImportBill(accountName: "Test Account", issueDate: new DateOnly(2024, 2, 15), invoiceNumber: "123456789012345"),
+        };
+        var command = new Import(bills);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, result.Imported);
+        Assert.Equal(1, result.Failed);
+        Assert.Contains(result.Errors, e => e.Contains("1234567890123456") && e.Contains("exceeds 15 characters"));
+        Assert.Single(account.Bills);
+    }
+
     [Fact]
     public async Task Handle_EmptyBillsList_ImportsNothing()
     {

--- a/tests/MooBank.Modules.Bills.Tests/Models/BillEntryTests.cs
+++ b/tests/MooBank.Modules.Bills.Tests/Models/BillEntryTests.cs
@@ -1,0 +1,164 @@
+#nullable enable
+using Asm.MooBank.Modules.Bills.Models;
+
+namespace Asm.MooBank.Modules.Bills.Tests.Models;
+
+/// <summary>
+/// Unit tests for mapping a <see cref="BillEntry"/> onto the shape the import command consumes.
+/// </summary>
+[Trait("Category", "Unit")]
+public class BillEntryTests
+{
+    /// <summary>
+    /// Given a bill entry with account, invoice and reading details
+    /// When it is converted to an import bill
+    /// Then those details should be carried across unchanged
+    /// </summary>
+    [Fact]
+    public void ToImportBill_BillDetails_AreCarriedAcross()
+    {
+        // Arrange
+        var entry = new BillEntry
+        {
+            AccountName = "AGL Electricity",
+            InvoiceNumber = "INV001",
+            IssueDate = new DateOnly(2026, 3, 14),
+            CurrentReading = 5400,
+            PreviousReading = 5100,
+            CostsIncludeGST = true,
+        };
+
+        // Act
+        var importBill = entry.ToImportBill();
+
+        // Assert
+        Assert.Equal("AGL Electricity", importBill.AccountName);
+        Assert.Equal("INV001", importBill.InvoiceNumber);
+        Assert.Equal(new DateOnly(2026, 3, 14), importBill.IssueDate);
+        Assert.Equal(5400, importBill.CurrentReading);
+        Assert.Equal(5100, importBill.PreviousReading);
+        Assert.True(importBill.CostsIncludeGST);
+    }
+
+    /// <summary>
+    /// Given any bill entry
+    /// When it is converted to an import bill
+    /// Then Cost and Total should be left unset
+    /// </summary>
+    /// <remarks>
+    /// Both are computed columns, so a value here would be silently dropped on insert. The entry
+    /// contract omits them precisely so a caller cannot supply the figures printed on an invoice
+    /// and believe they were stored; this guards that the mapping does not reintroduce them.
+    /// </remarks>
+    [Fact]
+    public void ToImportBill_ComputedFields_AreNotPopulated()
+    {
+        // Arrange
+        var entry = new BillEntry
+        {
+            AccountName = "AGL Electricity",
+            IssueDate = new DateOnly(2026, 3, 14),
+            CurrentReading = 5400,
+            PreviousReading = 5100,
+        };
+
+        // Act
+        var importBill = entry.ToImportBill();
+
+        // Assert
+        Assert.Null(importBill.Cost);
+        Assert.Null(importBill.Total);
+    }
+
+    /// <summary>
+    /// Given a bill entry with billing periods
+    /// When it is converted to an import bill
+    /// Then each period's dates should become midnight on the same day and its charges carried across
+    /// </summary>
+    [Fact]
+    public void ToImportBill_Periods_AreMappedToMidnightOnTheSameDay()
+    {
+        // Arrange
+        var entry = new BillEntry
+        {
+            AccountName = "AGL Electricity",
+            IssueDate = new DateOnly(2026, 3, 14),
+            Periods =
+            [
+                new BillEntryPeriod
+                {
+                    PeriodStart = new DateOnly(2026, 1, 1),
+                    PeriodEnd = new DateOnly(2026, 1, 31),
+                    PricePerUnit = 0.28m,
+                    TotalUsage = 412.5m,
+                    ChargePerDay = 1.15m,
+                },
+            ],
+        };
+
+        // Act
+        var importBill = entry.ToImportBill();
+
+        // Assert
+        var period = Assert.Single(importBill.Periods);
+        Assert.Equal(new DateTime(2026, 1, 1, 0, 0, 0), period.PeriodStart);
+        Assert.Equal(new DateTime(2026, 1, 31, 0, 0, 0), period.PeriodEnd);
+        Assert.Equal(0.28m, period.PricePerUnit);
+        Assert.Equal(412.5m, period.TotalUsage);
+        Assert.Equal(1.15m, period.ChargePerDay);
+    }
+
+    /// <summary>
+    /// Given a bill entry with discounts
+    /// When it is converted to an import bill
+    /// Then the discounts should be carried across
+    /// </summary>
+    [Fact]
+    public void ToImportBill_Discounts_AreCarriedAcross()
+    {
+        // Arrange
+        var entry = new BillEntry
+        {
+            AccountName = "AGL Electricity",
+            IssueDate = new DateOnly(2026, 3, 14),
+            Discounts =
+            [
+                new Discount { DiscountPercent = 12, Reason = "Pay on time" },
+                new Discount { DiscountAmount = 25m, Reason = "Loyalty" },
+            ],
+        };
+
+        // Act
+        var importBill = entry.ToImportBill();
+
+        // Assert
+        Assert.Collection(
+            importBill.Discounts,
+            d => Assert.Equal((byte)12, d.DiscountPercent),
+            d => Assert.Equal(25m, d.DiscountAmount));
+    }
+
+    /// <summary>
+    /// Given several bill entries
+    /// When the collection is converted
+    /// Then every entry should be mapped
+    /// </summary>
+    [Fact]
+    public void ToImportBill_Collection_MapsEveryEntry()
+    {
+        // Arrange
+        BillEntry[] entries =
+        [
+            new() { AccountName = "AGL Electricity", IssueDate = new DateOnly(2026, 1, 14) },
+            new() { AccountName = "Origin Gas", IssueDate = new DateOnly(2026, 2, 14) },
+        ];
+
+        // Act
+        var importBills = entries.ToImportBill().ToList();
+
+        // Assert
+        Assert.Equal(2, importBills.Count);
+        Assert.Equal("AGL Electricity", importBills[0].AccountName);
+        Assert.Equal("Origin Gas", importBills[1].AccountName);
+    }
+}

--- a/tests/MooBank.Modules.Bills.Tests/Support/TestEntities.cs
+++ b/tests/MooBank.Modules.Bills.Tests/Support/TestEntities.cs
@@ -2,6 +2,7 @@
 using Asm.MooBank.Domain.Entities.Utility;
 using Asm.MooBank.Models;
 using Bogus;
+using BillModels = Asm.MooBank.Modules.Bills.Models;
 using DomainAccount = Asm.MooBank.Domain.Entities.Utility.Account;
 
 namespace Asm.MooBank.Modules.Bills.Tests.Support;
@@ -190,7 +191,7 @@ internal static class TestEntities
         return account;
     }
 
-    public static Models.ImportBill CreateImportBill(
+    public static BillModels.ImportBill CreateImportBill(
         string accountName = "Test Account",
         DateOnly? issueDate = null,
         string? invoiceNumber = null,
@@ -198,10 +199,10 @@ internal static class TestEntities
         bool costsIncludeGST = true,
         int? currentReading = null,
         int? previousReading = null,
-        IEnumerable<Models.Period>? periods = null,
-        IEnumerable<Models.Discount>? discounts = null)
+        IEnumerable<BillModels.Period>? periods = null,
+        IEnumerable<BillModels.Discount>? discounts = null)
     {
-        return new Models.ImportBill
+        return new BillModels.ImportBill
         {
             AccountName = accountName,
             IssueDate = issueDate ?? DateOnly.FromDateTime(DateTime.UtcNow),
@@ -216,14 +217,14 @@ internal static class TestEntities
         };
     }
 
-    public static Models.Period CreateModelPeriod(
+    public static BillModels.Period CreateModelPeriod(
         DateTime? periodStart = null,
         DateTime? periodEnd = null,
         decimal chargePerDay = 1.0m,
         decimal pricePerUnit = 0.25m,
         int totalUsage = 500)
     {
-        return new Models.Period
+        return new BillModels.Period
         {
             PeriodStart = periodStart ?? DateTime.UtcNow.AddMonths(-1),
             PeriodEnd = periodEnd ?? DateTime.UtcNow,
@@ -233,12 +234,12 @@ internal static class TestEntities
         };
     }
 
-    public static Models.Discount CreateModelDiscount(
+    public static BillModels.Discount CreateModelDiscount(
         byte? discountPercent = null,
         decimal? discountAmount = null,
         string reason = "Discount")
     {
-        return new Models.Discount
+        return new BillModels.Discount
         {
             DiscountPercent = discountPercent,
             DiscountAmount = discountAmount,


### PR DESCRIPTION
Closes #923.

Adds two MCP tools so an LLM that has parsed a supplier's PDF has somewhere to put the result. `import-bills` is the first tool on the MCP surface that writes.

## The tools

| Tool | | |
|---|---|---|
| `get-bill-accounts` | read-only | Lists the utility accounts plus the date range already covered by recorded bills, so the model knows the account names and won't re-enter a period it already has. |
| `import-bills` | write | Records a batch. Each bill is accepted or rejected on its own; the result reports counts and reasons. |

Both wrap existing CQRS handlers — no new domain, schema or endpoint work.

`import-bills` dispatches `Commands.Bills.Import` rather than `Commands.Bills.Create` because Import already rejects duplicates by invoice number and issue date, so re-reading the same PDF is safe, and it reports per-bill outcomes instead of failing the whole batch.

## Why `BillEntry` isn't `ImportBill`

`BillEntry` deliberately omits `Cost` and `Total`, and a period's `Days`, `DaysInclusive` and `Cost`. All are computed columns — `Total` is `CurrentReading - PreviousReading`, `Cost` is the `utilities.TotalCost` function — so any value supplied is dropped on insert.

Reusing `ImportBill` would have generated a tool schema inviting the model to type in the totals printed on the invoice, which then vanish with nothing surfacing the discrepancy. Periods use `DateOnly` to match the `date` columns.

The shared write models and the Bills UI are untouched; the frontend posts `cost`/`total` today and they're discarded the same way, which is a separate pre-existing wart.

## Authorisation

No new asserts. `UtilityAccountRepository.Get` already filters to `user.Accounts`, so an account the user can't write to simply doesn't resolve by name. Per the ownership contract, repository filtering is the primary mechanism for a non-route, name-based context like this.

The MCP OAuth scope stays `api.read`. A second `api.write` scope would not narrow a leaked token — the connector consents once for its full scope set — and nothing enforces `scp` today, so it would be decoration. Permissions remain with the policies and requirements.

## Also fixed

`InvoiceNumber` is `VARCHAR(15)`. A longer one previously failed the insert with a truncation error that took the **whole batch** down. It's now a per-bill rejection like the others, which improves the REST import path too.

## Testing

`McpToolDiscoveryTests` resolves the tools from the composed host and asserts both are registered and that `import-bills` isn't advertised read-only. Tools are wired by assembly-prefix scan (`WithToolsFromAssemblies("Asm.MooBank.Modules")`), so neither the compiler nor a grep would report a module whose tools failed to register — this had to be checked against a real host.

That test caught its own bug: it initially stood up a second `WebApplicationFactory`, which raced the authorization collection's factory (`The entry point exited without ever building an IHost`). It passed under `--filter` and failed in the full run; it now shares the existing collection fixture.

Also added: `BillEntry` mapping tests (including a guard that the mapping doesn't reintroduce the computed fields) and an invoice-length rejection test.

`dotnet build MooBank.slnx` — 0 warnings, 0 errors. Full suite green: Bills 116, Api 75.

## Left alone deliberately

- `Bill.cs:14` declares `[StringLength(11)]` but the column is `VARCHAR(15)`. No runtime effect, so the guard uses the database's 15 rather than changing the annotation.
- `get-bill-accounts` lists shared accounts that `import-bills` will reject — the query returns `user.Accounts ∪ user.SharedAccounts`, the import repository accepts only `user.Accounts`. Narrowing the query would change the Bills page too, and whether family-shared utility accounts should be writable is a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
