### PR TITLE
feat(web): show tag and group colours as a row edge on the management screens

### DIFF
--- a/src/MooBank.Web.App/src/components/colourRow.test.ts
+++ b/src/MooBank.Web.App/src/components/colourRow.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { colourRowProps } from "./colourRow";
+
+describe("colourRowProps", () => {
+
+    it("carries the colour through as the custom property the CSS reads", () => {
+        const props = colourRowProps("#ff8800");
+
+        expect(props.className).toContain("colour-row");
+        expect(props.className).toContain("has-colour");
+        expect(props.style).toEqual({ "--row-colour": "#ff8800" });
+    });
+
+    it("marks a row with no colour so the edge stays reserved but empty", () => {
+        const props = colourRowProps(null);
+
+        // colour-row still applies: it reserves the border width so rows do not shift
+        // sideways when a colour is set or cleared. has-colour is what paints it.
+        expect(props.className).toContain("colour-row");
+        expect(props.className).not.toContain("has-colour");
+        expect(props.style).toBeUndefined();
+    });
+
+    it.each([undefined, null, "", 0, {}])("treats %o as no colour", (colour) => {
+        expect(colourRowProps(colour).className).not.toContain("has-colour");
+    });
+
+    it("keeps a caller's own class", () => {
+        // Group rows are clickable; losing that would silently drop the row's hover
+        // affordance and its navigation styling.
+        const props = colourRowProps("#ff8800", "clickable");
+
+        expect(props.className.split(" ")).toEqual(["clickable", "colour-row", "has-colour"]);
+    });
+
+    it("produces no stray whitespace when there is no caller class", () => {
+        expect(colourRowProps(null).className).toBe("colour-row");
+    });
+});

--- a/src/MooBank.Web.App/src/components/colourRow.ts
+++ b/src/MooBank.Web.App/src/components/colourRow.ts
@@ -1,0 +1,20 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Row props that show an entity's colour as an edge on its management row.
+ *
+ * Returns the class and custom property the `.colour-row` styles read (see
+ * `css/components/colourrow.css`). The colour is omitted rather than defaulted when
+ * unset, so an entity with no colour shows a reserved but empty edge instead of
+ * borrowing someone else's.
+ *
+ * `colour` is typed loosely because the generated `HexColour` is `unknown`.
+ */
+export const colourRowProps = (colour: unknown, className?: string) => {
+    const hasColour = typeof colour === "string" && colour.length > 0;
+
+    return {
+        className: [className, "colour-row", hasColour ? "has-colour" : null].filter(Boolean).join(" "),
+        style: hasColour ? ({ "--row-colour": colour } as CSSProperties) : undefined,
+    };
+};

--- a/src/MooBank.Web.App/src/components/index.ts
+++ b/src/MooBank.Web.App/src/components/index.ts
@@ -5,6 +5,7 @@ export * from "./AccountSummary";
 export * from "./AccountTypeBadge";
 export * from "./Amount";
 export * from "./ColourPicker";
+export * from "./colourRow";
 export * from "./CurrencyInput";
 export * from "./CurrencySelector";
 export * from "./InstitutionSelector";

--- a/src/MooBank.Web.App/src/css/components.css
+++ b/src/MooBank.Web.App/src/css/components.css
@@ -1,6 +1,7 @@
 @import "components/accountlist.css";
 @import "components/amount.css";
 @import "components/colourpicker.css";
+@import "components/colourrow.css";
 @import "components/import.css";
 @import "components/summary.css";
 @import "components/monthselector.css";

--- a/src/MooBank.Web.App/src/css/components/colourrow.css
+++ b/src/MooBank.Web.App/src/css/components/colourrow.css
@@ -1,0 +1,23 @@
+/* ---- Colour-coded management rows ----
+   On the tag and group management screens the row *is* the entity, so its colour is
+   shown as an edge on the row rather than as a marker beside the name. The account
+   list already treats a group's colour this way (see accountlist.css), so groups read
+   the same in both places.
+
+   Set --row-colour and the has-colour class on the <tr>, matching the convention in
+   accountlist.css. The border goes on the first cell because a border on a <tr> does
+   not render under border-collapse: collapse. */
+
+.colour-row > td:first-child {
+    /* Reserved even with no colour set, so rows do not shift sideways as colours are
+       applied and cleared. */
+    border-left: 4px solid transparent;
+}
+
+.colour-row.has-colour > td:first-child {
+    /* Mixed a little towards the opposite end of the theme so a pale colour still
+       separates from the page — the dot got this from its hairline outline, which a
+       border has no equivalent of. The shift is small enough to leave the hue
+       readable. Same light-dark() approach as accountlist.css. */
+    border-left-color: color-mix(in srgb, var(--row-colour) 88%, light-dark(#000, #fff));
+}

--- a/src/MooBank.Web.App/src/css/tags.css
+++ b/src/MooBank.Web.App/src/css/tags.css
@@ -1,9 +1,6 @@
-.tag-name-cell {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-}
-
+/* Still used by the budget lines, which show a tag's colour inline rather than as a
+   row edge. budget.css overrides only the size and background, so the shape and
+   outline come from here. */
 .tag-swatch {
     display: inline-block;
     width: 12px;

--- a/src/MooBank.Web.App/src/routes/groups/-components/GroupRow.tsx
+++ b/src/MooBank.Web.App/src/routes/groups/-components/GroupRow.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import type { Group } from "api/types.gen";
+import { colourRowProps } from "components";
 
 export const GroupRow: React.FC<GroupRowProps> = (props) => {
 
     const { onRowClick } = useAccountRowCommonState(props);
 
     return (
-        <tr onClick={onRowClick} className="clickable">
+        <tr onClick={onRowClick} {...colourRowProps(props.group.colour, "clickable")}>
             <td>
                 <div className="name">{props.group.name}</div>
             </td>

--- a/src/MooBank.Web.App/src/routes/tags/-components/TagRow.tsx
+++ b/src/MooBank.Web.App/src/routes/tags/-components/TagRow.tsx
@@ -6,6 +6,7 @@ import { useDeleteTag } from "../-hooks/useDeleteTag";
 import { useUpdateTag } from "../-hooks/useUpdateTag";
 import { TransactionTagTransactionTagPanel } from "./TagTagPanel";
 import { DeleteIcon } from "@andrewmclachlan/moo-ds";
+import { colourRowProps } from "components";
 
 
 export const TransactionTagRow: React.FC<TransactionTagRowProps> = (props) => {
@@ -15,12 +16,9 @@ export const TransactionTagRow: React.FC<TransactionTagRowProps> = (props) => {
     if (!tag) return <LoadingTableRow cols={3} />;
 
     return (
-        <tr>
+        <tr {...colourRowProps(tag.colour)}>
             <EditColumn value={tag.name} onChange={t => tagRow.updateTag(t.value)}>
-                <span className="tag-name-cell">
-                    <span className="tag-swatch" style={{ background: (tag.colour as string) || "var(--primary)" }} aria-hidden="true" />
-                    {tag.name}
-                </span>
+                {tag.name}
             </EditColumn>
             <TransactionTagTransactionTagPanel as="td" tag={tag} />
             <td className="row-action">


### PR DESCRIPTION
Group management showed no colour at all despite `Group` carrying one; tag management showed a dot. Both now show the colour as a thick left edge on the row.

## Why an edge rather than a dot

On these two screens the row *is* the entity, so the colour belongs to the whole record rather than to its name, and an edge reads that way where a marker beside the name reads as decorating the name. It also scans — a colour column down the left of the table is what you want when comparing rows in a list you're managing — and it gives groups their colour without adding a column or crowding the name cell.

It isn't a new convention: the account list already shows a group's colour as `border-left: 4px solid var(--group-colour)`. This is that treatment reaching the one screen that missed it, so groups now read the same in both places.

Scoped to the management screens. Tag pills elsewhere colour the whole pill and are untouched.

## Three things the border needs that the dot got for free

**The width is reserved even with no colour set** (`4px solid transparent`), or rows shift sideways as colours are applied and cleared.

**It goes on the first cell, not the `<tr>`.** moo-ds tables are `border-collapse: collapse`, under which a border on a row does not render at all — this would have silently done nothing. Checked that no cell has a competing left border, so the reserved transparent border can't erase one by winning the collapse on width.

**The colour is mixed slightly towards the opposite end of the theme** — `color-mix(… 88%, light-dark(#000, #fff))`. A pale colour on a 4px bar has nothing like the hairline outline that kept the dot visible against the page. 88% leaves the hue readable. Same approach `accountlist.css` already uses.

## Removals

The dot goes from the tag row, replaced by the border. `.tag-swatch` **stays** — the budget lines still show a tag's colour inline and lean on that rule for their shape and outline (`budget.css` overrides only size and background). `.tag-name-cell` went with the dot; nothing else used it.

## Testing

`colourRow.test.ts` covers the helper: colour through to the custom property, the reserved-but-empty state for no colour, non-string values treated as unset, and that a caller's own class survives — group rows are `clickable`, and losing that would silently drop their hover and navigation styling.

`tsc` clean, lint 0 errors (103 pre-existing warnings), 193 tests pass, build clean.

**Not visually verified.** The backend was down while I built this, so I couldn't render real rows to look at. The mechanism is confirmed by reading — `border-collapse: collapse` in moo-ds and no competing cell borders — but the actual appearance, particularly the pale-colour mix and the 4px weight, wants an eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
