### PR TITLE
fix(groups): give a new group a place at the end of the list

### DIFF
--- a/src/MooBank.Domain/Entities/Group/IGroupRepository.cs
+++ b/src/MooBank.Domain/Entities/Group/IGroupRepository.cs
@@ -2,4 +2,14 @@
 
 public interface IGroupRepository : IDeletableRepository<Group, Guid>, IWritableRepository<Group, Guid>
 {
+    /// <summary>
+    /// Gets the position a new group for this owner should take: one past the last of them, or
+    /// zero when the owner has none yet.
+    /// </summary>
+    /// <remarks>
+    /// A new group belongs at the end of the list — the owner put the existing ones where they
+    /// wanted them, and an arrival is not entitled to a place among them. Positions are only
+    /// meaningful within one owner's groups, so the owner has to be given.
+    /// </remarks>
+    Task<int> GetNextSortOrder(Guid ownerId, CancellationToken cancellationToken = default);
 }

--- a/src/MooBank.Infrastructure/Repositories/GroupRepository.cs
+++ b/src/MooBank.Infrastructure/Repositories/GroupRepository.cs
@@ -9,4 +9,14 @@ internal class GroupRepository(MooBankContext dataContext) : RepositoryDeleteBas
         var group = Entities.Find(id) ?? throw new NotFoundException();
         Entities.Remove(group);
     }
+
+    public async Task<int> GetNextSortOrder(Guid ownerId, CancellationToken cancellationToken = default)
+    {
+        // Projected as nullable so an owner with no groups gives null rather than throwing on Max.
+        var last = await Entities.Where(g => g.OwnerId == ownerId)
+                                 .Select(g => (int?)g.SortOrder)
+                                 .MaxAsync(cancellationToken);
+
+        return last is null ? 0 : last.Value + 1;
+    }
 }

--- a/src/MooBank.Modules.Groups/Commands/Create.cs
+++ b/src/MooBank.Modules.Groups/Commands/Create.cs
@@ -14,13 +14,17 @@ internal class CreateHandler(IGroupRepository groupRepository, IUnitOfWork unitO
     {
         // Security: Check not required the group is created against the current user.
 
+        // A new group goes on the end. Without a position of its own it would take the column
+        // default of zero and sort in among whatever else sits there, so it would appear part-way
+        // up a list the owner had already arranged.
         Domain.Entities.Group.Group entity = new()
         {
             Name = request.Name,
             Description = request.Description,
             ShowPosition = request.ShowTotal,
             Colour = request.Colour,
-            OwnerId = user.Id
+            OwnerId = user.Id,
+            SortOrder = await groupRepository.GetNextSortOrder(user.Id, cancellationToken),
         };
 
         groupRepository.Add(entity);

--- a/src/MooBank.Web.App/src/routes/groups/-hooks/useReorderGroups.ts
+++ b/src/MooBank.Web.App/src/routes/groups/-hooks/useReorderGroups.ts
@@ -1,7 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { reorderGroupsMutation, getAllGroupsQueryKey } from "api/@tanstack/react-query.gen";
-import type { Group } from "api/types.gen";
+import type { Options } from "api/sdk.gen";
+import type { Group, ReorderGroupsData } from "api/types.gen";
 import { toast } from "@andrewmclachlan/moo-ds";
+
+/** What the generated mutation takes: the request body, plus the usual per-call client options. */
+type ReorderVariables = Options<ReorderGroupsData>;
 
 /**
  * Saves the order the groups have been dragged into.
@@ -20,7 +24,7 @@ export const useReorderGroups = () => {
 
     const { mutateAsync, ...rest } = useMutation({
         ...reorderGroupsMutation(),
-        onMutate: async (variables: { body: { order: { groupIds: string[] } } }) => {
+        onMutate: async (variables: ReorderVariables) => {
             await queryClient.cancelQueries({ queryKey });
 
             const previous = queryClient.getQueryData<Group[]>(queryKey);
@@ -48,7 +52,7 @@ export const useReorderGroups = () => {
     });
 
     return {
-        reorder: (groupIds: string[]) => mutateAsync({ body: { order: { groupIds } } } as any),
+        reorder: (groupIds: string[]) => mutateAsync({ body: { order: { groupIds } } }),
         ...rest,
     };
 };

--- a/tests/MooBank.Infrastructure.Tests/Repositories/GroupRepositoryTests.cs
+++ b/tests/MooBank.Infrastructure.Tests/Repositories/GroupRepositoryTests.cs
@@ -1,0 +1,105 @@
+﻿#nullable enable
+using Asm.MooBank.Infrastructure.Repositories;
+using Asm.MooBank.Infrastructure.Tests.Support;
+
+namespace Asm.MooBank.Infrastructure.Tests.Repositories;
+
+/// <summary>
+/// Unit tests for <see cref="GroupRepository"/>, chiefly the position a new group is given.
+/// </summary>
+/// <remarks>
+/// Positions are only meaningful within one owner's groups — the column is not unique across the
+/// table — so the interesting cases are an owner with nothing yet, an owner whose positions have
+/// gaps in them, and somebody else's groups being counted by mistake.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class GroupRepositoryTests : IDisposable
+{
+    private readonly MooBankContext _context;
+
+    public GroupRepositoryTests()
+    {
+        _context = TestDbContextFactory.Create();
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Given an owner with no groups
+    /// When the next position is asked for
+    /// Then it should be the first one
+    /// </summary>
+    [Fact]
+    public async Task GetNextSortOrder_OwnerHasNoGroups_ReturnsZero()
+    {
+        // Arrange
+        var repository = CreateRepository();
+
+        // Act
+        var result = await repository.GetNextSortOrder(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, result);
+    }
+
+    /// <summary>
+    /// Given an owner whose groups have gaps in their positions
+    /// When the next position is asked for
+    /// Then it should be one past the last of them
+    /// </summary>
+    /// <remarks>
+    /// Counting the groups instead of reading the highest position would land on one already taken
+    /// as soon as the sequence is not contiguous, and nothing keeps it contiguous.
+    /// </remarks>
+    [Fact]
+    public async Task GetNextSortOrder_OwnerHasGroups_ReturnsOnePastTheLast()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+
+        _context.AddRange(
+            TestEntities.CreateGroup(ownerId: ownerId, sortOrder: 0),
+            TestEntities.CreateGroup(ownerId: ownerId, sortOrder: 1),
+            TestEntities.CreateGroup(ownerId: ownerId, sortOrder: 5));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = CreateRepository();
+
+        // Act
+        var result = await repository.GetNextSortOrder(ownerId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(6, result);
+    }
+
+    /// <summary>
+    /// Given groups belonging to somebody else
+    /// When the next position is asked for
+    /// Then they should not be counted
+    /// </summary>
+    [Fact]
+    public async Task GetNextSortOrder_SomebodyElsesGroups_AreIgnored()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+
+        _context.AddRange(
+            TestEntities.CreateGroup(ownerId: Guid.NewGuid(), sortOrder: 9),
+            TestEntities.CreateGroup(ownerId: ownerId, sortOrder: 0));
+        await _context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var repository = CreateRepository();
+
+        // Act
+        var result = await repository.GetNextSortOrder(ownerId, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, result);
+    }
+
+    private GroupRepository CreateRepository() => new(_context);
+}

--- a/tests/MooBank.Infrastructure.Tests/Support/TestEntities.cs
+++ b/tests/MooBank.Infrastructure.Tests/Support/TestEntities.cs
@@ -59,13 +59,15 @@ internal static class TestEntities
         Guid? id = null,
         string? name = null,
         Guid? ownerId = null,
-        bool showPosition = true)
+        bool showPosition = true,
+        int sortOrder = 0)
     {
         return new Group(id ?? Guid.NewGuid())
         {
             Name = name ?? Faker.Commerce.Department(),
             OwnerId = ownerId ?? Guid.NewGuid(),
             ShowPosition = showPosition,
+            SortOrder = sortOrder,
         };
     }
 

--- a/tests/MooBank.Modules.Groups.Tests/Commands/CreateTests.cs
+++ b/tests/MooBank.Modules.Groups.Tests/Commands/CreateTests.cs
@@ -196,6 +196,72 @@ public class CreateTests
         Assert.Null(result.Colour);
     }
 
+    /// <summary>
+    /// Given an owner who already has groups
+    /// When a group is created
+    /// Then it should take the position after the last of them
+    /// </summary>
+    /// <remarks>
+    /// Without a position of its own the new group keeps the column default of zero and sorts by
+    /// name among everything else sitting there, so it turns up part-way up a list the owner has
+    /// already arranged rather than on the end of it.
+    /// </remarks>
+    [Fact]
+    public async Task Handle_OwnerHasGroups_PlacesTheNewGroupLast()
+    {
+        // Arrange
+        DomainGroup? capturedGroup = null;
+
+        _mocks.GroupRepositoryMock
+            .Setup(r => r.Add(It.IsAny<DomainGroup>()))
+            .Callback<DomainGroup>(g => capturedGroup = g);
+
+        _mocks.GroupRepositoryMock
+            .Setup(r => r.GetNextSortOrder(_mocks.User.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+
+        var handler = new CreateHandler(
+            _mocks.GroupRepositoryMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.User);
+
+        var command = new Create("New Group", "A test group", false);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(capturedGroup);
+        Assert.Equal(3, capturedGroup.SortOrder);
+    }
+
+    /// <summary>
+    /// Given a user creating a group
+    /// When the handler is invoked
+    /// Then the position should be asked for against that user's own list
+    /// </summary>
+    /// <remarks>
+    /// Positions only mean anything within one owner's groups, so the wrong owner would give a
+    /// number picked from somebody else's list.
+    /// </remarks>
+    [Fact]
+    public async Task Handle_ValidCommand_AsksForThePositionOfTheOwnersList()
+    {
+        // Arrange
+        var handler = new CreateHandler(
+            _mocks.GroupRepositoryMock.Object,
+            _mocks.UnitOfWorkMock.Object,
+            _mocks.User);
+
+        var command = new Create("New Group", "A test group", false);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mocks.GroupRepositoryMock.Verify(r => r.GetNextSortOrder(_mocks.User.Id, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Fact]
     public async Task Handle_DifferentUser_SetsCorrectOwner()
     {


### PR DESCRIPTION
Two things the group-ordering work (#948) left behind.

## A new group had no position of its own

`Groups/Commands/Create` never set `SortOrder`, so every new group took the
column default of `0`. `GetAll` orders by `SortOrder` then `Name`, so the new
group tied with every group that had never been reordered and turned up
alphabetically among them — part-way up a list the owner had already arranged,
rather than on the end of it.

`Create` now asks for the position past the last one the owner has, or zero when
they have none yet. It reads that through `IGroupRepository.GetNextSortOrder`
rather than an injected `IQueryable<Group>`: this is a command handler, and
commands go through repositories (`.claude/rules/backend/cqrs.md`,
`.claude/rules/backend/entity-framework.md`).

The position is read as `MAX(SortOrder)` rather than counted, because the
sequence is not guaranteed contiguous — a delete leaves a gap, and counting
would then hand out a position already taken.

`DEFAULT (0)` on `dbo.Group.SortOrder` stays as it was. It is harmless now that
`Create` assigns a position, and remains a floor for any row written outside
this path. **No schema change is needed.**

## `as any` in the reorder hook

`useReorderGroups` cast its mutation payload to `any` to get past the generated
types. The variables type is `Options<ReorderGroupsData>`, which is exported by
the generated client, so it is taken from there. Behaviour is untouched: the
optimistic cache write, the rollback and the error toast are all as they were,
and the existing `useReorderGroups.test.tsx` passes unchanged.

## Verification

- **Mutation-tested.** Removing the `SortOrder` assignment from `Create` fails
  exactly the two new handler tests
  (`Handle_OwnerHasGroups_PlacesTheNewGroupLast`,
  `Handle_ValidCommand_AsksForThePositionOfTheOwnersList`) and nothing else.
  Weakening `GetNextSortOrder` to return the highest position instead of one
  past it fails exactly the two new repository tests that pin that
  (`GetNextSortOrder_OwnerHasGroups_ReturnsOnePastTheLast`,
  `GetNextSortOrder_SomebodyElsesGroups_AreIgnored`). Both reverts restored.
- Backend: `dotnet build MooBank.slnx` — 0 warnings, 0 errors.
  `dotnet test MooBank.slnx` — 2229 passed, 3 skipped (was 2224 passed);
  Groups 53 → 55, Infrastructure 61 → 64.
- Frontend: `npm run build`, `npm run typecheck` (tsc 7.0.2) and `npm run lint`
  (0 errors) all clean; `npm test` — 270 passed across 37 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
