### PR TITLE
fix(web): show chart skeletons, not spinners, while reports load

### DIFF
--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/Breakdown.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/Breakdown.tsx
@@ -4,7 +4,7 @@ import { useBreakdownReport } from "../../../-hooks/useBreakdownReport";
 
 import type { ChartData } from "chart.js";
 import { Doughnut } from "react-chartjs-2";
-import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
+import { Skeleton } from "@andrewmclachlan/moo-ds";
 
 import type { Period } from "models/dateFns";
 import { chartColours } from "utils/chartColours";
@@ -26,7 +26,9 @@ export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, 
             chartRef.current?.setDatasetVisibility(i, true);
         });
 
-        chartRef.current.update();
+        // Optional: the chart is unmounted while the report loads, so this runs
+        // with a null ref on the first pass.
+        chartRef.current?.update();
     }, [tagId]);
 
     const dataset: ChartData<"doughnut", number[], string> = useMemo(() => {
@@ -41,9 +43,12 @@ export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, 
         };
     }, [report.data, accountId, period?.startDate, period?.endDate, reportType, tagId]);
 
+    // The chart's shape is known before its data is, so hold the space with a
+    // skeleton rather than a spinner. Returning early also keeps an empty
+    // <Doughnut> from being painted underneath the placeholder while it loads.
+    if (report.isLoading) return <Skeleton.Chart variant="doughnut" count={3} />;
+
     return (
-        <>
-        {report.isLoading && <SpinnerContainer />}
         <Doughnut id="bytag" ref={chartRef} data={dataset} options={{
             maintainAspectRatio: false,
             plugins: {
@@ -66,7 +71,6 @@ export const Breakdown: React.FC<BreakdownProps> = ({ accountId, tagId, period, 
             },
         }}
         />
-        </>
     );
 }
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/InOut.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/InOut.tsx
@@ -10,7 +10,7 @@ import { Bar } from "react-chartjs-2";
 import { useChartColours } from "utils/chartColours";
 import type { Period } from "models/dateFns";
 import { useInOutReport as defaultReport } from "hooks/useInOutReport";
-import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
+import { Skeleton } from "@andrewmclachlan/moo-ds";
 import { Amount } from "components";
 
 
@@ -37,13 +37,17 @@ export const InOut: React.FC<InOutProps> = ({ accountId, period, useInOutReport 
     // Calculate the difference to the nearest $10
     const difference = Math.round((((report.data?.income ?? 0) - Math.abs(report.data?.outgoings ?? 0)) / 10.0)) * 10;
 
+    // The chart's shape is known before its data is, so hold the space with a
+    // skeleton rather than a spinner. Returning early also suppresses the
+    // heading, which would otherwise read "$0 saved" off the absent report.
+    if (report.isLoading) return <Skeleton.Chart variant="horizontal-bar" count={2} />;
+
     return (
         <>
             {difference >= 0 ?
                 <h4><Amount amount={difference} prefix="$" suffix=" saved" decimalPlaces={0} positiveColour negativeColour /></h4> :
                 <h4><Amount amount={difference} prefix="$" suffix=" overspent" decimalPlaces={0} positiveColour negativeColour /></h4>
             }
-            {report.isLoading && <SpinnerContainer />}
             <Bar id="inout" data={dataset} options={{
                 indexAxis: "y",
                 maintainAspectRatio: false,

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/InOutTrend.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/InOutTrend.tsx
@@ -5,7 +5,7 @@ import type { ChartData } from "chart.js";
 
 import type { Period } from "models/dateFns";
 import { useChartColours } from "utils/chartColours";
-import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
+import { Skeleton } from "@andrewmclachlan/moo-ds";
 
 
 export const InOutTrend: React.FC<InOutTrendProps> = ({ accountId, period }) => {
@@ -44,9 +44,12 @@ export const InOutTrend: React.FC<InOutTrendProps> = ({ accountId, period }) => 
         }]
     };
 
+    // The chart's shape is known before its data is, so hold the space with a
+    // skeleton rather than a spinner. Returning early also keeps an empty
+    // <Line> from being painted underneath the placeholder while it loads.
+    if (report.isLoading) return <Skeleton.Chart variant="line" count={2} />;
+
     return (
-        <>
-            {report.isLoading && <SpinnerContainer />}
             <Line id="inout" data={dataset} options={{
                 maintainAspectRatio: false,
                 scales: {
@@ -66,7 +69,6 @@ export const InOutTrend: React.FC<InOutTrendProps> = ({ accountId, period }) => 
                     }
                 }
             }} />
-        </>
     );
 }
 

--- a/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
+++ b/src/MooBank.Web.App/src/routes/accounts/$id/reports/-components/TopTags.tsx
@@ -4,7 +4,7 @@ import { useAllTagAverageReport } from "../../../-hooks/useAllTagAverageReport";
 
 import type { ChartData } from "chart.js";
 import { Bar } from "react-chartjs-2";
-import { SpinnerContainer } from "@andrewmclachlan/moo-ds";
+import { Skeleton } from "@andrewmclachlan/moo-ds";
 
 import type { Period } from "models/dateFns";
 import { useNavigate } from "@tanstack/react-router";
@@ -35,9 +35,12 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
         });
     }
 
+    // The chart's shape is known before its data is, so hold the space with a
+    // skeleton rather than a spinner. Returning early also keeps an empty <Bar>
+    // from being painted underneath the placeholder while the report loads.
+    if (report.isLoading) return <Skeleton.Chart variant="bar" count={top} />;
+
     return (
-        <>
-        {report.isLoading && <SpinnerContainer />}
         <Bar id="alltagaverage" data={dataset} options={{
             plugins: {
                 legend: {
@@ -68,7 +71,6 @@ export const TopTags: React.FC<TopTagsProps> = ({ accountId, period, reportType,
             },
         }}
         />
-        </>
     );
 }
 

--- a/src/MooBank.Web.App/src/routes/planning/-components/ForecastOutlook.test.tsx
+++ b/src/MooBank.Web.App/src/routes/planning/-components/ForecastOutlook.test.tsx
@@ -41,6 +41,9 @@ vi.mock("@andrewmclachlan/moo-ds", () => ({
             Text: () => <div data-testid="skeleton" />,
             Circle: () => <div data-testid="skeleton" />,
             Rect: () => <div data-testid="skeleton" />,
+            // Distinct testid: the chart placeholder is asserted separately from
+            // the KPI band's, which are counted in aggregate.
+            Chart: () => <div data-testid="skeleton-chart" />,
         },
     ),
     // Render the overlay inline so the popover content is assertable without a hover.
@@ -187,6 +190,10 @@ describe("ForecastOutlook", () => {
         // The band is still present, so the chart below it doesn't start high and jump down.
         expect(container.querySelector(".forecast-metrics")).not.toBeNull();
         expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0);
-        expect(screen.getByTestId("forecast-chart")).toBeInTheDocument();
+        // The chart's slot is held by its skeleton, not by the chart itself: an
+        // empty <Line> under a placeholder is furniture drawn from data we do
+        // not have yet.
+        expect(screen.getByTestId("skeleton-chart")).toBeInTheDocument();
+        expect(screen.queryByTestId("forecast-chart")).toBeNull();
     });
 });

--- a/src/MooBank.Web.App/src/routes/planning/-components/ForecastOutlook.tsx
+++ b/src/MooBank.Web.App/src/routes/planning/-components/ForecastOutlook.tsx
@@ -1,4 +1,4 @@
-import { Badge, Kpi, OverlayTrigger, Popover, Section, Skeleton, SpinnerContainer } from "@andrewmclachlan/moo-ds";
+import { Badge, Kpi, OverlayTrigger, Popover, Section, Skeleton } from "@andrewmclachlan/moo-ds";
 import { MetricsSkeleton } from "./MetricsSkeleton";
 import { format, parseISO } from "date-fns";
 import type { ExpenseModel, ForecastMonth, ForecastPlan, ForecastSummary } from "api/types.gen";
@@ -158,8 +158,12 @@ export const ForecastOutlook: React.FC<ForecastOutlookProps> = ({ plan, summary,
             {summary && <IncomeShortfallNote expenses={summary.expenses} currencyCode={currencyCode} />}
 
             <Section header="Balance Projection" className="forecast-chart-section">
-                <ForecastChart months={months} currencyCode={currencyCode} />
-                {loading && <SpinnerContainer />}
+                {/* A skeleton rather than a spinner: the projection is always two
+                    series, so the shape is known before the data is. Swapping for
+                    the chart also stops an empty one being painted underneath. */}
+                {loading
+                    ? <Skeleton.Chart variant="line" count={2} />
+                    : <ForecastChart months={months} currencyCode={currencyCode} />}
             </Section>
         </div>
     );


### PR DESCRIPTION
Dashboard widgets showed a **skeleton, then a spinner, then the chart**.

## Root cause

The skeleton and the spinner belong to two different queries.

`routes/-dashboard/TopTags.tsx` sets `loading={isLoading}` from `useAccounts()`, and `Widget` renders children only when `!loading`. So the inner `<TopTags>` can't mount until accounts arrive — and only then does it start its own report query, which rendered `<SpinnerContainer />`.

It's a strict waterfall: `useAllTagAverageReport(accountId, …)` is keyed on the account id, so the report fetch **cannot begin** until the skeleton has already gone. The spinner appearing after the skeleton wasn't a race, it was the only possible order. `Spinner`'s default `delay={300}` is why it showed up a beat later.

Same shape in five components: `TopTags`, `Breakdown`, `InOut`, `InOutTrend` and `ForecastOutlook`.

## The change

Each now holds its slot with the `Skeleton.Chart` matching the chart it's about to draw, so the placeholder is continuous from first paint through to real data. Variants and counts mirror what the dashboard widgets already pass, so there's no visible switch at the handover:

| Component | Placeholder |
|---|---|
| `TopTags` | `bar`, `count={top}` |
| `Breakdown` | `doughnut`, `count={3}` |
| `InOut` | `horizontal-bar`, `count={2}` |
| `InOutTrend` | `line`, `count={2}` |
| `ForecastOutlook` | `line`, `count={2}` |

They also **return** the placeholder rather than rendering it on top of the chart. The charts were being painted underneath with `?? []` data, and `InOut`'s heading read **"$0 saved"** off a report that hadn't arrived.

## Two consequences worth a look

- `Breakdown`'s `tagId` effect called `chartRef.current.update()` **unguarded** — safe only because the chart was always mounted. It's now absent while loading, so that call is optional-chained. This would have thrown otherwise.
- `ForecastOutlook`'s test asserted the chart rendered *while loading* — the exact behaviour being removed. It now asserts the skeleton holds the slot and the chart doesn't. Its moo-ds mock was missing `Skeleton.Chart`, which is why it failed first time.

## Verification

- `npm run test` — 270 pass across 37 files
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (the one warning on `Breakdown` is pre-existing, just shifted two lines)
- `npm run build` — succeeds

Not checked in a browser — the Chrome extension isn't connected here, and the dev server needs a sign-in I won't do. The change is a straight swap of loading placeholders, but it's worth a glance at the dashboard before merge.

## Unrelated, but noticed

MooBank is on **moo-ds 5.2.243**, whose `dist` still contains `loadingPlaceholder ||`. That predates MooApp #708, which changed it to `??` so a falsy placeholder no longer silently reverts to a spinner. It doesn't affect these widgets (all five pass an unconditional element), but `npm run update-moo` would pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
