### PR TITLE
Name the resource group each SQL server actually lives in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
       artifact-name: database
       server-name: mclachlan-staging
       database-name: MooBank-Staging
-      resource-group: MooBank
+      resource-group: Data-Staging
       publish-profile: src/MooBank.Database/Deploy.publish.xml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
@@ -289,7 +289,7 @@ jobs:
       artifact-name: database
       server-name: mclachlan
       database-name: MooBank
-      resource-group: MooBank
+      resource-group: Data
       publish-profile: src/MooBank.Database/Deploy.publish.xml
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
The staging database deploy failed with:

```
(AuthorizationFailed) ... does not have authorization to perform action
'Microsoft.Sql/servers/firewallRules/write' over scope
'/subscriptions/***/resourceGroups/MooBank/providers/Microsoft.Sql/servers/mclachlan-staging/firewallRules/...'
```

That reads like a missing role. It wasn't — the role assignments were correct:

```
SQL Server Contributor  .../resourceGroups/Data-Staging
SQL Server Contributor  .../resourceGroups/Data
```

## The actual cause

Both database jobs passed `resource-group: MooBank`. I took that from the app deployment
sitting next to them and assumed one resource group for the project. Confirmed otherwise:

```
mclachlan          Data
mclachlan-staging  Data-Staging
```

So the firewall call named a scope that doesn't contain the server it was talking about.
Azure answers that with `AuthorizationFailed` rather than "no such resource", which is why it
looked like a permissions problem.

## The fix

- `database-staging` → `Data-Staging`
- `database-production` → `Data`
- `staging` and `post-production` keep `MooBank`, which is where the web app is

No change to the reusable workflow — it was doing exactly what it was told.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
