### PR TITLE
Close the gaps left behind by the payment-linking work

### DIFF
--- a/src/MooBank.Database/Script.PreDeployment1.sql
+++ b/src/MooBank.Database/Script.PreDeployment1.sql
@@ -176,3 +176,30 @@ BEGIN
 
     DROP TABLE #ForecastIncomeSegments;
 END
+
+/*
+ Gives every forecast plan a currency, so the column can be made NOT NULL.
+
+ Plans have always been created with one -- CreatePlan falls back to the author's own currency --
+ but rows predating that are still null, and a plan with no currency renders every amount in the
+ forecast with no symbol. The family's currency is the right answer for a family's plan; AUD is the
+ same default the User table already carries, for the case where a family somehow has no members.
+
+ Runs before the column is altered: the deployment plan is worked out first, but pre-deployment
+ executes ahead of the schema changes it was planned alongside.
+
+ Idempotent by construction -- once nothing is null there is nothing to update.
+*/
+IF OBJECT_ID('dbo.ForecastPlan', 'U') IS NOT NULL
+   AND COL_LENGTH('dbo.ForecastPlan', 'CurrencyCode') IS NOT NULL
+   AND EXISTS (SELECT 1 FROM dbo.ForecastPlan WHERE CurrencyCode IS NULL)
+BEGIN
+    UPDATE p
+    SET p.CurrencyCode = COALESCE(
+        (SELECT TOP 1 u.Currency FROM dbo.[User] u WHERE u.FamilyId = p.FamilyId ORDER BY u.Id),
+        'AUD')
+    FROM dbo.ForecastPlan p
+    WHERE p.CurrencyCode IS NULL;
+
+    PRINT 'Backfilled CurrencyCode on forecast plans that had none.';
+END

--- a/src/MooBank.Database/dbo/Tables/ForecastPlan.sql
+++ b/src/MooBank.Database/dbo/Tables/ForecastPlan.sql
@@ -8,7 +8,7 @@
     [AccountScopeMode] TINYINT NOT NULL CONSTRAINT DF_ForecastPlan_AccountScopeMode DEFAULT 0,
     [StartingBalanceMode] TINYINT NOT NULL CONSTRAINT DF_ForecastPlan_StartingBalanceMode DEFAULT 0,
     [StartingBalanceAmount] DECIMAL(18,2) NULL,
-    [CurrencyCode] CHAR(3) NULL,
+    [CurrencyCode] CHAR(3) NOT NULL,
     [OutgoingStrategy] NVARCHAR(MAX) NULL,
     [Assumptions] NVARCHAR(MAX) NULL,
     [IsArchived] BIT NOT NULL CONSTRAINT DF_ForecastPlan_IsArchived DEFAULT 0,

--- a/src/MooBank.Database/dbo/Tables/ForecastPlannedItem.sql
+++ b/src/MooBank.Database/dbo/Tables/ForecastPlannedItem.sql
@@ -11,6 +11,10 @@ CREATE TABLE [dbo].[ForecastPlannedItem]
     [DateMode] TINYINT NOT NULL,
     [Notes] NVARCHAR(MAX) NULL,
     CONSTRAINT [PK_ForecastPlannedItem] PRIMARY KEY CLUSTERED ([Id]),
+    -- Redundant on its own -- Id is already unique -- but it gives ForecastPlannedItemTransaction
+    -- something to point a composite foreign key at, so a link row cannot name one plan while its
+    -- item belongs to another.
+    CONSTRAINT [UQ_ForecastPlannedItem_Id_ForecastPlanId] UNIQUE ([Id], [ForecastPlanId]),
     CONSTRAINT [FK_ForecastPlannedItem_ForecastPlan] FOREIGN KEY ([ForecastPlanId]) REFERENCES [ForecastPlan]([Id]) ON DELETE CASCADE,
     CONSTRAINT [FK_ForecastPlannedItem_ItemType] FOREIGN KEY ([ItemType]) REFERENCES [PlannedItemType]([Id]),
     CONSTRAINT [FK_ForecastPlannedItem_DateMode] FOREIGN KEY ([DateMode]) REFERENCES [PlannedItemDateMode]([Id]),

--- a/src/MooBank.Database/dbo/Tables/ForecastPlannedItemTransaction.sql
+++ b/src/MooBank.Database/dbo/Tables/ForecastPlannedItemTransaction.sql
@@ -7,12 +7,13 @@ CREATE TABLE [dbo].[ForecastPlannedItemTransaction]
 (
     [Id] UNIQUEIDENTIFIER NOT NULL CONSTRAINT DF_ForecastPlannedItemTransaction_Id DEFAULT NEWID(),
     [PlannedItemId] UNIQUEIDENTIFIER NOT NULL,
-    -- Denormalised from the item so a payment can be claimed by only one item within a plan.
+    -- Denormalised from the item so the unique index below can stop two items in one plan claiming
+    -- the same payment. The composite foreign key is what keeps it honest: the pair has to match a
+    -- real (item, plan) pair, so this cannot drift from the item it belongs to.
     [ForecastPlanId] UNIQUEIDENTIFIER NOT NULL,
     [TransactionId] UNIQUEIDENTIFIER NOT NULL,
     CONSTRAINT [PK_ForecastPlannedItemTransaction] PRIMARY KEY CLUSTERED ([Id]),
-    CONSTRAINT [FK_ForecastPlannedItemTransaction_PlannedItem] FOREIGN KEY ([PlannedItemId]) REFERENCES [ForecastPlannedItem]([Id]) ON DELETE CASCADE,
-    CONSTRAINT [FK_ForecastPlannedItemTransaction_ForecastPlan] FOREIGN KEY ([ForecastPlanId]) REFERENCES [ForecastPlan]([Id]),
+    CONSTRAINT [FK_ForecastPlannedItemTransaction_PlannedItem] FOREIGN KEY ([PlannedItemId], [ForecastPlanId]) REFERENCES [ForecastPlannedItem]([Id], [ForecastPlanId]) ON DELETE CASCADE,
     CONSTRAINT [FK_ForecastPlannedItemTransaction_Transaction] FOREIGN KEY ([TransactionId]) REFERENCES [Transaction]([TransactionId])
 )
 GO

--- a/src/MooBank.Database/dbo/Tables/Group.sql
+++ b/src/MooBank.Database/dbo/Tables/Group.sql
@@ -1,7 +1,7 @@
-CREATE TABLE [Group] (
+﻿CREATE TABLE [Group] (
     Id UNIQUEIDENTIFIER NOT NULL CONSTRAINT DF_AccountGroup_Id DEFAULT (NEWID()),
     [Name] NVARCHAR(255) NOT NULL,
-    [Description] NVARCHAR(4000) NOT NULL,
+    [Description] NVARCHAR(4000) NULL,
     [OwnerId] UNIQUEIDENTIFIER NOT NULL,
     [ShowPosition] BIT NOT NULL,
     [Colour] CHAR(7) NULL,

--- a/src/MooBank.Modules.Forecast/Commands/SetPlannedItemPayments.cs
+++ b/src/MooBank.Modules.Forecast/Commands/SetPlannedItemPayments.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel;
 using Asm.MooBank.Domain.Entities.Forecast;
 using Asm.MooBank.Domain.Entities.Forecast.Specifications;
+using Asm.MooBank.Models;
 using Asm.MooBank.Modules.Forecast.Models;
+using Asm.MooBank.Modules.Forecast.Services;
 
 namespace Asm.MooBank.Modules.Forecast.Commands;
 
@@ -11,11 +13,24 @@ namespace Asm.MooBank.Modules.Forecast.Commands;
 [DisplayName("SetPlannedItemPayments")]
 public record SetPlannedItemPayments(Guid PlanId, Guid ItemId, PlannedItemPayments Payments) : ICommand<PlannedItem>;
 
-internal class SetPlannedItemPaymentsHandler(IForecastRepository forecastRepository, IUnitOfWork unitOfWork) : ICommandHandler<SetPlannedItemPayments, PlannedItem>
+internal class SetPlannedItemPaymentsHandler(IForecastRepository forecastRepository, IPlannedItemMatcher matcher, IUnitOfWork unitOfWork, User user) : ICommandHandler<SetPlannedItemPayments, PlannedItem>
 {
     public async ValueTask<PlannedItem> Handle(SetPlannedItemPayments request, CancellationToken cancellationToken)
     {
         var plan = await forecastRepository.Get(request.PlanId, new ForecastPlanDetailsSpecification(), cancellationToken);
+
+        // Owning the plan is not the same as owning the payments. The candidate list only ever
+        // offers spending on the plan's own accounts, but nothing made the command agree with it,
+        // so any identifier at all could be linked and then read back as a figure in the forecast.
+        var outOfScope = await matcher.FindOutOfScope(
+            request.Payments.TransactionIds,
+            PlanScope.AccountIds(plan, user),
+            cancellationToken);
+
+        if (outOfScope.Count > 0)
+        {
+            throw new NotFoundException("One or more of those payments could not be found");
+        }
 
         plan.SetPlannedItemTransactions(request.ItemId, request.Payments.TransactionIds);
 

--- a/src/MooBank.Modules.Forecast/Services/IPlannedItemMatcher.cs
+++ b/src/MooBank.Modules.Forecast/Services/IPlannedItemMatcher.cs
@@ -20,4 +20,17 @@ internal interface IPlannedItemMatcher
     Task<IReadOnlyList<LinkedPayment>> GetPayments(
         IEnumerable<Guid> transactionIds,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Which of the given payments are not on any of the given accounts.
+    /// </summary>
+    /// <remarks>
+    /// Identifiers that match no transaction at all count as out of scope: from the caller's side
+    /// there is no difference between a payment that is somebody else's and one that does not
+    /// exist, and answering differently would say which.
+    /// </remarks>
+    Task<IReadOnlyList<Guid>> FindOutOfScope(
+        IEnumerable<Guid> transactionIds,
+        IReadOnlyCollection<Guid> accountIds,
+        CancellationToken cancellationToken = default);
 }

--- a/src/MooBank.Modules.Forecast/Services/PlanScope.cs
+++ b/src/MooBank.Modules.Forecast/Services/PlanScope.cs
@@ -1,0 +1,21 @@
+using Asm.MooBank.Models;
+using DomainForecastPlan = Asm.MooBank.Domain.Entities.Forecast.ForecastPlan;
+
+namespace Asm.MooBank.Modules.Forecast.Services;
+
+/// <summary>
+/// The accounts a plan is allowed to see.
+/// </summary>
+/// <remarks>
+/// Shared rather than worked out at each call site, because the two places that needed it had
+/// drifted apart: the candidate list filtered by these accounts while the command that recorded the
+/// author's answer filtered by nothing at all, so a payment that could never have been offered
+/// could still be linked.
+/// </remarks>
+internal static class PlanScope
+{
+    public static IReadOnlyList<Guid> AccountIds(DomainForecastPlan plan, User user) =>
+        plan.AccountScopeMode == AccountScopeMode.SelectedAccounts
+            ? [.. plan.Accounts.Select(a => a.InstrumentId)]
+            : [.. user.Accounts, .. user.SharedAccounts];
+}

--- a/src/MooBank.Modules.Forecast/Services/PlannedItemMatcher.cs
+++ b/src/MooBank.Modules.Forecast/Services/PlannedItemMatcher.cs
@@ -41,4 +41,23 @@ internal class PlannedItemMatcher(IQueryable<DomainTransaction> transactions) : 
             Math.Abs(r.Amount),
             !r.ExcludeFromReporting))];
     }
+
+    public async Task<IReadOnlyList<Guid>> FindOutOfScope(
+        IEnumerable<Guid> transactionIds,
+        IReadOnlyCollection<Guid> accountIds,
+        CancellationToken cancellationToken = default)
+    {
+        var ids = transactionIds.Distinct().ToList();
+
+        if (ids.Count == 0) return [];
+
+        // Asked the way round that cannot be fooled by a missing row: find the ones that *are*
+        // allowed, and treat everything else as refused.
+        var inScope = await transactions
+            .Where(t => ids.Contains(t.Id) && accountIds.Contains(t.AccountId))
+            .Select(t => t.Id)
+            .ToListAsync(cancellationToken);
+
+        return [.. ids.Except(inScope)];
+    }
 }

--- a/tests/MooBank.Modules.Forecast.Tests/Commands/SetPlannedItemPaymentsTests.cs
+++ b/tests/MooBank.Modules.Forecast.Tests/Commands/SetPlannedItemPaymentsTests.cs
@@ -1,0 +1,119 @@
+#nullable enable
+using Asm.MooBank.Domain.Entities.Forecast.Specifications;
+using Asm.MooBank.Modules.Forecast.Commands;
+using Asm.MooBank.Modules.Forecast.Models;
+using Asm.MooBank.Modules.Forecast.Tests.Support;
+using DomainPlannedItem = Asm.MooBank.Domain.Entities.Forecast.ForecastPlannedItem;
+
+namespace Asm.MooBank.Modules.Forecast.Tests.Commands;
+
+/// <summary>
+/// Unit tests for recording which payments belong to a planned item.
+/// </summary>
+/// <remarks>
+/// Owning the plan is not the same as owning the payments. The candidate list only ever offers
+/// spending on the plan's own accounts; this command has to hold the same line, or an identifier
+/// that could never have been offered can still be linked and read back as a figure.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class SetPlannedItemPaymentsTests
+{
+    private readonly TestMocks _mocks = new();
+
+    private (SetPlannedItemPaymentsHandler Handler, DomainPlannedItem Item) CreateHandler()
+    {
+        var planId = Guid.NewGuid();
+        var item = TestEntities.CreatePlannedItem(planId: planId);
+        var plan = TestEntities.CreateForecastPlan(id: planId, familyId: _mocks.User.FamilyId, plannedItems: [item]);
+
+        _mocks.ForecastRepositoryMock
+            .Setup(r => r.Get(planId, It.IsAny<ForecastPlanDetailsSpecification>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(plan);
+
+        return (new SetPlannedItemPaymentsHandler(
+            _mocks.ForecastRepositoryMock.Object,
+            _mocks.PlannedItemMatcherMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.User), item);
+    }
+
+    /// <summary>
+    /// Given payments on the plan's own accounts
+    /// When they are linked to an item
+    /// Then they should be recorded
+    /// </summary>
+    [Fact]
+    public async Task Handle_PaymentsInScope_RecordsThem()
+    {
+        // Arrange
+        var (handler, item) = CreateHandler();
+        var payments = new[] { Guid.NewGuid(), Guid.NewGuid() };
+
+        // Act
+        await handler.Handle(
+            new SetPlannedItemPayments(item.ForecastPlanId, item.Id, new PlannedItemPayments { TransactionIds = payments }),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(payments.Order(), item.Transactions.Select(t => t.TransactionId).Order());
+        _mocks.UnitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Given a payment that is not on any of the plan's accounts
+    /// When it is linked
+    /// Then it should be refused and nothing recorded
+    /// </summary>
+    /// <remarks>
+    /// The defect this pins down: the command took whatever identifiers it was handed. Owning the
+    /// plan was the only thing checked, so somebody else's payment could be linked to your own plan
+    /// and its amount read back through the forecast.
+    /// </remarks>
+    [Fact]
+    public async Task Handle_PaymentOutOfScope_IsRefusedAndRecordsNothing()
+    {
+        // Arrange
+        var (handler, item) = CreateHandler();
+        var stranger = Guid.NewGuid();
+
+        _mocks.PlannedItemMatcherMock
+            .Setup(m => m.FindOutOfScope(It.IsAny<IEnumerable<Guid>>(), It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([stranger]);
+
+        // Act / Assert
+        await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(
+            new SetPlannedItemPayments(item.ForecastPlanId, item.Id, new PlannedItemPayments { TransactionIds = [stranger] }),
+            TestContext.Current.CancellationToken).AsTask());
+
+        Assert.Empty(item.Transactions);
+        _mocks.UnitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    /// <summary>
+    /// Given an empty list of payments
+    /// When it is applied
+    /// Then the item's links should be cleared without complaint
+    /// </summary>
+    /// <remarks>
+    /// Unlinking everything is how an author says a payment was not the item's after all, so it
+    /// must not be mistaken for an attempt to link nothing they own.
+    /// </remarks>
+    [Fact]
+    public async Task Handle_EmptyList_ClearsTheLinks()
+    {
+        // Arrange
+        var (handler, item) = CreateHandler();
+
+        await handler.Handle(
+            new SetPlannedItemPayments(item.ForecastPlanId, item.Id, new PlannedItemPayments { TransactionIds = [Guid.NewGuid()] }),
+            TestContext.Current.CancellationToken);
+
+        // Act
+        await handler.Handle(
+            new SetPlannedItemPayments(item.ForecastPlanId, item.Id, new PlannedItemPayments { TransactionIds = [] }),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(item.Transactions);
+    }
+}

--- a/tests/MooBank.Modules.Forecast.Tests/Support/TestMocks.cs
+++ b/tests/MooBank.Modules.Forecast.Tests/Support/TestMocks.cs
@@ -32,6 +32,11 @@ public class TestMocks
             .Setup(m => m.GetPayments(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync([]);
 
+        // Everything is in scope unless a test says otherwise.
+        PlannedItemMatcherMock
+            .Setup(m => m.FindOutOfScope(It.IsAny<IEnumerable<Guid>>(), It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
         User = CreateTestUser();
     }
 


### PR DESCRIPTION
You asked what I'd sacrificed and never followed up. This is that list, fixed.

## 1. Linking payments checked the plan, not the payments

`SetPlannedItemPayments` took whatever transaction IDs it was handed. The endpoint authorises
the *plan*, and the domain method checked the item existed and that no other item on the same
plan already claimed the payment — but nothing checked the transactions existed, were yours, or
sat in the plan's account scope.

`GetPaymentCandidates` filtered by `accountIds`. The command didn't. So a payment that could
never have been *offered* could still be *linked*, and its amount read back through the
forecast. GUIDs aren't guessable, so this is low severity — but it's an authorisation gap, not
a design preference.

Both sides now ask one shared question (`PlanScope.AccountIds`). They disagreed precisely
because each worked it out for itself.

An identifier matching no transaction is treated the same as one belonging to someone else —
answering differently would tell you which.

## 2. A denormalised column with nothing keeping it true

`ForecastPlannedItemTransaction.ForecastPlanId` exists so the unique index can stop two items in
one plan claiming the same payment. I wrote a comment saying it was denormalised, which is not
the same as keeping it honest — nothing stopped it drifting from its item's actual plan.

Now a composite FK on `(PlannedItemId, ForecastPlanId)` → `ForecastPlannedItem(Id, ForecastPlanId)`,
backed by a new unique constraint on the parent. The redundant single-column FK to `ForecastPlan`
is gone; the composite one implies it.

## 3. Nullability

**`ForecastPlan.CurrencyCode` → `NOT NULL`.** Every plan has a currency in principle —
`CreatePlan` falls back to the author's — but **both** rows in my local database held NULL, which
renders every amount with no symbol. Backfilled in pre-deployment from the family's currency,
falling back to `'AUD'` (the same default `User.Currency` already carries), then tightened.

**`Group.Description` → `NULL`.** The reverse problem: the column refused NULL while the domain
entity, the module model and the create/update path all treat description as optional. All nine
rows satisfied the constraint with `''` — that's how the argument had already been settled in
practice. The column now agrees. Existing empty strings are left alone.

## What I did *not* change, and why

**`OutgoingStrategy` and `Assumptions` staying as JSON.** I originally called this an asymmetry
worth fixing — income became relational, outgoings didn't. On inspection that was wrong. Income
genuinely is a *list of dated items*; these are configuration bags (`LookbackMonths`, inflation
rates, a safety buffer) including three fields marked "not yet honoured". Building relational
tables for unimplemented settings would be worse than leaving them.

**The one-time migration scaffolding.** `__ForecastIncomeStrategyMigration`, the flexible-window
`DROP TABLE` block, and the three that predate me all still run (guarded, no-ops) on every
deploy. They're removable **once every environment has run them** — and staging hasn't had a
successful CI deployment yet, so removing them now would mean staging never gets them. Worth
doing after the pipeline goes green against both. Say if you'd rather I just did it.

## Verification

- Build clean, no warnings. All 22 test projects pass. Forecast tests 132 → 135.
- **Mutation tested**: inverting the scope check fails exactly the out-of-scope test.
- **Published to the local database**: backfill ran (`Backfilled CurrencyCode…`), `CurrencyCode`
  is now `is_nullable=0` with both plans on AUD, `Group.Description` is `is_nullable=1`, and the
  FK is confirmed 2-column. Republished immediately after — zero errors, so the backfill is
  idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
