### PR TITLE
Ask once before deploying to production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,19 +273,29 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+  # The one approval for a production release. It does nothing, which is the point: GitHub asks
+  # for environment approval once per job, so the gate has to be a job by itself or every job
+  # behind it asks again. Approving this approves the release; what follows is the release.
+  approve-production:
+    runs-on: ubuntu-latest
+    environment: Production
+    needs: [staging, database-staging]
+    if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
+    steps:
+      - run: echo "::notice::Starting production deployment"
+
   # The production schema lands after staging has exercised it, and before the swap puts the new
   # code in front of it.
   database-production:
     concurrency:
       group: moobank-production
       cancel-in-progress: false
-    needs: [staging, database-staging]
+    needs: approve-production
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     # TEMPORARY: pinned to the branch so this can be proved before it is released.
     # Change to @v4 once AndrewMcLachlan/Actions#36 is merged and v4.8 is cut.
     uses: AndrewMcLachlan/actions/.github/workflows/deploy-sql-database.yml@feature/deploy-sql-database
     with:
-      environment: Production
       artifact-name: database
       server-name: mclachlan
       database-name: MooBank
@@ -300,11 +310,10 @@ jobs:
     concurrency:
       group: moobank-production
       cancel-in-progress: false
-    needs: [staging, database-staging]
+    needs: approve-production
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
     uses: AndrewMcLachlan/actions/.github/workflows/azure-appservice-swap-slot.yml@v4
     with:
-      environment: Production
       app-name: moobank
       resource-group: MooBank
       slot-name: staging

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -312,7 +312,9 @@ jobs:
       cancel-in-progress: false
     needs: approve-production
     if: (github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.ref == 'refs/heads/main')
-    uses: AndrewMcLachlan/actions/.github/workflows/azure-appservice-swap-slot.yml@v4
+    # TEMPORARY: pinned alongside the database workflow, for the optional environment input.
+    # Back to @v4 with the others once AndrewMcLachlan/Actions#36 is released.
+    uses: AndrewMcLachlan/actions/.github/workflows/azure-appservice-swap-slot.yml@feature/deploy-sql-database
     with:
       app-name: moobank
       resource-group: MooBank


### PR DESCRIPTION
Two approvals for one production release was a defect, not a safety feature.

## Why it happened

GitHub asks for environment approval **once per job**. `database-production` and `production`
were two jobs both carrying `environment: Production`, so both stopped at the gate and asked
the same question — with nothing on either prompt to distinguish them.

I had assumed GitHub would batch the prompt when two jobs reach the same environment together.
It doesn't. That assumption was mine and it was wrong.

## The fix

```yaml
  approve-production:
    runs-on: ubuntu-latest
    environment: Production
    needs: [staging, database-staging]
    steps:
      - run: echo "::notice::Starting production deployment"
```

The gate is a job of its own that does nothing. Approving it *is* the decision. The schema
deploy and the slot swap then hang off it with **no environment of their own**, so they run
on the approval already given — and run together.

```
staging ─┬─ approve-production ─┬─ database-production ─┐
         │      [approve]       └─ production (swap) ───┴─ post-production
```

Pairs with AndrewMcLachlan/Actions#36, which makes the `environment` input optional on
`deploy-sql-database.yml` and `azure-appservice-swap-slot.yml` so a caller can gate elsewhere.
Passing an environment still behaves exactly as before, so no other consumer changes.

## Worth watching on the first run

The two post-gate jobs pass no environment, which reaches the reusable workflows as
`environment: ''`. I expect GitHub to treat that as "no environment" and run them ungated — but
that is the one thing here I have not seen work, so it's the thing to check. If it turns out
empty isn't accepted, the fallback is a `Production-Apply` environment with no reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
