### PR TITLE
Let import-bills publish the bills it needs

### DIFF
--- a/src/MooBank.Modules.Bills/McpTools/BillTools.cs
+++ b/src/MooBank.Modules.Bills/McpTools/BillTools.cs
@@ -19,7 +19,7 @@ public class BillTools(IQueryDispatcher queryDispatcher, ICommandDispatcher comm
         "Each bill is accepted or rejected on its own; the result reports how many of each and why. " +
         "Do not supply the bill's total cost or overall usage total (the computed Total) — MooBank calculates those from the readings, periods and discounts.")]
     public ValueTask<ImportResult> ImportBills(
-        [Description("The bills to record.")] IEnumerable<BillEntry> bills,
+        [Description("The bills to record.")] BillImport request,
         CancellationToken cancellationToken = default) =>
-        commandDispatcher.Dispatch(new Commands.Bills.Import(bills.ToImportBill()), cancellationToken);
+        commandDispatcher.Dispatch(new Commands.Bills.Import(request.Bills.ToImportBill()), cancellationToken);
 }

--- a/src/MooBank.Modules.Bills/Models/BillEntry.cs
+++ b/src/MooBank.Modules.Bills/Models/BillEntry.cs
@@ -3,6 +3,28 @@ using System.ComponentModel;
 namespace Asm.MooBank.Modules.Bills.Models;
 
 /// <summary>
+/// The bills handed to the import tool.
+/// </summary>
+/// <remarks>
+/// A wrapper rather than a bare collection parameter, and not a stylistic choice: the MCP server
+/// builds each tool's schema with the DI container available, and asks it whether it can supply
+/// each parameter. Microsoft's container answers yes to <c>IEnumerable&lt;T&gt;</c> for any T --
+/// that is how it resolves "all the registered T", returning an empty sequence when there are none.
+/// So a collection parameter is taken for a dependency, left out of the published schema entirely,
+/// and injected empty at call time. The tool then reports importing nothing, having been given
+/// nothing, however much the caller sent.
+///
+/// A concrete record is not resolvable, so it stays in the schema. Anything the container could
+/// satisfy -- <c>IEnumerable&lt;T&gt;</c>, <c>IList&lt;T&gt;</c>, a registered interface -- has the
+/// same problem, and fails just as quietly.
+/// </remarks>
+public record BillImport
+{
+    [Description("The bills to record.")]
+    public IEnumerable<BillEntry> Bills { get; set; } = [];
+}
+
+/// <summary>
 /// A bill as read off a supplier's invoice.
 /// </summary>
 /// <remarks>

--- a/src/MooBank.Modules.Bills/Models/BillEntry.cs
+++ b/src/MooBank.Modules.Bills/Models/BillEntry.cs
@@ -7,16 +7,20 @@ namespace Asm.MooBank.Modules.Bills.Models;
 /// </summary>
 /// <remarks>
 /// A wrapper rather than a bare collection parameter, and not a stylistic choice: the MCP server
-/// builds each tool's schema with the DI container available, and asks it whether it can supply
-/// each parameter. Microsoft's container answers yes to <c>IEnumerable&lt;T&gt;</c> for any T --
-/// that is how it resolves "all the registered T", returning an empty sequence when there are none.
-/// So a collection parameter is taken for a dependency, left out of the published schema entirely,
-/// and injected empty at call time. The tool then reports importing nothing, having been given
-/// nothing, however much the caller sent.
+/// builds each tool's schema with the DI container available, and asks it, of each parameter,
+/// whether that is something it supplies. Anything it claims is left out of the schema and injected
+/// at call time instead.
 ///
-/// A concrete record is not resolvable, so it stays in the schema. Anything the container could
-/// satisfy -- <c>IEnumerable&lt;T&gt;</c>, <c>IList&lt;T&gt;</c>, a registered interface -- has the
-/// same problem, and fails just as quietly.
+/// Microsoft's container claims <c>IEnumerable&lt;T&gt;</c> for every T. It is special-cased: asking
+/// for one does not look for a registration of <c>IEnumerable&lt;T&gt;</c> but gathers every
+/// registration of T, and succeeds even when there are none, handing back an empty array. So a
+/// bare collection parameter is taken for a dependency and quietly supplied empty, and the tool
+/// reports importing nothing because it was given nothing, however much the caller sent. An empty
+/// array rather than null is why nothing threw.
+///
+/// <c>IEnumerable&lt;T&gt;</c> alone behaves this way: <c>IList&lt;T&gt;</c>,
+/// <c>ICollection&lt;T&gt;</c>, <c>T[]</c> and <c>List&lt;T&gt;</c> are all refused, as is any type
+/// nothing has registered. A record is safe for that reason, not because it is a record.
 /// </remarks>
 public record BillImport
 {

--- a/tests/MooBank.Modules.Bills.Tests/McpTools/BillToolsSchemaTests.cs
+++ b/tests/MooBank.Modules.Bills.Tests/McpTools/BillToolsSchemaTests.cs
@@ -49,9 +49,12 @@ public class BillToolsSchemaTests
     /// </summary>
     /// <remarks>
     /// The defect this pins down: import-bills took an IEnumerable of bills, which the container
-    /// will happily resolve to an empty sequence, so it was classed as a dependency and dropped
-    /// from the schema. The tool published no parameters at all and imported nothing, whatever it
-    /// was sent.
+    /// claims for every T and resolves to an empty array, so it was classed as a dependency and
+    /// dropped from the schema. The tool published no parameters at all and imported nothing,
+    /// whatever it was sent.
+    ///
+    /// Generic over the assembly rather than written against the one tool, because the same thing
+    /// happens to any parameter the container will claim, and it never announces itself.
     /// </remarks>
     [Fact]
     public void EveryCallerSuppliedParameterAppearsInTheSchema()

--- a/tests/MooBank.Modules.Bills.Tests/McpTools/BillToolsSchemaTests.cs
+++ b/tests/MooBank.Modules.Bills.Tests/McpTools/BillToolsSchemaTests.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using System.Reflection;
+using Asm.MooBank.Modules.Bills.McpTools;
+using Microsoft.Extensions.DependencyInjection;
+using ModelContextProtocol.Server;
+using Postie.Cqrs.Commands;
+using Postie.Cqrs.Queries;
+
+namespace Asm.MooBank.Modules.Bills.Tests.McpTools;
+
+/// <summary>
+/// Unit tests for the schemas the bill tools publish to an MCP client.
+/// </summary>
+/// <remarks>
+/// A tool whose parameter is missing from its schema does not fail. The client cannot see the
+/// parameter, so it sends nothing; the server supplies a default and the tool runs and reports
+/// success over no data at all. Nothing throws and nothing is logged, so the only way this is
+/// caught is by looking at the published schema, which is what these do.
+/// </remarks>
+[Trait("Category", "Unit")]
+public class BillToolsSchemaTests
+{
+    /// <summary>
+    /// Builds each tool the way the server does, which is the part that matters: with the
+    /// dependency injection container available, so parameters it can satisfy are treated as
+    /// dependencies rather than as arguments.
+    /// </summary>
+    private static IEnumerable<(MethodInfo Method, McpServerTool Tool)> Tools()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var target = new BillTools(Mock.Of<IQueryDispatcher>(), Mock.Of<ICommandDispatcher>());
+        var options = new McpServerToolCreateOptions { Services = services };
+
+        return typeof(BillTools)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance)
+            .Where(m => m.GetCustomAttribute<McpServerToolAttribute>() is not null)
+            .Select(m => (m, McpServerTool.Create(m, target, options)));
+    }
+
+    private static string[] SchemaProperties(McpServerTool tool) =>
+        tool.ProtocolTool.InputSchema.TryGetProperty("properties", out var properties)
+            ? [.. properties.EnumerateObject().Select(p => p.Name)]
+            : [];
+
+    /// <summary>
+    /// Given the bill tools as the server registers them
+    /// When their schemas are published
+    /// Then every parameter a caller has to supply should appear in them
+    /// </summary>
+    /// <remarks>
+    /// The defect this pins down: import-bills took an IEnumerable of bills, which the container
+    /// will happily resolve to an empty sequence, so it was classed as a dependency and dropped
+    /// from the schema. The tool published no parameters at all and imported nothing, whatever it
+    /// was sent.
+    /// </remarks>
+    [Fact]
+    public void EveryCallerSuppliedParameterAppearsInTheSchema()
+    {
+        foreach (var (method, tool) in Tools())
+        {
+            // A cancellation token is the framework's to provide, not the caller's.
+            var expected = method.GetParameters()
+                                 .Where(p => p.ParameterType != typeof(CancellationToken))
+                                 .Select(p => p.Name!)
+                                 .ToArray();
+
+            var published = SchemaProperties(tool);
+
+            Assert.Equal(expected.Order(), published.Order());
+        }
+    }
+
+    /// <summary>
+    /// Given the import tool
+    /// When its schema is published
+    /// Then the bills themselves should be described, not just the wrapper around them
+    /// </summary>
+    /// <remarks>
+    /// The parameter appearing is not enough on its own -- a wrapper whose contents were dropped
+    /// would still pass the test above while being just as useless to a caller.
+    /// </remarks>
+    [Fact]
+    public void ImportBillsDescribesTheBills()
+    {
+        var (_, tool) = Tools().Single(t => t.Tool.ProtocolTool.Name == "import-bills");
+
+        var schema = tool.ProtocolTool.InputSchema.GetRawText();
+
+        Assert.Contains("\"bills\"", schema);
+        Assert.Contains("accountName", schema);
+        Assert.Contains("periods", schema);
+    }
+}


### PR DESCRIPTION
`import-bills` published an empty parameter schema and returned
`{"imported":0,"failed":0,"errors":[]}` for every call, whatever was sent.

## Cause

The tool took `IEnumerable<BillEntry> bills`. `WithToolsFromAssembly` builds each tool's schema
with the DI container available and asks it whether it can supply each parameter — and
Microsoft's container answers **yes to `IEnumerable<T>` for any `T`**. That's how it resolves
"everything registered as `T`", returning an empty sequence when nothing is.

So `bills` was classed as a dependency, dropped from the published schema, and injected empty
at call time. Nothing threw and nothing was logged: the tool reported importing no bills
because it had been given none — and the caller couldn't have sent any, since the schema it
was working from had no parameters in it.

## Verified, not assumed

```
BareEnumerable   no DI    properties=[bills]
BareEnumerable   with DI  properties=[]        <- the bug
Wrapped          with DI  properties=[request]
```

My first attempt at reproducing this used `McpServerTool.Create(method, target)` with no
service provider, which produced a perfectly good 1,853-character schema and sent me looking
in the wrong place. The container is the whole thing.

Confirmed against the live server too: `get-transactions` publishes its full `criteria` object
with formats, enums and required fields; `import-bills` publishes `{}`.

## The fix

Bills arrive wrapped in a `BillImport` record. A concrete record isn't resolvable from the
container, so it survives into the schema — which is why every other tool here, all of which
take a single record, worked all along.

## Tests

Two, both building the tools **the way the server does, container and all** — the only way this
is visible:

- every caller-supplied parameter appears in the published schema (generic over the assembly,
  so it covers future tools too)
- `import-bills` describes the bills themselves, not merely a wrapper — a wrapper whose
  contents were dropped would pass the first test while being just as useless

Mutation tested: reverting to `IEnumerable<BillEntry>` fails exactly those two, 116 others pass.

## Worth knowing

This traps **any** tool parameter the container can satisfy — `IEnumerable<T>`, `IList<T>`, a
registered interface — and it fails silently every time. The generic test now guards the Bills
module; the other modules' tools all happen to take concrete records, so they're fine today.

Build clean, no warnings. All 22 test projects pass; Bills 116 → 118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
