### PR TITLE
Give each deployment tier its own concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
   # SqlPackage killed part way through a schema change is not. These queue rather than cancel.
   database-staging:
     concurrency:
-      group: moobank-database
+      group: moobank-staging
       cancel-in-progress: false
     needs: [build, test, test-frontend, docker-push]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
@@ -255,8 +255,8 @@ jobs:
 
   staging:
     concurrency:
-      group: moobank-deploy-group
-      cancel-in-progress: true
+      group: moobank-staging
+      cancel-in-progress: false
     needs: [build, test, test-frontend, docker-push]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/deploy-azure.yml@v4
@@ -277,7 +277,7 @@ jobs:
   # code in front of it.
   database-production:
     concurrency:
-      group: moobank-database
+      group: moobank-production
       cancel-in-progress: false
     needs: [staging, database-staging]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
@@ -298,8 +298,8 @@ jobs:
 
   production:
     concurrency:
-      group: moobank-deploy-group
-      cancel-in-progress: true
+      group: moobank-production
+      cancel-in-progress: false
     needs: [staging, database-staging]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/azure-appservice-swap-slot.yml@v4
@@ -315,7 +315,7 @@ jobs:
 
   post-production:
     concurrency:
-      group: moobank-deploy-group
+      group: moobank-post-production
       cancel-in-progress: true
     needs: [build, production, database-production]
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')


### PR DESCRIPTION
Fixes a deadlock and a worse problem it exposed.

## The deadlock

`database-staging` and `database-production` shared `moobank-database` with
`cancel-in-progress: false`. `database-production` waits on the Production environment's
required reviewer. So an approval nobody had got round to held the group, and the *staging*
database of every later run queued behind it:

```
run 2281  database-production  waiting   <- holds moobank-database
run 2282  database-staging     pending   <- queued behind an approval
```

Staging shouldn't wait on a decision about production.

## The worse one

In run 2281, `production / swap-slot` is **cancelled** while `database-production` is still
`waiting`. The two jobs were in different groups with opposite cancellation rules —
`moobank-deploy-group` cancels in progress, `moobank-database` doesn't — so a newer run
killed the swap and left the schema deploy pending approval.

Approving it now would put a schema into production with none of the code that asked for it.
That split is precisely what running the two together was supposed to prevent; I reintroduced
it by putting them in different groups.

## The fix

| Group | Jobs | cancel-in-progress |
|---|---|---|
| `moobank-staging` | `database-staging`, `staging` | false |
| `moobank-production` | `database-production`, `production` | false |
| `moobank-post-production` | `post-production` | true |

A tier's schema and its app now share a group, so neither can be superseded without the
other, and neither tier waits on the other. `post-production` still supersedes, which is what
it's for.

## Note on the good news

Run 2281's `database-staging / deploy-database` **succeeded**. The resource-group fix worked
and the whole mechanism runs end to end — firewall opened, Entra token acquired, SqlPackage
published, firewall closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
