### PR TITLE
Deploy each database alongside its app, behind one production approval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,7 +257,7 @@ jobs:
     concurrency:
       group: moobank-deploy-group
       cancel-in-progress: true
-    needs: [build, test, test-frontend, docker-push, database-staging]
+    needs: [build, test, test-frontend, docker-push]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/deploy-azure.yml@v4
     with:
@@ -279,7 +279,7 @@ jobs:
     concurrency:
       group: moobank-database
       cancel-in-progress: false
-    needs: staging
+    needs: [staging, database-staging]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     # TEMPORARY: pinned to the branch so this can be proved before it is released.
     # Change to @v4 once AndrewMcLachlan/Actions#36 is merged and v4.8 is cut.
@@ -300,7 +300,7 @@ jobs:
     concurrency:
       group: moobank-deploy-group
       cancel-in-progress: true
-    needs: database-production
+    needs: [staging, database-staging]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/azure-appservice-swap-slot.yml@v4
     with:
@@ -317,7 +317,7 @@ jobs:
     concurrency:
       group: moobank-deploy-group
       cancel-in-progress: true
-    needs: [build, production]
+    needs: [build, production, database-production]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/deploy-azure.yml@v4
     with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
     concurrency:
       group: moobank-database
       cancel-in-progress: false
-    needs: [build, test, test-frontend]
+    needs: [build, test, test-frontend, docker-push]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     # TEMPORARY: pinned to the branch so this can be proved before it is released.
     # Change to @v4 once AndrewMcLachlan/Actions#36 is merged and v4.8 is cut.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,14 +237,7 @@ jobs:
       group: moobank-database
       cancel-in-progress: false
     needs: [build, test, test-frontend]
-    # main deploys as usual. A workflow_dispatch from any branch also deploys, which is how
-    # this gets proved before it is trusted: the Staging environment's own deployment-branch
-    # rules decide which branches qualify and who approves them, which is a better place for
-    # that decision than a condition in here.
-    #
-    # Dispatch rather than the pull request itself, because on a pull_request event github.ref
-    # is refs/pull/N/merge -- it never matches a feature/* branch policy.
-    if: (github.event_name == 'workflow_dispatch') || (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
+    if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     # TEMPORARY: pinned to the branch so this can be proved before it is released.
     # Change to @v4 once AndrewMcLachlan/Actions#36 is merged and v4.8 is cut.
     uses: AndrewMcLachlan/actions/.github/workflows/deploy-sql-database.yml@feature/deploy-sql-database


### PR DESCRIPTION
Follows #949. Two commits that should have gone up when they were written — my mistake, they
sat on the merged branch instead.

## The problem

`database-production` ran *before* `production`, so each stopped at the `Production`
environment separately and asked for its own approval — and the first of those was the
irreversible one. Approve the schema, decline the swap, and production is left running old
code against a database that has moved on.

## The change

Schema and app now go out together on each tier:

```
build ─┬─ test ──────────┬─ docker-push ─── staging ──────────┐
       └─ test-frontend ─┴─ database-staging ─────────────────┤
                                                              ├─ database-production ─┐
                                                              └─ production (swap) ───┴─ post-production
```

Both production jobs become ready at the same moment and wait on the same environment, so the
review prompt lists `Production` once and one approval covers both. One decision about one
release.

I'm confident but not certain GitHub batches the approval this way. If it prompts twice they
arrive together rather than in sequence, and nothing runs unapproved either way — worth
watching on the first production run.

Also reverts the `workflow_dispatch` gate on `database-staging`: feature-branch deployment
turned out not to be wanted, so every deploy job is back to `main`-only.

## Still outstanding from #949

The two `uses:` lines are still pinned to `deploy-sql-database.yml@feature/deploy-sql-database`.
Once **AndrewMcLachlan/Actions#36** is merged and `v4.8` cut, they need flipping to `@v4` —
a merged `main` pointing at a feature branch breaks the day that branch is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
